### PR TITLE
Make clippy check all targets, including tests, fix some tests warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ compile_cairo:
 	cairo-compile cairo_syscalls/syscalls.cairo --output cairo_syscalls/syscalls.json
 
 clippy:
-	cargo clippy  -- -D warnings
+	cargo clippy --all-targets -- -D warnings
 
 remove-venv:
 	rm -rf starknet-in-rs-venv

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -1005,7 +1005,7 @@ mod tests {
         };
         assert_eq!(
             handler._get_caller_address(&vm, ptr),
-            Ok(CallInfo::default().caller_address.into())
+            Ok(CallInfo::default().caller_address)
         )
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -178,8 +178,8 @@ pub mod test_utils {
     #[macro_export]
     macro_rules! allocate_selector {
         ($vm: expr, (($si:expr, $off:expr), $val:expr)) => {
-            let v = crate::bigint_str!($val);
-            let k = crate::relocatable_value!($si, $off);
+            let v = $crate::bigint_str!($val);
+            let k = $crate::relocatable_value!($si, $off);
             $vm.insert_value(&k, v).unwrap();
         };
     }


### PR DESCRIPTION
Otherwise, warnings on other targets than the default go unnoticed.