### PR TITLE
add instructions for activating env before compiling cairo programs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ It makes use of [cairo-rs](https://github.com/lambdaclass/cairo-rs), the Rust im
 Run the following make targets to have a working environment:
 ```bash
 $ make deps
+$ source starknet-in-rs-venv/bin/activate
 $ make compile_cairo
+$ deactivate
 $ make build
 ```
 


### PR DESCRIPTION
@juanbono we should add this or change the `make compile_cairo` command to activate the env.
