### PR TITLE
Change mutability of functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "cairo-rs"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs#fd7edb403b3f9039b9499ee494e5ecc756084e3f"
+source = "git+https://github.com/lambdaclass/cairo-rs#12fe3a522f435e7b1c931c2a06993281c74041f4"
 dependencies = [
  "bincode",
  "clap",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -380,9 +380,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -486,22 +486,22 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs#fd7edb403b3f9039b9499ee494e5ecc756084e3f"
+source = "git+https://github.com/lambdaclass/cairo-rs#12fe3a522f435e7b1c931c2a06993281c74041f4"
 dependencies = [
  "nom",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pest"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -539,18 +539,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "semver"
@@ -630,27 +630,27 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -786,9 +786,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -824,18 +824,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -856,9 +856,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-xid"

--- a/src/business_logic/execution/objects.rs
+++ b/src/business_logic/execution/objects.rs
@@ -10,7 +10,7 @@ pub(crate) struct OrderedEvent {
     #[allow(unused)] // TODO: remove once used
     data: Vec<BigInt>,
 }
-
+#[derive(Clone)]
 pub(crate) struct TransactionExecutionContext {
     pub(crate) n_emitted_events: u32,
     pub(crate) version: usize,

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -7,7 +7,7 @@ use crate::business_logic::execution::objects::*;
 use crate::business_logic::execution::state::ExecutionResourcesManager;
 use crate::core::errors::syscall_handler_errors::SyscallHandlerError;
 use crate::core::syscalls::syscall_handler::SyscallHandler;
-use crate::definitions::general_config::StarknetGeneralConfig;
+use crate::definitions::general_config::{self, StarknetGeneralConfig};
 use crate::hash_utils::calculate_contract_address_from_hash;
 use crate::state::state_api_objects::BlockInfo;
 use crate::utils::*;
@@ -31,36 +31,29 @@ pub struct BusinessLogicSyscallHandler {
     l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
     general_config: StarknetGeneralConfig,
     tx_info_ptr: Option<MaybeRelocatable>,
-}
-
-impl BusinessLogicSyscallHandler {
-    pub fn new() -> Self {
-        let events = Vec::new();
-        let tx_execution_context = TransactionExecutionContext::new();
-        let read_only_segments = Vec::new();
-        let resources_manager = ExecutionResourcesManager::default();
-    tx_info_ptr: Option<MaybeRelocatable>,
     block_info: BlockInfo,
 }
 
 impl BusinessLogicSyscallHandler {
     pub fn new(block_info: BlockInfo) -> Self {
-        let events = RefCell::new(Vec::new());
-        let tx_execution_context = RefCell::new(TransactionExecutionContext::new());
-        let read_only_segments = RefCell::new(Vec::new());
-        let resources_manager = RefCell::new(ExecutionResourcesManager::default());
+        let events = Vec::new();
+        let tx_execution_context = TransactionExecutionContext::new();
+        let read_only_segments = Vec::new();
+        let resources_manager = ExecutionResourcesManager::default();
+        let contract_address = 0;
+        let l2_to_l1_messages = Vec::new();
         let general_config = StarknetGeneralConfig::new();
         let tx_info_ptr = None;
 
         BusinessLogicSyscallHandler {
-            events,
             tx_execution_context,
-            general_config,
-            tx_info_ptr,
+            events,
             read_only_segments,
             resources_manager,
-            contract_address: 0,
-            l2_to_l1_messages: Vec::new(),
+            contract_address,
+            l2_to_l1_messages,
+            general_config,
+            tx_info_ptr,
             block_info,
         }
     }

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -156,7 +156,7 @@ impl SyscallHandler for BusinessLogicSyscallHandler {
             let signature = vm
                 .write_arg(&signature, &tx.signature)
                 .map_err(|x| SyscallHandlerError::VirtualMachineError(x.into()))?;
-            let signature = signature.get_relocatable()?.clone();
+            let signature = signature.get_relocatable()?;
             let signature_len = signature.offset;
 
             let chain_id = self.general_config.starknet_os_config.chain_id as usize;

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -86,7 +86,7 @@ struct OsSyscallHandler {
 
 impl SyscallHandler for OsSyscallHandler {
     fn get_tx_info(
-        &self,
+        &mut self,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<(), SyscallHandlerError> {
@@ -94,7 +94,7 @@ impl SyscallHandler for OsSyscallHandler {
     }
 
     fn emit_event(
-        &self,
+        &mut self,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<(), SyscallHandlerError> {
@@ -118,7 +118,7 @@ impl SyscallHandler for OsSyscallHandler {
     }
 
     fn _get_tx_info_ptr(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
     ) -> Result<MaybeRelocatable, SyscallHandlerError> {
         Ok(MaybeRelocatable::from(
@@ -149,7 +149,7 @@ impl SyscallHandler for OsSyscallHandler {
     /// Returns the system call request written in the syscall segment, starting at syscall_ptr.
     /// Does not perform validations on the request, since it was validated in the BL.
     fn _read_and_validate_syscall_request(
-        &self,
+        &mut self,
         syscall_name: &str,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
@@ -180,7 +180,7 @@ impl SyscallHandler for OsSyscallHandler {
     }
 
     fn _get_caller_address(
-        &self,
+        &mut self,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<u64, SyscallHandlerError> {
@@ -215,7 +215,7 @@ impl SyscallHandler for OsSyscallHandler {
 
     /// Allocates and returns a new temporary segment.
     fn allocate_segment(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
         data: Vec<MaybeRelocatable>,
     ) -> Result<Relocatable, SyscallHandlerError> {
@@ -631,7 +631,7 @@ mod tests {
 
     #[test]
     fn get_tx_info_ptr_reloc() {
-        let handler = OsSyscallHandler::new(
+        let mut handler = OsSyscallHandler::new(
             VecDeque::new(),
             VecDeque::new(),
             VecDeque::new(),
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     fn get_tx_info_ptr_none() {
-        let handler = OsSyscallHandler::new(
+        let mut handler = OsSyscallHandler::new(
             VecDeque::new(),
             VecDeque::new(),
             VecDeque::new(),
@@ -923,7 +923,7 @@ mod tests {
 
     #[test]
     fn get_caller_address_err() {
-        let handler = OsSyscallHandler::new(
+        let mut handler = OsSyscallHandler::new(
             VecDeque::new(),
             VecDeque::new(),
             VecDeque::new(),
@@ -950,7 +950,7 @@ mod tests {
     fn get_caller_address() {
         let mut call_stack = VecDeque::new();
         call_stack.push_back(CallInfo::default());
-        let handler = OsSyscallHandler::new(
+        let mut handler = OsSyscallHandler::new(
             VecDeque::new(),
             VecDeque::new(),
             call_stack,
@@ -1034,7 +1034,7 @@ mod tests {
     #[test]
     fn allocate_segment() {
         let mut vm = vm!();
-        let handler = OsSyscallHandler::new(
+        let mut handler = OsSyscallHandler::new(
             VecDeque::new(),
             VecDeque::new(),
             VecDeque::new(),

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -26,7 +26,7 @@ use super::hint_code::*;
 
 pub(crate) trait SyscallHandler {
     fn emit_event(
-        &self,
+        &mut self,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<(), SyscallHandlerError>;
@@ -38,7 +38,7 @@ pub(crate) trait SyscallHandler {
     ) -> Result<(), SyscallHandlerError>;
 
     fn get_tx_info(
-        &self,
+        &mut self,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<(), SyscallHandlerError>;
@@ -50,7 +50,7 @@ pub(crate) trait SyscallHandler {
     ) -> Result<(), SyscallHandlerError>;
 
     fn _get_tx_info_ptr(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
     ) -> Result<MaybeRelocatable, SyscallHandlerError>;
 
@@ -61,7 +61,7 @@ pub(crate) trait SyscallHandler {
     ) -> Result<u32, SyscallHandlerError>;
 
     fn _read_and_validate_syscall_request(
-        &self,
+        &mut self,
         syscall_name: &str,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
@@ -82,7 +82,7 @@ pub(crate) trait SyscallHandler {
     ) -> Result<Vec<u32>, SyscallHandlerError>;
 
     fn _get_caller_address(
-        &self,
+        &mut self,
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<u64, SyscallHandlerError>;
@@ -94,7 +94,7 @@ pub(crate) trait SyscallHandler {
     fn _storage_read(&mut self, address: u32) -> Result<u32, SyscallHandlerError>;
     fn _storage_write(&mut self, address: u32, value: u32);
     fn allocate_segment(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
         data: Vec<MaybeRelocatable>,
     ) -> Result<Relocatable, SyscallHandlerError>;
@@ -149,7 +149,7 @@ impl SyscallHintProcessor<BusinessLogicSyscallHandler> {
 
 impl<H: SyscallHandler> SyscallHintProcessor<H> {
     pub fn should_run_syscall_hint(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
         exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,
@@ -166,7 +166,7 @@ impl<H: SyscallHandler> SyscallHintProcessor<H> {
     }
 
     fn execute_syscall_hint(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
         _exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,
@@ -193,7 +193,7 @@ impl<H: SyscallHandler> SyscallHintProcessor<H> {
 
 impl<H: SyscallHandler> HintProcessor for SyscallHintProcessor<H> {
     fn execute_hint(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
         exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,
@@ -254,8 +254,7 @@ fn get_syscall_ptr(
         .map_err(|_| SyscallHandlerError::SegmentationFault)?;
     let syscall_ptr = vm
         .get_relocatable(&location)
-        .map_err(|_| SyscallHandlerError::SegmentationFault)?
-        .into_owned();
+        .map_err(|_| SyscallHandlerError::SegmentationFault)?;
     Ok(syscall_ptr)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,9 +32,8 @@ pub fn get_relocatable(
     vm: &VirtualMachine,
     syscall_ptr: &Relocatable,
 ) -> Result<Relocatable, SyscallHandlerError> {
-    Ok(vm
-        .get_relocatable(syscall_ptr)
-        .map_err(|_| SyscallHandlerError::SegmentationFault)?)
+    vm.get_relocatable(syscall_ptr)
+        .map_err(|_| SyscallHandlerError::SegmentationFault)
 }
 
 pub fn bigint_to_usize(bigint: &BigInt) -> Result<usize, SyscallHandlerError> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,8 +34,7 @@ pub fn get_relocatable(
 ) -> Result<Relocatable, SyscallHandlerError> {
     Ok(vm
         .get_relocatable(syscall_ptr)
-        .map_err(|_| SyscallHandlerError::SegmentationFault)?
-        .into_owned())
+        .map_err(|_| SyscallHandlerError::SegmentationFault)?)
 }
 
 pub fn bigint_to_usize(bigint: &BigInt) -> Result<usize, SyscallHandlerError> {
@@ -228,7 +227,7 @@ pub mod test_utils {
         }};
         ($vm:expr, $ids_data:expr, $hint_code:expr) => {{
             let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
-            let hint_processor = BuiltinHintProcessor::new_empty();
+            let mut hint_processor = BuiltinHintProcessor::new_empty();
             hint_processor.execute_hint(
                 &mut $vm,
                 exec_scopes_ref!(),
@@ -258,7 +257,7 @@ pub mod test_utils {
         }};
         ($vm:expr, $ids_data:expr, $hint_code:expr) => {{
             let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
-            let hint_processor = SyscallHintProcessor::new_empty().unwrap();
+            let mut hint_processor = SyscallHintProcessor::new_empty().unwrap();
             hint_processor.execute_hint(
                 &mut $vm,
                 exec_scopes_ref!(),


### PR DESCRIPTION
Due to the new mutability of the Hint processor, we had to change the mutability of our own implementation. This allows us to remove the refcells but the signature of functions must be changed too.