### PR TITLE
Implement StateReader trait for CachedState

### DIFF
--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -1,4 +1,7 @@
+use num_bigint::BigInt;
 use thiserror::Error;
+
+use crate::state::state_chache::StorageEntry;
 
 #[derive(Debug, PartialEq, Error)]
 pub enum StateError {
@@ -8,4 +11,10 @@ pub enum StateError {
     AssignedContractClassCache,
     #[error("Cache already initialized")]
     StateCacheAlreadyInitialized,
+    #[error("No class hash assigned for contact address: {0}")]
+    NoneClassHash(BigInt),
+    #[error("No nonce assigned for contact address: {0}")]
+    NoneNonce(BigInt),
+    #[error("No storage value assigned for entry: {0:?}")]
+    NoneStorage(StorageEntry),
 }

--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -6,4 +6,6 @@ pub enum StateError {
     MissingContractClassCache,
     #[error("ContractClassCache must be None")]
     AssignedContractClassCache,
+    #[error("Cache already initialized")]
+    StateCacheAlreadyInitialized,
 }

--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -17,4 +17,8 @@ pub enum StateError {
     NoneNonce(BigInt),
     #[error("No storage value assigned for entry: {0:?}")]
     NoneStorage(StorageEntry),
+    #[error("Cannot deploy contract at address: {0}")]
+    ContractAddressOutOfRangeAddress(BigInt),
+    #[error("Requested contract address {0} is unavailable for deployment")]
+    ContractAddressUnavailable(BigInt),
 }

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -1,0 +1,160 @@
+use std::collections::HashMap;
+
+use num_bigint::BigInt;
+
+use crate::{core::errors::state_errors::StateError, services::api::contract_class::ContractClass};
+
+use super::{
+    state_api::StateReader,
+    state_api_objects::BlockInfo,
+    state_chache::{StateCache, StorageEntry},
+};
+
+pub(crate) type ContractClassCache = HashMap<Vec<u8>, ContractClass>;
+
+pub(crate) struct CachedState<T: StateReader> {
+    block_info: BlockInfo,
+    pub(crate) state_reader: T,
+    pub(crate) cache: StateCache,
+    contract_classes: Option<ContractClassCache>,
+}
+
+impl<T: StateReader> CachedState<T> {
+    pub(crate) fn new(
+        block_info: BlockInfo,
+        state_reader: T,
+        contract_class_cache: Option<ContractClassCache>,
+    ) -> Self {
+        Self {
+            block_info,
+            cache: StateCache::default(),
+            contract_classes: contract_class_cache,
+            state_reader,
+        }
+    }
+
+    pub(crate) fn block_info(&self) -> &BlockInfo {
+        &self.block_info
+    }
+
+    pub(crate) fn get_contract_classes(&self) -> Result<&ContractClassCache, StateError> {
+        self.contract_classes
+            .as_ref()
+            .ok_or(StateError::MissingContractClassCache)
+    }
+
+    pub(crate) fn insert_contract_class(
+        &mut self,
+        key: Vec<u8>,
+        value: ContractClass,
+    ) -> Result<(), StateError> {
+        self.contract_classes
+            .as_mut()
+            .ok_or(StateError::MissingContractClassCache)?
+            .insert(key, value);
+
+        Ok(())
+    }
+
+    pub(crate) fn set_contract_class_cache(
+        &mut self,
+        contract_classes: ContractClassCache,
+    ) -> Result<(), StateError> {
+        if self.contract_classes.is_some() {
+            return Err(StateError::AssignedContractClassCache);
+        }
+        self.contract_classes = Some(contract_classes);
+        Ok(())
+    }
+
+    pub(crate) fn update_block_info(&mut self, block_info: BlockInfo) {
+        self.block_info = block_info;
+    }
+
+    pub(crate) fn set_contract_class(&mut self, class_hash: &[u8], contract_class: ContractClass) {
+        if let Some(contract_classes) = &mut self.contract_classes {
+            contract_classes.insert(Vec::from(class_hash), contract_class);
+        }
+    }
+
+    pub(crate) fn deploy_contract(&self, contract_address: &BigInt, class_hash: &[u8]) {
+        todo!()
+    }
+
+    pub(crate) fn set_storage_at(
+        &self,
+        contract_address: &BigInt,
+        key: &[u8; 32],
+        value: BigInt,
+    ) -> BigInt {
+        todo!()
+    }
+}
+
+impl<T: StateReader> StateReader for CachedState<T> {
+    fn get_contract_class(&mut self, class_hash: &[u8]) -> Result<ContractClass, StateError> {
+        if !(self.get_contract_classes()?.contains_key(class_hash)) {
+            let contract_class = &self.state_reader.get_contract_class(class_hash)?;
+            self.insert_contract_class(class_hash.to_vec(), contract_class.to_owned());
+        }
+        self.get_contract_class(class_hash)
+    }
+
+    fn get_class_hash_at(&mut self, contract_address: &BigInt) -> Result<Vec<u8>, StateError> {
+        if !(self
+            .cache
+            .get_address_to_class_hash()
+            .contains_key(contract_address))
+        {
+            let class_hash = self.state_reader.get_class_hash_at(contract_address)?;
+            self.cache
+                .class_hash_initial_values
+                .insert(contract_address.clone(), class_hash);
+        }
+
+        // Safe unwrap
+        Ok(self
+            .cache
+            .get_address_to_class_hash()
+            .get(contract_address)
+            .unwrap()
+            .to_vec())
+    }
+
+    fn get_nonce_at(&mut self, contract_address: &BigInt) -> Result<BigInt, StateError> {
+        if !(self
+            .cache
+            .get_address_to_nonce()
+            .contains_key(contract_address))
+        {
+            let nonce = self.state_reader.get_nonce_at(contract_address)?;
+            self.cache
+                .nonce_initial_values
+                .insert(contract_address.clone(), nonce);
+        }
+        // Safe unwrap
+        Ok(self
+            .cache
+            .get_address_to_nonce()
+            .get(contract_address)
+            .unwrap()
+            .to_owned())
+    }
+
+    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<BigInt, StateError> {
+        if !(self.cache.get_storage_view().contains_key(storage_entry)) {
+            let value = self.state_reader.get_storage_at(storage_entry)?;
+            self.cache
+                .storage_initial_values
+                .insert(storage_entry.clone(), value);
+        }
+
+        // Safe unwrap
+        Ok(self
+            .cache
+            .get_storage_view()
+            .get(storage_entry)
+            .unwrap()
+            .clone())
+    }
+}

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -112,12 +112,11 @@ impl<T: StateReader> StateReader for CachedState<T> {
                 .insert(contract_address.clone(), class_hash);
         }
 
-        // Safe unwrap
         Ok(self
             .cache
             .get_address_to_class_hash()
             .get(contract_address)
-            .unwrap()
+            .ok_or_else(|| StateError::NoneClassHash(contract_address.clone()))?
             .to_vec())
     }
 
