### PR TITLE
remove refs to bigint

### DIFF
--- a/src/business_logic/execution/execution_errors.rs
+++ b/src/business_logic/execution/execution_errors.rs
@@ -6,7 +6,7 @@ pub enum ExecutionError {
     #[error("Missing field for TxStruct")]
     MissingTxStructField,
     #[error("Expected an int value but get wrong data type")]
-    NotABigIntValue,
+    NotAFeltValue,
     #[error("Expected a relocatable value but get wrong data type")]
     NotARelocatableValue,
     #[error("Error converting from {0} to {1}")]

--- a/src/business_logic/execution/objects.rs
+++ b/src/business_logic/execution/objects.rs
@@ -3,7 +3,6 @@ use cairo_rs::{
     vm::vm_core::VirtualMachine,
 };
 use felt::{Felt, NewFelt};
-use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
 
 use crate::{

--- a/src/business_logic/fact_state/state.rs
+++ b/src/business_logic/fact_state/state.rs
@@ -1,4 +1,4 @@
-use num_bigint::BigInt;
+use felt::Felt;
 use patricia_tree::PatriciaTree;
 use std::{borrow::Borrow, collections::HashMap, hash, ops::Deref, rc::Rc, thread::current};
 
@@ -138,9 +138,9 @@ impl<T> SharedState<T> {
     pub fn apply_updates<S>(
         &self,
         ffc: FactFetchingContext<S>,
-        address_to_class_hash: HashMap<BigInt, Vec<u8>>,
-        address_to_nonce: HashMap<BigInt, BigInt>,
-        storage_updates: HashMap<BigInt, HashMap<[u8; 32], BigInt>>,
+        address_to_class_hash: HashMap<Felt, Vec<u8>>,
+        address_to_nonce: HashMap<Felt, Felt>,
+        storage_updates: HashMap<Felt, HashMap<[u8; 32], Felt>>,
         block_info: BlockInfo,
     ) -> Self
     where

--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -1,9 +1,9 @@
-use num_bigint::BigInt;
 use std::collections::HashMap;
 
-use crate::{
-    bigint, core::errors::state_errors::StateError, services::api::contract_class::ContractClass,
-};
+use felt::Felt;
+use num_traits::Zero;
+
+use crate::{core::errors::state_errors::StateError, services::api::contract_class::ContractClass};
 
 use super::{
     state_api::{State, StateReader},
@@ -93,7 +93,7 @@ impl<T: StateReader + Clone> StateReader for CachedState<T> {
             .ok_or(StateError::MissingContractClassCache)
     }
 
-    fn get_class_hash_at(&mut self, contract_address: &BigInt) -> Result<&Vec<u8>, StateError> {
+    fn get_class_hash_at(&mut self, contract_address: &Felt) -> Result<&Vec<u8>, StateError> {
         if self.cache.get_class_hash(contract_address).is_none() {
             let class_hash = self.state_reader.get_class_hash_at(contract_address)?;
             self.cache
@@ -106,7 +106,7 @@ impl<T: StateReader + Clone> StateReader for CachedState<T> {
             .ok_or_else(|| StateError::NoneClassHash(contract_address.clone()))
     }
 
-    fn get_nonce_at(&mut self, contract_address: &BigInt) -> Result<&BigInt, StateError> {
+    fn get_nonce_at(&mut self, contract_address: &Felt) -> Result<&Felt, StateError> {
         if self.cache.get_nonce(contract_address).is_none() {
             let nonce = self.state_reader.get_nonce_at(contract_address)?;
             self.cache
@@ -118,7 +118,7 @@ impl<T: StateReader + Clone> StateReader for CachedState<T> {
             .ok_or_else(|| StateError::NoneNonce(contract_address.clone()))
     }
 
-    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<&BigInt, StateError> {
+    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<&Felt, StateError> {
         if self.cache.get_storage(storage_entry).is_none() {
             let value = self.state_reader.get_storage_at(storage_entry)?;
             self.cache
@@ -145,10 +145,10 @@ impl<T: StateReader + Clone> State for CachedState<T> {
 
     fn deploy_contract(
         &mut self,
-        contract_address: BigInt,
+        contract_address: Felt,
         class_hash: Vec<u8>,
     ) -> Result<(), StateError> {
-        if contract_address == bigint!(0) {
+        if contract_address == Felt::zero() {
             return Err(StateError::ContractAddressOutOfRangeAddress(
                 contract_address,
             ));
@@ -166,7 +166,7 @@ impl<T: StateReader + Clone> State for CachedState<T> {
         Ok(())
     }
 
-    fn increment_nonce(&mut self, contract_address: &BigInt) -> Result<(), StateError> {
+    fn increment_nonce(&mut self, contract_address: &Felt) -> Result<(), StateError> {
         let new_nonce = self.get_nonce_at(contract_address)? + 1;
         self.cache
             .nonce_writes
@@ -178,7 +178,7 @@ impl<T: StateReader + Clone> State for CachedState<T> {
         self.block_info = block_info;
     }
 
-    fn set_storage_at(&mut self, storage_entry: &StorageEntry, value: BigInt) {
+    fn set_storage_at(&mut self, storage_entry: &StorageEntry, value: Felt) {
         self.cache
             .storage_writes
             .insert(storage_entry.clone(), value);

--- a/src/business_logic/state/state_api.rs
+++ b/src/business_logic/state/state_api.rs
@@ -1,4 +1,4 @@
-use num_bigint::BigInt;
+use felt::Felt;
 
 use crate::{core::errors::state_errors::StateError, services::api::contract_class::ContractClass};
 
@@ -8,11 +8,11 @@ pub(crate) trait StateReader {
     /// Returns the contract class of the given class hash.
     fn get_contract_class(&mut self, class_hash: &[u8]) -> Result<&ContractClass, StateError>;
     /// Returns the class hash of the contract class at the given address.
-    fn get_class_hash_at(&mut self, contract_address: &BigInt) -> Result<&Vec<u8>, StateError>;
+    fn get_class_hash_at(&mut self, contract_address: &Felt) -> Result<&Vec<u8>, StateError>;
     /// Returns the nonce of the given contract instance.
-    fn get_nonce_at(&mut self, contract_address: &BigInt) -> Result<&BigInt, StateError>;
+    fn get_nonce_at(&mut self, contract_address: &Felt) -> Result<&Felt, StateError>;
     /// Returns the storage value under the given key in the given contract instance.
-    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<&BigInt, StateError>;
+    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<&Felt, StateError>;
 }
 
 pub(crate) trait State {
@@ -20,10 +20,10 @@ pub(crate) trait State {
     fn set_contract_class(&mut self, class_hash: &[u8], contract_class: &ContractClass);
     fn deploy_contract(
         &mut self,
-        contract_address: BigInt,
+        contract_address: Felt,
         class_hash: Vec<u8>,
     ) -> Result<(), StateError>;
-    fn increment_nonce(&mut self, contract_address: &BigInt) -> Result<(), StateError>;
+    fn increment_nonce(&mut self, contract_address: &Felt) -> Result<(), StateError>;
     fn update_block_info(&mut self, block_info: BlockInfo);
-    fn set_storage_at(&mut self, storage_entry: &StorageEntry, value: BigInt);
+    fn set_storage_at(&mut self, storage_entry: &StorageEntry, value: Felt);
 }

--- a/src/business_logic/state/state_cache.rs
+++ b/src/business_logic/state/state_cache.rs
@@ -1,28 +1,27 @@
 use std::collections::{HashMap, HashSet};
 
-use num_bigint::BigInt;
-
 use crate::core::errors::state_errors::StateError;
 use crate::services::api::contract_class::ContractClass;
+use felt::Felt;
 
 use super::state_api_objects::BlockInfo;
 
 use super::state_api::StateReader;
 
 /// (contract_address, key)
-pub(crate) type StorageEntry = (BigInt, [u8; 32]);
+pub(crate) type StorageEntry = (Felt, [u8; 32]);
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct StateCache {
     // Reader's cached information; initial values, read before any write operation (per cell)
-    pub(crate) class_hash_initial_values: HashMap<BigInt, Vec<u8>>,
-    pub(crate) nonce_initial_values: HashMap<BigInt, BigInt>,
-    pub(crate) storage_initial_values: HashMap<StorageEntry, BigInt>,
+    pub(crate) class_hash_initial_values: HashMap<Felt, Vec<u8>>,
+    pub(crate) nonce_initial_values: HashMap<Felt, Felt>,
+    pub(crate) storage_initial_values: HashMap<StorageEntry, Felt>,
 
     // Writer's cached information.
-    pub(crate) class_hash_writes: HashMap<BigInt, Vec<u8>>,
-    pub(crate) nonce_writes: HashMap<BigInt, BigInt>,
-    pub(crate) storage_writes: HashMap<StorageEntry, BigInt>,
+    pub(crate) class_hash_writes: HashMap<Felt, Vec<u8>>,
+    pub(crate) nonce_writes: HashMap<Felt, Felt>,
+    pub(crate) storage_writes: HashMap<StorageEntry, Felt>,
 }
 
 impl StateCache {
@@ -37,21 +36,21 @@ impl StateCache {
         }
     }
 
-    pub(crate) fn get_class_hash(&self, contract_address: &BigInt) -> Option<&Vec<u8>> {
+    pub(crate) fn get_class_hash(&self, contract_address: &Felt) -> Option<&Vec<u8>> {
         if self.class_hash_writes.contains_key(contract_address) {
             return self.class_hash_writes.get(contract_address);
         }
         self.class_hash_initial_values.get(contract_address)
     }
 
-    pub(crate) fn get_nonce(&self, contract_address: &BigInt) -> Option<&BigInt> {
+    pub(crate) fn get_nonce(&self, contract_address: &Felt) -> Option<&Felt> {
         if self.nonce_writes.contains_key(contract_address) {
             return self.nonce_writes.get(contract_address);
         }
         self.nonce_initial_values.get(contract_address)
     }
 
-    pub(crate) fn get_storage(&self, storage_entry: &StorageEntry) -> Option<&BigInt> {
+    pub(crate) fn get_storage(&self, storage_entry: &StorageEntry) -> Option<&Felt> {
         if self.storage_writes.contains_key(storage_entry) {
             return self.storage_writes.get(storage_entry);
         }
@@ -67,9 +66,9 @@ impl StateCache {
 
     pub(crate) fn update_writes(
         &mut self,
-        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
-        address_to_nonce: &HashMap<BigInt, BigInt>,
-        storage_updates: &HashMap<StorageEntry, BigInt>,
+        address_to_class_hash: &HashMap<Felt, Vec<u8>>,
+        address_to_nonce: &HashMap<Felt, Felt>,
+        storage_updates: &HashMap<StorageEntry, Felt>,
     ) {
         self.class_hash_writes.extend(address_to_class_hash.clone());
         self.nonce_writes.extend(address_to_nonce.clone());
@@ -78,9 +77,9 @@ impl StateCache {
 
     pub(crate) fn set_initial_values(
         &mut self,
-        address_to_class_hash: &HashMap<BigInt, Vec<u8>>,
-        address_to_nonce: &HashMap<BigInt, BigInt>,
-        storage_updates: &HashMap<StorageEntry, BigInt>,
+        address_to_class_hash: &HashMap<Felt, Vec<u8>>,
+        address_to_nonce: &HashMap<Felt, Felt>,
+        storage_updates: &HashMap<StorageEntry, Felt>,
     ) -> Result<(), StateError> {
         if !(self.class_hash_initial_values.is_empty()
             && self.class_hash_writes.is_empty()
@@ -95,8 +94,8 @@ impl StateCache {
         Ok(())
     }
 
-    pub(crate) fn get_accessed_contract_addresses(&self) -> HashSet<BigInt> {
-        let mut set: HashSet<BigInt> = HashSet::with_capacity(self.class_hash_writes.len());
+    pub(crate) fn get_accessed_contract_addresses(&self) -> HashSet<Felt> {
+        let mut set: HashSet<Felt> = HashSet::with_capacity(self.class_hash_writes.len());
         set.extend(self.class_hash_writes.keys().cloned());
         set.extend(self.nonce_writes.keys().cloned());
         set.extend(self.storage_writes.keys().map(|x| x.0.clone()));
@@ -106,16 +105,16 @@ impl StateCache {
 
 #[cfg(test)]
 mod tests {
-    use crate::{bigint, business_logic::state};
+    use crate::business_logic::state;
 
     use super::*;
 
     #[test]
     fn state_chache_set_initial_values() {
         let mut state_cache = StateCache::new();
-        let address_to_class_hash = HashMap::from([(bigint!(10), b"pedersen".to_vec())]);
-        let address_to_nonce = HashMap::from([(bigint!(9), bigint!(12))]);
-        let storage_updates = HashMap::from([((bigint!(20), [1; 32]), bigint!(18))]);
+        let address_to_class_hash = HashMap::from([(10.into(), b"pedersen".to_vec())]);
+        let address_to_nonce = HashMap::from([(9.into(), 12.into())]);
+        let storage_updates = HashMap::from([((20.into(), [1; 32]), 18.into())]);
         assert!(state_cache
             .set_initial_values(&address_to_class_hash, &address_to_nonce, &storage_updates)
             .is_ok());
@@ -126,24 +125,24 @@ mod tests {
 
         assert_eq!(
             state_cache.get_accessed_contract_addresses(),
-            HashSet::from([bigint!(10), bigint!(9), bigint!(20)])
+            HashSet::from([10.into(), 9.into(), 20.into()])
         );
     }
 
     #[test]
     fn state_chache_update_writes_from_other() {
         let mut state_cache = StateCache::new();
-        let address_to_class_hash = HashMap::from([(bigint!(10), b"pedersen".to_vec())]);
-        let address_to_nonce = HashMap::from([(bigint!(9), bigint!(12))]);
-        let storage_updates = HashMap::from([((bigint!(20), [1; 32]), bigint!(18))]);
+        let address_to_class_hash = HashMap::from([(10.into(), b"pedersen".to_vec())]);
+        let address_to_nonce = HashMap::from([(9.into(), 12.into())]);
+        let storage_updates = HashMap::from([((20.into(), [1; 32]), 18.into())]);
         state_cache
             .set_initial_values(&address_to_class_hash, &address_to_nonce, &storage_updates)
             .expect("Error setting StateCache values");
 
         let mut other_state_cache = StateCache::new();
-        let other_address_to_class_hash = HashMap::from([(bigint!(10), b"sha-3".to_vec())]);
-        let other_address_to_nonce = HashMap::from([(bigint!(401), bigint!(100))]);
-        let other_storage_updates = HashMap::from([((bigint!(4002), [2; 32]), bigint!(101))]);
+        let other_address_to_class_hash = HashMap::from([(10.into(), b"sha-3".to_vec())]);
+        let other_address_to_nonce = HashMap::from([(401.into(), 100.into())]);
+        let other_storage_updates = HashMap::from([((4002.into(), [2; 32]), 101.into())]);
         other_state_cache
             .set_initial_values(
                 &other_address_to_class_hash,
@@ -155,18 +154,18 @@ mod tests {
         state_cache.update_writes_from_other(&other_state_cache);
 
         assert_eq!(
-            state_cache.get_class_hash(&bigint!(10)),
+            state_cache.get_class_hash(&10.into()),
             Some(&b"sha-3".to_vec())
         );
         assert_eq!(
             state_cache.nonce_writes,
-            HashMap::from([(bigint!(9), bigint!(12)), (bigint!(401), bigint!(100))])
+            HashMap::from([(9.into(), 12.into()), (401.into(), 100.into())])
         );
         assert_eq!(
             state_cache.storage_writes,
             HashMap::from([
-                ((bigint!(20), [1; 32]), bigint!(18)),
-                ((bigint!(4002), [2; 32]), bigint!(101))
+                ((20.into(), [1; 32]), 18.into()),
+                ((4002.into(), [2; 32]), 101.into())
             ])
         );
     }

--- a/src/core/block_hash/starknet_block_hash.rs
+++ b/src/core/block_hash/starknet_block_hash.rs
@@ -6,7 +6,6 @@ use crate::{
     hash_utils::compute_hash_on_elements,
 };
 use felt::{Felt, FeltOps};
-use num_bigint::{BigInt, Sign};
 use starknet_crypto::{pedersen_hash, FieldElement};
 use std::iter::zip;
 

--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -1,4 +1,4 @@
-use num_bigint::BigInt;
+use felt::Felt;
 use thiserror::Error;
 
 use crate::business_logic::state::state_cache::StorageEntry;
@@ -16,13 +16,13 @@ pub enum StateError {
     #[error("Cache already initialized")]
     StateCacheAlreadyInitialized,
     #[error("No class hash assigned for contact address: {0}")]
-    NoneClassHash(BigInt),
+    NoneClassHash(Felt),
     #[error("No nonce assigned for contact address: {0}")]
-    NoneNonce(BigInt),
+    NoneNonce(Felt),
     #[error("No storage value assigned for entry: {0:?}")]
     NoneStorage(StorageEntry),
     #[error("Cannot deploy contract at address: {0}")]
-    ContractAddressOutOfRangeAddress(BigInt),
+    ContractAddressOutOfRangeAddress(Felt),
     #[error("Requested contract address {0} is unavailable for deployment")]
-    ContractAddressUnavailable(BigInt),
+    ContractAddressUnavailable(Felt),
 }

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -310,7 +310,6 @@ impl Default for BusinessLogicSyscallHandler {
 
 #[cfg(test)]
 mod tests {
-    use crate::bigint;
     use crate::business_logic::execution::objects::{
         OrderedEvent, OrderedL2ToL1Message, TransactionExecutionContext,
     };
@@ -332,7 +331,6 @@ mod tests {
     use cairo_rs::vm::errors::vm_errors::VirtualMachineError;
     use cairo_rs::vm::vm_core::VirtualMachine;
     use felt::Felt;
-    use num_bigint::{BigInt, Sign};
     use std::any::Any;
     use std::borrow::Cow;
     use std::collections::HashMap;

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -380,12 +380,10 @@ mod tests {
     use crate::utils::{get_integer, test_utils::*};
     use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
     use cairo_rs::vm::vm_core::VirtualMachine;
-    use num_bigint::{BigInt, Sign};
     use std::any::Any;
     use std::collections::{HashMap, VecDeque};
 
     use super::{CallInfo, OsSyscallHandler, TransactionExecutionInfo};
-    use crate::bigint;
     use crate::core::syscalls::hint_code::GET_BLOCK_NUMBER;
     use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use cairo_rs::hint_processor::hint_processor_definition::HintProcessor;

--- a/src/core/syscalls/syscall_response.rs
+++ b/src/core/syscalls/syscall_response.rs
@@ -211,7 +211,6 @@ mod tests {
         },
         utils::test_utils::vm,
     };
-    use num_bigint::{BigInt, Sign};
 
     #[test]
     fn write_get_caller_address_response() {

--- a/src/definitions/general_config.rs
+++ b/src/definitions/general_config.rs
@@ -1,5 +1,4 @@
 use felt::{Felt, FeltOps};
-use num_bigint::BigInt;
 use num_traits::{Num, Zero};
 
 #[allow(unused)]

--- a/src/services/api/contract_class.rs
+++ b/src/services/api/contract_class.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use cairo_rs::types::program::Program;
-use num_bigint::BigInt;
+use felt::Felt;
 
 use crate::public::abi::AbiType;
 
@@ -17,8 +17,8 @@ pub(crate) enum EntryPointType {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ContractEntryPoint {
-    pub(crate) selector: BigInt,
-    pub(crate) offset: BigInt,
+    pub(crate) selector: Felt,
+    pub(crate) offset: Felt,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
I can't remove the bigint dependency until the felt_str! macro is adapted to avoid using that crate directly