### PR TITLE
Missing hints in executor

### DIFF
--- a/src/business_logic/execution/state.rs
+++ b/src/business_logic/execution/state.rs
@@ -4,6 +4,14 @@ use std::collections::HashMap;
 pub struct ExecutionResourcesManager(HashMap<String, u32>);
 
 impl ExecutionResourcesManager {
+    pub fn new(syscalls: Vec<String>) -> Self {
+        let mut manager = HashMap::new();
+        for syscall in syscalls {
+            manager.insert(syscall, 0);
+        }
+        ExecutionResourcesManager(manager)
+    }
+
     pub fn increment_syscall_counter(&mut self, syscall_name: &str, amount: u32) -> Option<()> {
         self.0.get_mut(syscall_name).map(|val| *val += amount)
     }

--- a/src/core/syscalls/hint_code.rs
+++ b/src/core/syscalls/hint_code.rs
@@ -26,7 +26,6 @@ pub(crate) const SEND_MESSAGE_TO_L1: &str =
 pub(crate) const LIBRARY_CALL_L1_HANDLER: &str =
     "syscall_handler.library_call_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-#[allow(unused)] // TODO: remove after using.
 pub(crate) const LIBRARY_CALL: &str =
     "syscall_handler.library_call(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
@@ -34,7 +33,6 @@ pub(crate) const LIBRARY_CALL: &str =
 pub(crate) const GET_TX_SIGNATURE: &str =
     "syscall_handler.get_tx_signature(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-#[allow(unused)] // TODO: remove after using.
 pub(crate) const GET_TX_INFO: &str =
     "syscall_handler.get_tx_info(segments=segments, syscall_ptr=ids.syscall_ptr)";
 

--- a/src/core/syscalls/hint_code.rs
+++ b/src/core/syscalls/hint_code.rs
@@ -2,13 +2,12 @@
 //     Syscall hints
 // *************************
 
-pub(crate) const DEPLOY_SYSCALL_CODE: &str =
+pub(crate) const DEPLOY: &str =
     "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
 pub(crate) const EMIT_EVENT_CODE: &str =
     "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-#[allow(unused)] // TODO: remove after using.
 pub(crate) const GET_SEQUENCER_ADDRESS: &str =
     "syscall_handler.get_sequencer_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
@@ -20,7 +19,6 @@ pub(crate) const STORAGE_WRITE: &str =
 pub(crate) const STORAGE_READ: &str =
     "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-#[allow(unused)] // TODO: remove after using.
 pub(crate) const SEND_MESSAGE_TO_L1: &str =
     "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
@@ -44,17 +42,11 @@ pub(crate) const GET_TX_INFO: &str =
 pub(crate) const GET_CONTRACT_ADDRESS: &str =
     "syscall_handler.get_contract_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-#[allow(unused)] // TODO: remove after using.
 pub(crate) const GET_CALLER_ADDRESS: &str =
     "syscall_handler.get_caller_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-#[allow(unused)] // TODO: remove after using.
 pub(crate) const GET_BLOCK_TIMESTAMP: &str =
     "syscall_handler.get_block_timestamp(segments=segments, syscall_ptr=ids.syscall_ptr)";
-
-#[allow(unused)] // TODO: remove after using.
-pub(crate) const DEPLOY: &str =
-    "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
 #[allow(unused)] // TODO: remove after using.
 pub(crate) const GET_BLOCK_NUMBER: &str =

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -261,6 +261,10 @@ impl<H: SyscallHandler> SyscallHintProcessor<H> {
                 let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
                 self.syscall_handler.get_sequencer_address(vm, syscall_ptr)
             }
+            LIBRARY_CALL => {
+                let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
+                self.syscall_handler.library_call(vm, syscall_ptr)
+            }
             SEND_MESSAGE_TO_L1 => {
                 let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
                 self.syscall_handler.send_message_to_l1(vm, syscall_ptr)

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -97,7 +97,9 @@ pub(crate) trait SyscallHandler {
         syscall_ptr: Relocatable,
     ) -> Result<u32, SyscallHandlerError>;
     fn _storage_read(&mut self, address: u32) -> Result<u32, SyscallHandlerError>;
+
     fn _storage_write(&mut self, address: u32, value: u32);
+
     fn allocate_segment(
         &mut self,
         vm: &mut VirtualMachine,
@@ -110,6 +112,44 @@ pub(crate) trait SyscallHandler {
         vm: &mut VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<(), SyscallHandlerError> {
+        response.write_syscall_response(vm, syscall_ptr)
+    }
+
+    fn get_block_info(&self) -> &BlockInfo;
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // ***********************************
+    //  Implementation of Default methods
+    // ***********************************
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    fn get_block_timestamp(
+        &mut self,
+        vm: &mut VirtualMachine,
+        syscall_ptr: Relocatable,
+    ) -> Result<(), SyscallHandlerError> {
+        let _request = if let SyscallRequest::GetBlockTimestamp(request) =
+            self._read_and_validate_syscall_request("get_block_timestamp", vm, syscall_ptr)?
+        {
+            request
+        } else {
+            return Err(SyscallHandlerError::ExpectedGetBlockTimestampRequest);
+        };
+
+        let block_timestamp = self.get_block_info().block_timestamp;
+
+        let response = GetBlockTimestampResponse::new(block_timestamp);
+
+        response.write_syscall_response(vm, syscall_ptr)
+    }
+
+    fn get_caller_address(
+        &mut self,
+        vm: &mut VirtualMachine,
+        syscall_ptr: Relocatable,
+    ) -> Result<(), SyscallHandlerError> {
+        let caller_address = self._get_caller_address(vm, syscall_ptr)?;
+        let response = GetCallerAddressResponse::new(caller_address);
         response.write_syscall_response(vm, syscall_ptr)
     }
 
@@ -150,38 +190,6 @@ pub(crate) trait SyscallHandler {
             "get_block_timestamp" => GetBlockTimestampRequest::from_ptr(vm, syscall_ptr),
             _ => Err(SyscallHandlerError::UnknownSyscall),
         }
-    }
-
-    fn get_block_info(&self) -> &BlockInfo;
-
-    fn get_block_timestamp(
-        &mut self,
-        vm: &mut VirtualMachine,
-        syscall_ptr: Relocatable,
-    ) -> Result<(), SyscallHandlerError> {
-        let _request = if let SyscallRequest::GetBlockTimestamp(request) =
-            self._read_and_validate_syscall_request("get_block_timestamp", vm, syscall_ptr)?
-        {
-            request
-        } else {
-            return Err(SyscallHandlerError::ExpectedGetBlockTimestampRequest);
-        };
-
-        let block_timestamp = self.get_block_info().block_timestamp;
-
-        let response = GetBlockTimestampResponse::new(block_timestamp);
-
-        response.write_syscall_response(vm, syscall_ptr)
-    }
-
-    fn get_caller_address(
-        &mut self,
-        vm: &mut VirtualMachine,
-        syscall_ptr: Relocatable,
-    ) -> Result<(), SyscallHandlerError> {
-        let caller_address = self._get_caller_address(vm, syscall_ptr)?;
-        let response = GetCallerAddressResponse::new(caller_address);
-        response.write_syscall_response(vm, syscall_ptr)
     }
 }
 
@@ -236,14 +244,26 @@ impl<H: SyscallHandler> SyscallHintProcessor<H> {
             .ok_or(SyscallHandlerError::WrongHintData)?;
 
         match &*hint_data.code {
-            DEPLOY_SYSCALL_CODE => Err(SyscallHandlerError::NotImplemented),
+            DEPLOY => Err(SyscallHandlerError::NotImplemented),
             EMIT_EVENT_CODE => {
                 let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
                 self.syscall_handler.emit_event(vm, syscall_ptr)
             }
-            GET_TX_INFO => {
+            GET_BLOCK_TIMESTAMP => {
                 let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
-                self.syscall_handler.get_tx_info(vm, syscall_ptr)
+                self.syscall_handler.get_block_timestamp(vm, syscall_ptr)
+            }
+            GET_CALLER_ADDRESS => {
+                let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
+                self.syscall_handler.get_caller_address(vm, syscall_ptr)
+            }
+            GET_SEQUENCER_ADDRESS => {
+                let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
+                self.syscall_handler.get_sequencer_address(vm, syscall_ptr)
+            }
+            SEND_MESSAGE_TO_L1 => {
+                let syscall_ptr = get_syscall_ptr(vm, &hint_data.ids_data, &hint_data.ap_tracking)?;
+                self.syscall_handler.send_message_to_l1(vm, syscall_ptr)
             }
             _ => Err(SyscallHandlerError::NotImplemented),
         }
@@ -320,8 +340,11 @@ fn get_syscall_ptr(
 #[cfg(test)]
 mod tests {
 
-    use crate::utils::get_integer;
+    use crate::business_logic::execution::objects::{OrderedEvent, OrderedL2ToL1Message};
+    use crate::utils::test_utils::ids_data;
+    use crate::utils::{get_big_int, get_integer, get_relocatable};
     use crate::{add_segments, bigint, utils::test_utils::vm};
+    use crate::{allocate_selector, memory_insert};
     use cairo_rs::relocatable;
     use num_bigint::{BigInt, Sign};
 
@@ -333,12 +356,10 @@ mod tests {
         let mut vm = vm!();
         add_segments!(vm, 3);
 
-        vm.insert_value(&relocatable!(1, 0), bigint!(0)).unwrap();
-        vm.insert_value(&relocatable!(1, 1), bigint!(1)).unwrap();
-        vm.insert_value(&relocatable!(1, 2), bigint!(2)).unwrap();
-        vm.insert_value(&relocatable!(1, 4), relocatable!(2, 0))
-            .unwrap();
-
+        memory_insert!(
+            vm,
+            [((1, 0), 0), ((1, 1), 1), ((1, 2), 2), ((1, 4), (2, 0))]
+        );
         assert_eq!(
             syscall.read_syscall_request("send_message_to_l1", &vm, relocatable!(1, 0)),
             Ok(SyscallRequest::SendMessageToL1(SendMessageToL1SysCall {
@@ -356,13 +377,17 @@ mod tests {
         let mut vm = vm!();
         add_segments!(vm, 2);
 
-        vm.insert_value(&relocatable!(1, 0), bigint!(0)).unwrap();
-        vm.insert_value(&relocatable!(1, 1), bigint!(1)).unwrap();
-        vm.insert_value(&relocatable!(1, 2), bigint!(2)).unwrap();
-        vm.insert_value(&relocatable!(1, 3), bigint!(3)).unwrap();
-        vm.insert_value(&relocatable!(1, 4), relocatable!(1, 20))
-            .unwrap();
-        vm.insert_value(&relocatable!(1, 5), bigint!(4)).unwrap();
+        memory_insert!(
+            vm,
+            [
+                ((1, 0), 0),
+                ((1, 1), 1),
+                ((1, 2), 2),
+                ((1, 3), 3),
+                ((1, 4), (1, 20)),
+                ((1, 5), 4)
+            ]
+        );
 
         assert_eq!(
             syscall.read_syscall_request("deploy", &vm, relocatable!(1, 0)),
@@ -383,24 +408,33 @@ mod tests {
         let mut vm = vm!();
         add_segments!(vm, 2);
 
-        vm.insert_value(&relocatable!(1, 0), bigint!(18)).unwrap();
-        assert!(syscall
-            .get_block_timestamp(&mut vm, relocatable!(1, 0))
-            .is_ok());
+        memory_insert!(
+            vm,
+            [
+                ((1, 0), (1, 1)), // syscall_ptr
+                ((1, 1), 18)
+            ]
+        );
 
-        // Check that syscall.get_block_timestamp insert syscall.get_block_info().block_timestamp in the (1,1) position
-        assert!(vm
-            .insert_value(
-                &relocatable!(1, 1),
-                bigint!(syscall.get_block_info().block_timestamp + 10)
+        let ids_data = ids_data!["syscall_ptr"];
+
+        let hint_data = HintProcessorData::new_default(GET_SEQUENCER_ADDRESS.to_string(), ids_data);
+        // invoke syscall
+        let mut syscall_handler = SyscallHintProcessor::new_empty().unwrap();
+        syscall_handler
+            .execute_hint(
+                &mut vm,
+                &mut ExecutionScopes::new(),
+                &any_box!(hint_data),
+                &HashMap::new(),
             )
-            .is_err());
-        assert!(vm
-            .insert_value(
-                &relocatable!(1, 1),
-                bigint!(syscall.get_block_info().block_timestamp)
-            )
-            .is_ok())
+            .unwrap();
+
+        // Check that syscall.get_block_timestamp insert syscall.get_block_info().block_timestamp in the (1,2) position
+        assert_eq!(
+            get_big_int(&vm, &relocatable!(1, 2)).unwrap(),
+            bigint!(syscall.get_block_info().block_timestamp)
+        );
     }
 
     #[test]
@@ -409,37 +443,221 @@ mod tests {
         let mut vm = vm!();
         add_segments!(vm, 2);
 
-        vm.insert_value(&relocatable!(1, 0), bigint!(18)).unwrap();
-        assert!(syscall
-            .get_sequencer_address(&mut vm, relocatable!(1, 0))
-            .is_ok());
+        memory_insert!(vm, [((1, 0), (1, 1)), ((1, 1), 18)]);
+
+        let ids_data = ids_data!["syscall_ptr"];
+
+        let hint_data = HintProcessorData::new_default(GET_SEQUENCER_ADDRESS.to_string(), ids_data);
+        // invoke syscall
+        let mut syscall_handler = SyscallHintProcessor::new_empty().unwrap();
+        syscall_handler
+            .execute_hint(
+                &mut vm,
+                &mut ExecutionScopes::new(),
+                &any_box!(hint_data),
+                &HashMap::new(),
+            )
+            .unwrap();
 
         // Check that syscall.get_sequencer insert syscall.get_block_info().sequencer_address in the (1,1) position
-        assert!(vm
-            .insert_value(
-                &relocatable!(1, 1),
-                bigint!(syscall.get_block_info().sequencer_address + 10)
-            )
-            .is_err());
-        assert!(vm
-            .insert_value(
-                &relocatable!(1, 1),
-                bigint!(syscall.get_block_info().sequencer_address)
-            )
-            .is_ok())
+        assert_eq!(get_big_int(&vm, &relocatable!(1, 2)).unwrap(), bigint!(0))
     }
 
     #[test]
-    fn get_caller_address_test() {
+    fn emit_event_test() {
+        // create data and variables to execute hint
+
+        let mut vm = vm!();
+        add_segments!(vm, 4);
+
+        // insert keys and data to generate the event
+        // keys ptr points to (3,0)
+        // data ptr points to (3,3)
+
+        // selector of syscall
+        let selector = "1280709301550335749748";
+
+        allocate_selector!(vm, ((2, 0), selector.as_bytes()));
+        memory_insert!(
+            vm,
+            [
+                ((1, 0), (2, 0)), // syscall ptr
+                ((2, 1), 2),      // keys len
+                ((2, 2), (3, 0)), // keys ptr
+                ((2, 3), 2),      // data len
+                ((2, 4), (3, 3)), // data ptr
+                ((3, 0), 1),      // keys pointed by key ptr
+                ((3, 1), 1),
+                ((3, 3), 1), // data pointed by data ptr
+                ((3, 4), 1)
+            ]
+        );
+        // syscall_ptr
+        let ids_data = ids_data!["syscall_ptr"];
+
+        let hint_data = HintProcessorData::new_default(EMIT_EVENT_CODE.to_string(), ids_data);
+        // invoke syscall
+        let mut syscall_handler = SyscallHintProcessor::new_empty().unwrap();
+        syscall_handler
+            .execute_hint(
+                &mut vm,
+                &mut ExecutionScopes::new(),
+                &any_box!(hint_data),
+                &HashMap::new(),
+            )
+            .unwrap();
+
+        let event = syscall_handler
+            .syscall_handler
+            .events
+            .get(0)
+            .unwrap()
+            .clone();
+
+        assert_eq!(
+            OrderedEvent::new(
+                0,
+                Vec::from([bigint!(1), bigint!(1)]),
+                Vec::from([bigint!(1), bigint!(1)])
+            ),
+            event
+        );
+        assert_eq!(
+            syscall_handler
+                .syscall_handler
+                .tx_execution_context
+                .n_emitted_events,
+            1
+        );
+    }
+
+    #[test]
+    fn get_tx_info_test() {
+        let mut vm = vm!();
+        add_segments!(vm, 3);
+
+        // insert data to form the request
+        memory_insert!(
+            vm,
+            [
+                ((1, 0), (2, 0)), //  syscall_ptr
+                ((2, 0), 1),      //  version
+                ((2, 1), 1),      //  account_contract_address
+                ((2, 2), 2),      //  max_fee
+                ((2, 3), 1),      //  signature_len
+                ((2, 4), (3, 0)), //  signature
+                ((2, 5), 1),      //  transaction_hash
+                ((2, 6), 1),      //  chain_id
+                ((2, 7), 1)       //  nonce
+            ]
+        );
+
+        // syscall_ptr
+        let ids_data = ids_data!["syscall_ptr"];
+
+        let hint_data = HintProcessorData::new_default(GET_TX_INFO.to_string(), ids_data);
+        // invoke syscall
+        let mut hint_procesor = SyscallHintProcessor::new_empty().unwrap();
+        let err = hint_procesor.execute_hint(
+            &mut vm,
+            &mut ExecutionScopes::new(),
+            &any_box!(hint_data),
+            &HashMap::new(),
+        );
+
+        assert_eq!(
+            err,
+            Err(VirtualMachineError::UnknownHint(
+                "Hint not implemented".to_string()
+            ))
+        )
+    }
+
+    #[test]
+    fn test_get_caller_address_ok() {
         let mut syscall = BusinessLogicSyscallHandler::new(BlockInfo::default());
         let mut vm = vm!();
+
         add_segments!(vm, 2);
 
-        vm.insert_value(&relocatable!(1, 0), bigint!(18)).unwrap();
-        // check that it wrote the response in the correct place
-        assert!(syscall
-            .get_caller_address(&mut vm, relocatable!(1, 0))
-            .is_ok());
-        assert_eq!(get_integer(&vm, &relocatable!(1, 1)).unwrap(), 0)
+        // direction (1,0) is the sycall_ptr
+        memory_insert!(vm, [((1, 0), (1, 1)), ((1, 1), 0)]);
+
+        // syscall_ptr
+        let ids_data = ids_data!["syscall_ptr"];
+
+        let hint_data = HintProcessorData::new_default(GET_CALLER_ADDRESS.to_string(), ids_data);
+        // invoke syscall
+        let mut hint_processor = SyscallHintProcessor::new_empty().unwrap();
+        hint_processor
+            .execute_hint(
+                &mut vm,
+                &mut ExecutionScopes::new(),
+                &any_box!(hint_data),
+                &HashMap::new(),
+            )
+            .unwrap();
+
+        // response is written in direction (1,2)
+        assert_eq!(
+            get_integer(&vm, &relocatable!(1, 2)).unwrap() as u64,
+            hint_processor.syscall_handler.contract_address
+        )
+    }
+
+    #[test]
+    fn test_send_message_to_l1_ok() {
+        let mut vm = vm!();
+
+        add_segments!(vm, 3);
+
+        // parameters are read from memory location (1,1)
+        memory_insert!(
+            vm,
+            [
+                ((1, 0), (1, 1)), // syscall_ptr
+                ((1, 1), 0),
+                ((1, 2), 1),
+                ((1, 3), 2),
+                ((1, 5), (2, 0)),
+                ((2, 0), 18),
+                ((2, 1), 12)
+            ]
+        );
+
+        // syscall_ptr
+        let ids_data = ids_data!["syscall_ptr"];
+
+        let hint_data = HintProcessorData::new_default(SEND_MESSAGE_TO_L1.to_string(), ids_data);
+        // invoke syscall
+        let mut hint_processor = SyscallHintProcessor::new_empty().unwrap();
+        hint_processor
+            .execute_hint(
+                &mut vm,
+                &mut ExecutionScopes::new(),
+                &any_box!(hint_data),
+                &HashMap::new(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            hint_processor
+                .syscall_handler
+                .tx_execution_context
+                .n_sent_messages,
+            1
+        );
+        assert_eq!(
+            hint_processor.syscall_handler.l2_to_l1_messages,
+            vec![OrderedL2ToL1Message::new(
+                hint_processor
+                    .syscall_handler
+                    .tx_execution_context
+                    .n_sent_messages
+                    - 1,
+                1,
+                vec![bigint!(18), bigint!(12)],
+            )]
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,7 +115,7 @@ pub mod test_utils {
         ( $( $name: expr ),* ) => {
             {
                 let ids_names = vec![$( $name ),*];
-                let references = references!(ids_names.len() as i32);
+                let references = crate::utils::test_utils::references!(ids_names.len() as i32);
                 let mut ids_data = HashMap::<String, cairo_rs::hint_processor::hint_processor_definition::HintReference>::new();
                 for (i, name) in ids_names.iter().enumerate() {
                     ids_data.insert(name.to_string(), references.get(&i).unwrap().clone());
@@ -158,7 +158,7 @@ pub mod test_utils {
     #[macro_export]
     macro_rules! memory_insert {
         ($vm:expr, [ $( (($si:expr, $off:expr), $val:tt) ),* ] ) => {
-            $( allocate_values!($vm, $si, $off, $val); )*
+            $( crate::allocate_values!($vm, $si, $off, $val); )*
         };
     }
     pub(crate) use memory_insert;
@@ -166,13 +166,13 @@ pub mod test_utils {
     #[macro_export]
     macro_rules! allocate_values {
         ($vm: expr, $si:expr, $off:expr, ($sival:expr, $offval:expr)) => {
-            let k = relocatable_value!($si, $off);
-            let v = relocatable_value!($sival, $offval);
+            let k = crate::relocatable_value!($si, $off);
+            let v = crate::relocatable_value!($sival, $offval);
             $vm.insert_value(&k, &v).unwrap();
         };
         ($vm: expr, $si:expr, $off:expr, $val:expr) => {
             let v = bigint!($val);
-            let k = relocatable_value!($si, $off);
+            let k = crate::relocatable_value!($si, $off);
             $vm.insert_value(&k, v).unwrap();
         };
     }
@@ -181,8 +181,8 @@ pub mod test_utils {
     #[macro_export]
     macro_rules! allocate_selector {
         ($vm: expr, (($si:expr, $off:expr), $val:expr)) => {
-            let v = super::bigint_str!($val);
-            let k = relocatable_value!($si, $off);
+            let v = crate::bigint_str!($val);
+            let k = crate::relocatable_value!($si, $off);
             $vm.insert_value(&k, v).unwrap();
         };
     }


### PR DESCRIPTION
* Refactor tests to use the hint executor
* Move all tests that use the executor to the file `syscall_resource_manager.rs`.
*  Add a building method for execution_resource_manager to create the map where the counting of syscall calls is done