@@ -132,12 +131,11 @@ impl<T: StateReader> StateReader for CachedState<T> {
                 .nonce_initial_values
                 .insert(contract_address.clone(), nonce);
         }
-        // Safe unwrap
         Ok(self
             .cache
             .get_address_to_nonce()
             .get(contract_address)
-            .unwrap()
+            .ok_or_else(|| StateError::NoneNonce(contract_address.clone()))?
             .to_owned())
     }
 
@@ -149,12 +147,11 @@ impl<T: StateReader> StateReader for CachedState<T> {
                 .insert(storage_entry.clone(), value);
         }
 
-        // Safe unwrap
         Ok(self
             .cache
             .get_storage_view()
             .get(storage_entry)
-            .unwrap()
+            .ok_or_else(|| StateError::NoneStorage(storage_entry.clone()))?
             .clone())
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cached_state;
 pub mod state_api;
 pub mod state_api_objects;
 pub(crate) mod state_chache;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,3 @@
+pub(crate) mod cached_state;
 pub mod state_api;
 pub mod state_api_objects;
-pub(crate) mod state_chache;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod cached_state;
 pub mod state_api;
 pub mod state_api_objects;
+pub(crate) mod state_chache;

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -1,18 +1,18 @@
 use num_bigint::BigInt;
 
-use crate::services::api::contract_class::ContractClass;
+use crate::{core::errors::state_errors::StateError, services::api::contract_class::ContractClass};
 
