### PR TITLE
Add fields to StarknetGeneralConfig

### DIFF
--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -51,7 +51,7 @@ impl BusinessLogicSyscallHandler {
         let contract_address = 1;
         let caller_address = 0;
         let l2_to_l1_messages = Vec::new();
-        let general_config = StarknetGeneralConfig::new();
+        let general_config = StarknetGeneralConfig::default();
         let tx_info_ptr = None;
 
         BusinessLogicSyscallHandler {

--- a/src/definitions/general_config.rs
+++ b/src/definitions/general_config.rs
@@ -43,7 +43,20 @@ pub(crate) struct StarknetGeneralConfig {
 }
 
 impl StarknetGeneralConfig {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(
+        starknet_os_config: StarknetOsConfig,
+        contract_storage_commitment_tree_height: u64,
+        global_state_commitment_tree_height: u64,
+        sequencer_address: u64,
+    ) -> Self {
+        Self {
+            starknet_os_config,
+            contract_storage_commitment_tree_height,
+            global_state_commitment_tree_height,
+            sequencer_address,
+        }
+    }
+    pub(crate) fn default() -> Self {
         Self {
             starknet_os_config: StarknetOsConfig {
                 chain_id: StarknetChainId::TestNet,

--- a/src/definitions/general_config.rs
+++ b/src/definitions/general_config.rs
@@ -37,6 +37,9 @@ pub(crate) struct StarknetOsConfig {
 #[derive(Debug, Clone)]
 pub(crate) struct StarknetGeneralConfig {
     pub(crate) starknet_os_config: StarknetOsConfig,
+    contract_storage_commitment_tree_height: u64,
+    global_state_commitment_tree_height: u64,
+    sequencer_address: u64,
 }
 
 impl StarknetGeneralConfig {
@@ -46,6 +49,9 @@ impl StarknetGeneralConfig {
                 chain_id: StarknetChainId::TestNet,
                 fee_token_address: BigInt::zero(),
             },
+            contract_storage_commitment_tree_height: 0,
+            global_state_commitment_tree_height: 0,
+            sequencer_address: 0,
         }
     }
 }


### PR DESCRIPTION
Add fields to StarknetGeneralConfig.
These fields will be used in the StarknetState y SharedState implementation