### PR TITLE
Emit event hint

### DIFF
--- a/src/business_logic/execution/mod.rs
+++ b/src/business_logic/execution/mod.rs
@@ -1,0 +1,1 @@
+pub mod objects;

--- a/src/business_logic/execution/objects.rs
+++ b/src/business_logic/execution/objects.rs
@@ -1,0 +1,25 @@
+use num_bigint::BigInt;
+
+pub(crate) struct OrderedEvent {
+    order: u32,
+    keys: Vec<BigInt>,
+    data: Vec<BigInt>,
+}
+
+pub(crate) struct TransactionExecutionContext {
+    pub(crate) n_emitted_events: u32,
+}
+
+impl OrderedEvent {
+    pub fn new(order: u32, keys: Vec<BigInt>, data: Vec<BigInt>) -> Self {
+        OrderedEvent { order, keys, data }
+    }
+}
+
+impl TransactionExecutionContext {
+    pub fn new() -> Self {
+        TransactionExecutionContext {
+            n_emitted_events: 0,
+        }
+    }
+}

--- a/src/business_logic/mod.rs
+++ b/src/business_logic/mod.rs
@@ -1,0 +1,1 @@
+pub mod execution;

--- a/src/core/syscall_handler.rs
+++ b/src/core/syscall_handler.rs
@@ -283,13 +283,12 @@ fn get_integer_range(
     addr: &Relocatable,
     size: usize,
 ) -> Result<Vec<BigInt>, SyscallHandlerError> {
-    let range: Vec<BigInt> = vm
+    Ok(vm
         .get_integer_range(addr, size)
         .map_err(|_| SyscallHandlerError::SegmentationFault)?
         .into_iter()
         .map(|c| c.into_owned())
-        .collect();
-    Ok(range)
+        .collect::<Vec<BigInt>>())
 }
 
 #[cfg(test)]

--- a/src/core/syscall_request.rs
+++ b/src/core/syscall_request.rs
@@ -2,7 +2,6 @@ use crate::core::errors::syscall_hadler_errors::SyscallHandlerError;
 use cairo_rs::types::relocatable::Relocatable;
 use cairo_rs::vm::vm_core::VirtualMachine;
 use num_bigint::BigInt;
-use std::collections::HashMap;
 
 pub(crate) enum SyscallRequest {
     EmitEvent(EmitEventStruct),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod business_logic;
 pub mod core;
 pub mod utils;


### PR DESCRIPTION
This PR adds the syscall Emit_Event and the the corresponding structs ( TxExecutionContext that has the data of the transaction that is being executed currently, and Events that stores the messages that have been emitted during the execution).