### PR TITLE
remove todo! from OsSyscallHandler::send_message_to_l1

### DIFF
--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -116,7 +116,7 @@ impl SyscallHandler for OsSyscallHandler {
         vm: &VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<(), SyscallHandlerError> {
-        todo!()
+        Ok(())
     }
 
     fn _get_tx_info_ptr(


### PR DESCRIPTION
Python implementation:
https://github.com/starkware-libs/cairo-lang/blob/de741b92657f245a50caab99cfaef093152fd8be/src/starkware/starknet/core/os/syscall_utils.py#L319