-use super::state_api_objects::BlockInfo;
+use super::{state_api_objects::BlockInfo, state_chache::StorageEntry};
 
 pub(crate) trait StateReader {
     /// Returns the contract class of the given class hash.
-    fn get_contract_class(&self, class_hash: &[u8]) -> ContractClass;
+    fn get_contract_class(&mut self, class_hash: &[u8]) -> Result<ContractClass, StateError>;
     /// Returns the class hash of the contract class at the given address.
-    fn get_class_hash_at(&self, contract_address: &BigInt) -> Vec<u8>;
+    fn get_class_hash_at(&mut self, contract_address: &BigInt) -> Result<Vec<u8>, StateError>;
     /// Returns the nonce of the given contract instance.
-    fn get_nonce_at(&self, contract_address: &BigInt) -> BigInt;
+    fn get_nonce_at(&mut self, contract_address: &BigInt) -> Result<BigInt, StateError>;
     /// Returns the storage value under the given key in the given contract instance.
-    fn get_storage_at(&self, contract_address: &BigInt, key: &BigInt) -> BigInt;
+    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<BigInt, StateError>;
 }
 
 pub(crate) trait State {

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -16,10 +16,14 @@ pub(crate) trait StateReader {
 }
 
 pub(crate) trait State {
-    fn block_info(&self) -> BlockInfo;
+    fn get_block_info(&self) -> &BlockInfo;
     fn set_contract_class(&mut self, class_hash: &[u8], contract_class: &ContractClass);
-    fn deploy_contract(&self, contract_address: &BigInt, class_hash: &[u8]);
-    fn increment_nonce(&mut self, contract_address: &BigInt);
-    fn update_block_info(&mut self, block_info: &BlockInfo);
-    fn set_storage_at(&mut self, contract_address: &BigInt, key: &BigInt, value: BigInt);
+    fn deploy_contract(
+        &mut self,
+        contract_address: BigInt,
+        class_hash: Vec<u8>,
+    ) -> Result<(), StateError>;
+    fn increment_nonce(&mut self, contract_address: &BigInt) -> Result<(), StateError>;
+    fn update_block_info(&mut self, block_info: BlockInfo);
+    fn set_storage_at(&mut self, storage_entry: &StorageEntry, value: BigInt);
 }

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -6,13 +6,13 @@ use super::{state_api_objects::BlockInfo, state_chache::StorageEntry};
 
 pub(crate) trait StateReader {
     /// Returns the contract class of the given class hash.
-    fn get_contract_class(&mut self, class_hash: &[u8]) -> Result<ContractClass, StateError>;
+    fn get_contract_class(&mut self, class_hash: &[u8]) -> Result<&ContractClass, StateError>;
     /// Returns the class hash of the contract class at the given address.
-    fn get_class_hash_at(&mut self, contract_address: &BigInt) -> Result<Vec<u8>, StateError>;
+    fn get_class_hash_at(&mut self, contract_address: &BigInt) -> Result<&Vec<u8>, StateError>;
     /// Returns the nonce of the given contract instance.
-    fn get_nonce_at(&mut self, contract_address: &BigInt) -> Result<BigInt, StateError>;
+    fn get_nonce_at(&mut self, contract_address: &BigInt) -> Result<&BigInt, StateError>;
     /// Returns the storage value under the given key in the given contract instance.
-    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<BigInt, StateError>;
+    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<&BigInt, StateError>;
 }
 
 pub(crate) trait State {

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -2,7 +2,7 @@ use num_bigint::BigInt;
 
 use crate::{core::errors::state_errors::StateError, services::api::contract_class::ContractClass};
 
-use super::{state_api_objects::BlockInfo, state_chache::StorageEntry};
+use super::{cached_state::StorageEntry, state_api_objects::BlockInfo};
 
 pub(crate) trait StateReader {
     /// Returns the contract class of the given class hash.

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -2,7 +2,7 @@ use num_bigint::BigInt;
 
 use crate::{core::errors::state_errors::StateError, services::api::contract_class::ContractClass};
 
-use super::{cached_state::StorageEntry, state_api_objects::BlockInfo};
+use super::{state_api_objects::BlockInfo, state_chache::StorageEntry};
 
 pub(crate) trait StateReader {
     /// Returns the contract class of the given class hash.

--- a/src/state/state_chache.rs
+++ b/src/state/state_chache.rs
@@ -28,6 +28,16 @@ pub(crate) struct StateCache {
 }
 
 impl StateCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            class_hash_initial_values: HashMap::new(),
+            nonce_initial_values: HashMap::new(),
+            storage_initial_values: HashMap::new(),
+            class_hash_writes: HashMap::new(),
+            nonce_writes: HashMap::new(),
+            storage_writes: HashMap::new(),
+        }
+    }
     pub(crate) fn get_address_to_class_hash(&self) -> HashMap<BigInt, Vec<u8>> {
         let mut address_to_class_hash = self.class_hash_initial_values.clone();
         address_to_class_hash.extend(self.class_hash_writes.clone());
@@ -55,20 +65,20 @@ impl StateCache {
 
     pub(crate) fn update_writes(
         &mut self,
-        address_to_class_hash: HashMap<BigInt, Vec<u8>>,
-        address_to_nonce: HashMap<BigInt, BigInt>,
-        storage_updates: HashMap<StorageEntry, BigInt>,
+        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
+        address_to_nonce: &HashMap<BigInt, BigInt>,
+        storage_updates: &HashMap<StorageEntry, BigInt>,
     ) {
-        self.class_hash_writes.extend(address_to_class_hash);
-        self.nonce_writes.extend(address_to_nonce);
-        self.storage_writes.extend(storage_updates);
+        self.class_hash_writes.extend(address_to_class_hash.clone());
+        self.nonce_writes.extend(address_to_nonce.clone());
+        self.storage_writes.extend(storage_updates.clone());
     }
 
     pub(crate) fn set_initial_values(
         &mut self,
-        address_to_class_hash: HashMap<BigInt, Vec<u8>>,
-        address_to_nonce: HashMap<BigInt, BigInt>,
-        storage_updates: HashMap<StorageEntry, BigInt>,
+        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
+        address_to_nonce: &HashMap<BigInt, BigInt>,
+        storage_updates: &HashMap<StorageEntry, BigInt>,
     ) -> Result<(), StateError> {
         if !(self.get_address_to_class_hash().is_empty()
             && self.get_address_to_nonce().is_empty()

--- a/src/state/state_chache.rs
+++ b/src/state/state_chache.rs
@@ -12,19 +12,17 @@ use super::state_api::StateReader;
 /// (contract_address, key)
 pub(crate) type StorageEntry = (BigInt, [u8; 32]);
 
-pub(crate) type ContractClassCache = HashMap<Vec<u8>, ContractClass>;
-
 #[derive(Debug, Default, Clone)]
 pub(crate) struct StateCache {
     // Reader's cached information; initial values, read before any write operation (per cell)
-    class_hash_initial_values: HashMap<BigInt, Vec<u8>>,
-    nonce_initial_values: HashMap<BigInt, BigInt>,
-    storage_initial_values: HashMap<StorageEntry, BigInt>,
+    pub(crate) class_hash_initial_values: HashMap<BigInt, Vec<u8>>,
+    pub(crate) nonce_initial_values: HashMap<BigInt, BigInt>,
+    pub(crate) storage_initial_values: HashMap<StorageEntry, BigInt>,
 
     // Writer's cached information.
-    class_hash_writes: HashMap<BigInt, Vec<u8>>,
-    nonce_writes: HashMap<BigInt, BigInt>,
-    storage_writes: HashMap<StorageEntry, BigInt>,
+    pub(crate) class_hash_writes: HashMap<BigInt, Vec<u8>>,
+    pub(crate) nonce_writes: HashMap<BigInt, BigInt>,
+    pub(crate) storage_writes: HashMap<StorageEntry, BigInt>,
 }
 
 impl StateCache {
@@ -99,152 +97,6 @@ impl StateCache {
     }
 }
 
-pub(crate) struct CachedState<T: StateReader> {
-    block_info: BlockInfo,
-    pub(crate) state_reader: T,
-    pub(crate) cache: StateCache,
-    contract_classes: Option<ContractClassCache>,
-}
-
-impl<T: StateReader> CachedState<T> {
-    pub(crate) fn new(
-        block_info: BlockInfo,
-        state_reader: T,
-        contract_class_cache: Option<ContractClassCache>,
-    ) -> Self {
-        Self {
-            block_info,
-            cache: StateCache::default(),
-            contract_classes: contract_class_cache,
-            state_reader,
-        }
-    }
-
-    pub(crate) fn block_info(&self) -> &BlockInfo {
-        &self.block_info
-    }
-
-    pub(crate) fn get_contract_classes(&self) -> Result<&ContractClassCache, StateError> {
-        self.contract_classes
-            .as_ref()
-            .ok_or(StateError::MissingContractClassCache)
-    }
-
-    pub(crate) fn insert_contract_class(
-        &mut self,
-        key: Vec<u8>,
-        value: ContractClass,
-    ) -> Result<(), StateError> {
-        self.contract_classes
-            .as_mut()
-            .ok_or(StateError::MissingContractClassCache)?
-            .insert(key, value);
-
-        Ok(())
-    }
-
-    pub(crate) fn set_contract_class_cache(
-        &mut self,
-        contract_classes: ContractClassCache,
-    ) -> Result<(), StateError> {
-        if self.contract_classes.is_some() {
-            return Err(StateError::AssignedContractClassCache);
-        }
-        self.contract_classes = Some(contract_classes);
-        Ok(())
-    }
-
-    pub(crate) fn update_block_info(&mut self, block_info: BlockInfo) {
-        self.block_info = block_info;
-    }
-
-    pub(crate) fn set_contract_class(&mut self, class_hash: &[u8], contract_class: ContractClass) {
-        if let Some(contract_classes) = &mut self.contract_classes {
-            contract_classes.insert(Vec::from(class_hash), contract_class);
-        }
-    }
-
-    pub(crate) fn deploy_contract(&self, contract_address: &BigInt, class_hash: &[u8]) {
-        todo!()
-    }
-
-    pub(crate) fn set_storage_at(
-        &self,
-        contract_address: &BigInt,
-        key: &[u8; 32],
-        value: BigInt,
-    ) -> BigInt {
-        todo!()
-    }
-}
-
-impl<T: StateReader> StateReader for CachedState<T> {
-    fn get_contract_class(&mut self, class_hash: &[u8]) -> Result<ContractClass, StateError> {
-        if !(self.get_contract_classes()?.contains_key(class_hash)) {
-            let contract_class = &self.state_reader.get_contract_class(class_hash)?;
-            self.insert_contract_class(class_hash.to_vec(), contract_class.to_owned());
-        }
-        self.get_contract_class(class_hash)
-    }
-
-    fn get_class_hash_at(&mut self, contract_address: &BigInt) -> Result<Vec<u8>, StateError> {
-        if !(self
-            .cache
-            .get_address_to_class_hash()
-            .contains_key(contract_address))
-        {
-            let class_hash = self.state_reader.get_class_hash_at(contract_address)?;
-            self.cache
-                .class_hash_initial_values
-                .insert(contract_address.clone(), class_hash);
-        }
-
-        // Safe unwrap
-        Ok(self
-            .cache
-            .get_address_to_class_hash()
-            .get(contract_address)
-            .unwrap()
-            .to_vec())
-    }
-
-    fn get_nonce_at(&mut self, contract_address: &BigInt) -> Result<BigInt, StateError> {
-        if !(self
-            .cache
-            .get_address_to_nonce()
-            .contains_key(contract_address))
-        {
-            let nonce = self.state_reader.get_nonce_at(contract_address)?;
-            self.cache
-                .nonce_initial_values
-                .insert(contract_address.clone(), nonce);
-        }
-        // Safe unwrap
-        Ok(self
-            .cache
-            .get_address_to_nonce()
-            .get(contract_address)
-            .unwrap()
-            .to_owned())
-    }
-
-    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<BigInt, StateError> {
-        if !(self.cache.get_storage_view().contains_key(storage_entry)) {
-            let value = self.state_reader.get_storage_at(storage_entry)?;
-            self.cache
-                .storage_initial_values
-                .insert(storage_entry.clone(), value);
-        }
-
-        // Safe unwrap
-        Ok(self
-            .cache
-            .get_storage_view()
-            .get(storage_entry)
-            .unwrap()
-            .clone())
-    }
-}
 #[cfg(test)]
 mod tests {
     use crate::{bigint, state};

--- a/src/state/state_chache.rs
+++ b/src/state/state_chache.rs
@@ -14,6 +14,91 @@ pub(crate) type StorageEntry = (BigInt, [u8; 32]);
 
 pub(crate) type ContractClassCache = HashMap<Vec<u8>, ContractClass>;
 
+#[derive(Debug, Default, Clone)]
+pub(crate) struct StateCache {
+    // Reader's cached information; initial values, read before any write operation (per cell)
+    class_hash_initial_values: HashMap<BigInt, Vec<u8>>,
+    nonce_initial_values: HashMap<BigInt, BigInt>,
+    storage_initial_values: HashMap<StorageEntry, BigInt>,
+
+    // Writer's cached information.
+    class_hash_writes: HashMap<BigInt, Vec<u8>>,
+    nonce_writes: HashMap<BigInt, BigInt>,
+    storage_writes: HashMap<StorageEntry, BigInt>,
+}
+
+impl StateCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            class_hash_initial_values: HashMap::new(),
+            nonce_initial_values: HashMap::new(),
+            storage_initial_values: HashMap::new(),
+            class_hash_writes: HashMap::new(),
+            nonce_writes: HashMap::new(),
+            storage_writes: HashMap::new(),
+        }
+    }
+    pub(crate) fn get_address_to_class_hash(&self) -> HashMap<BigInt, Vec<u8>> {
+        let mut address_to_class_hash = self.class_hash_initial_values.clone();
+        address_to_class_hash.extend(self.class_hash_writes.clone());
+        address_to_class_hash
+    }
+
+    pub(crate) fn get_address_to_nonce(&self) -> HashMap<BigInt, BigInt> {
+        let mut address_to_nonce = self.nonce_initial_values.clone();
+        address_to_nonce.extend(self.nonce_writes.clone());
+        address_to_nonce
+    }
+
+    pub(crate) fn get_storage_view(&self) -> HashMap<StorageEntry, BigInt> {
+        let mut storage_view = self.storage_initial_values.clone();
+        storage_view.extend(self.storage_writes.clone());
+        storage_view
+    }
+
+    pub(crate) fn update_writes_from_other(&mut self, other: &Self) {
+        self.class_hash_writes
+            .extend(other.class_hash_writes.clone());
+        self.nonce_writes.extend(other.nonce_writes.clone());
+        self.storage_writes.extend(other.storage_writes.clone());
+    }
+
+    pub(crate) fn update_writes(
+        &mut self,
+        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
+        address_to_nonce: &HashMap<BigInt, BigInt>,
+        storage_updates: &HashMap<StorageEntry, BigInt>,
+    ) {
+        self.class_hash_writes.extend(address_to_class_hash.clone());
+        self.nonce_writes.extend(address_to_nonce.clone());
+        self.storage_writes.extend(storage_updates.clone());
+    }
+
+    pub(crate) fn set_initial_values(
+        &mut self,
+        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
+        address_to_nonce: &HashMap<BigInt, BigInt>,
+        storage_updates: &HashMap<StorageEntry, BigInt>,
+    ) -> Result<(), StateError> {
+        if !(self.get_address_to_class_hash().is_empty()
+            && self.get_address_to_nonce().is_empty()
+            && self.get_storage_view().is_empty())
+        {
+            return Err(StateError::StateCacheAlreadyInitialized);
+        }
+        self.update_writes(address_to_class_hash, address_to_nonce, storage_updates);
+        Ok(())
+    }
+
+    pub(crate) fn get_accessed_contract_addresses(&self) -> HashSet<BigInt> {
+        let mut set: HashSet<BigInt> = HashSet::with_capacity(self.class_hash_writes.len());
+        set.extend(self.class_hash_writes.keys().cloned());
+        set.extend(self.nonce_writes.keys().cloned());
+        set.extend(self.storage_writes.keys().map(|x| x.0.clone()));
+        set
+    }
+}
+
 pub(crate) struct CachedState<T: StateReader> {
     block_info: BlockInfo,
     pub(crate) state_reader: T,
@@ -160,92 +245,6 @@ impl<T: StateReader> StateReader for CachedState<T> {
             .clone())
     }
 }
-
-#[derive(Debug, Default, Clone)]
-pub(crate) struct StateCache {
-    // Reader's cached information; initial values, read before any write operation (per cell)
-    class_hash_initial_values: HashMap<BigInt, Vec<u8>>,
-    nonce_initial_values: HashMap<BigInt, BigInt>,
-    storage_initial_values: HashMap<StorageEntry, BigInt>,
-
-    // Writer's cached information.
-    class_hash_writes: HashMap<BigInt, Vec<u8>>,
-    nonce_writes: HashMap<BigInt, BigInt>,
-    storage_writes: HashMap<StorageEntry, BigInt>,
-}
-
-impl StateCache {
-    pub(crate) fn new() -> Self {
-        Self {
-            class_hash_initial_values: HashMap::new(),
-            nonce_initial_values: HashMap::new(),
-            storage_initial_values: HashMap::new(),
-            class_hash_writes: HashMap::new(),
-            nonce_writes: HashMap::new(),
-            storage_writes: HashMap::new(),
-        }
-    }
-    pub(crate) fn get_address_to_class_hash(&self) -> HashMap<BigInt, Vec<u8>> {
-        let mut address_to_class_hash = self.class_hash_initial_values.clone();
-        address_to_class_hash.extend(self.class_hash_writes.clone());
-        address_to_class_hash
-    }
-
-    pub(crate) fn get_address_to_nonce(&self) -> HashMap<BigInt, BigInt> {
-        let mut address_to_nonce = self.nonce_initial_values.clone();
-        address_to_nonce.extend(self.nonce_writes.clone());
-        address_to_nonce
-    }
-
-    pub(crate) fn get_storage_view(&self) -> HashMap<StorageEntry, BigInt> {
-        let mut storage_view = self.storage_initial_values.clone();
-        storage_view.extend(self.storage_writes.clone());
-        storage_view
-    }
-
-    pub(crate) fn update_writes_from_other(&mut self, other: &Self) {
-        self.class_hash_writes
-            .extend(other.class_hash_writes.clone());
-        self.nonce_writes.extend(other.nonce_writes.clone());
-        self.storage_writes.extend(other.storage_writes.clone());
-    }
-
-    pub(crate) fn update_writes(
-        &mut self,
-        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
-        address_to_nonce: &HashMap<BigInt, BigInt>,
-        storage_updates: &HashMap<StorageEntry, BigInt>,
-    ) {
-        self.class_hash_writes.extend(address_to_class_hash.clone());
-        self.nonce_writes.extend(address_to_nonce.clone());
-        self.storage_writes.extend(storage_updates.clone());
-    }
-
-    pub(crate) fn set_initial_values(
-        &mut self,
-        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
-        address_to_nonce: &HashMap<BigInt, BigInt>,
-        storage_updates: &HashMap<StorageEntry, BigInt>,
-    ) -> Result<(), StateError> {
-        if !(self.get_address_to_class_hash().is_empty()
-            && self.get_address_to_nonce().is_empty()
-            && self.get_storage_view().is_empty())
-        {
-            return Err(StateError::StateCacheAlreadyInitialized);
-        }
-        self.update_writes(address_to_class_hash, address_to_nonce, storage_updates);
-        Ok(())
-    }
-
-    pub(crate) fn get_accessed_contract_addresses(&self) -> HashSet<BigInt> {
-        let mut set: HashSet<BigInt> = HashSet::with_capacity(self.class_hash_writes.len());
-        set.extend(self.class_hash_writes.keys().cloned());
-        set.extend(self.nonce_writes.keys().cloned());
-        set.extend(self.storage_writes.keys().map(|x| x.0.clone()));
-        set
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{bigint, state};


### PR DESCRIPTION
* Modify `StateReader` trait
* Implement `StateReader` trait for `CachedState`
* Modify `StateCache` methods + unit tests

Note: The `CachedState` methods are not tested since to create one we need another struct that implements the `StateReader` trait

https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/starknet/business_logic/state/state.py#L167