### PR TITLE
Add tests for _call_contract_and_write_response

### DIFF
--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -120,18 +120,6 @@ impl SyscallHandler for BusinessLogicSyscallHandler {
         Ok(segment_start)
     }
 
-    fn _call_contract_and_write_response(
-        &mut self,
-        syscall_name: &str,
-        vm: &mut VirtualMachine,
-        syscall_ptr: Relocatable,
-    ) -> Result<(), SyscallHandlerError> {
-        let response_data = self._call_contract(syscall_name, vm, syscall_ptr)?;
-        // TODO: Should we build a response struct to pass to _write_syscall_response?
-        // self._write_syscall_response(response_data, vm, syscall_ptr);
-        todo!()
-    }
-
     fn _deploy(
         &mut self,
         vm: &VirtualMachine,

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -368,6 +368,7 @@ mod tests {
     use crate::business_logic::state::state_api_objects::BlockInfo;
     use crate::core::errors::syscall_handler_errors::SyscallHandlerError;
     use crate::core::syscalls::syscall_handler::{SyscallHandler, SyscallHintProcessor};
+    use crate::core::syscalls::syscall_request::CallContractRequest;
     use crate::utils::{get_integer, test_utils::*};
     use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
     use cairo_rs::vm::errors::memory_errors::MemoryError;
@@ -886,6 +887,15 @@ mod tests {
         assert_eq!(
             handler._call_contract_and_write_response("call_contract", &mut vm, syscall_ptr),
             Ok(())
+        );
+
+        let addr = Relocatable::from(&(syscall_ptr + 5));
+        assert_eq!(
+            vm.get_relocatable(&addr),
+            Ok(Relocatable {
+                segment_index: -1,
+                offset: 0
+            })
         )
     }
 }

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -890,16 +890,10 @@ mod tests {
         );
 
         let addr_0 = Relocatable::from(&(syscall_ptr + 5));
-        assert_eq!(
-            vm.get_relocatable(&addr_0),
-            Ok(Relocatable {
-                segment_index: -1,
-                offset: 0
-            })
-        );
+        assert_eq!(get_integer(&vm, &addr_0), Ok(1));
         let addr_1 = Relocatable::from(&(syscall_ptr + 6));
         assert_eq!(
-            get_relocatable(&vm, &addr_0),
+            get_relocatable(&vm, &addr_1),
             Ok(Relocatable {
                 segment_index: -1,
                 offset: 0

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -49,7 +49,7 @@ impl OsSingleStarknetStorage {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct OsSyscallHandler {
     tx_execution_info_iterator: VecDeque<TransactionExecutionInfo>,
     call_iterator: VecDeque<CallInfo>,
@@ -75,23 +75,6 @@ pub(crate) struct OsSyscallHandler {
     // The TransactionExecutionInfo for the transaction currently being executed.
     tx_execution_info: Option<TransactionExecutionInfo>,
     block_info: BlockInfo,
-}
-
-impl Default for OsSyscallHandler {
-    fn default() -> Self {
-        Self {
-            tx_execution_info_iterator: VecDeque::new(),
-            call_iterator: VecDeque::new(),
-            call_stack: VecDeque::new(),
-            deployed_contracts_iterator: VecDeque::new(),
-            retdata_iterator: VecDeque::new(),
-            execute_code_read_iterator: VecDeque::new(),
-            starknet_storage_by_address: HashMap::new(),
-            tx_info_ptr: None,
-            tx_execution_info: None,
-            block_info: BlockInfo::default(),
-        }
-    }
 }
 
 impl SyscallHandler for OsSyscallHandler {

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -369,7 +369,7 @@ mod tests {
     use crate::core::errors::syscall_handler_errors::SyscallHandlerError;
     use crate::core::syscalls::syscall_handler::{SyscallHandler, SyscallHintProcessor};
     use crate::core::syscalls::syscall_request::CallContractRequest;
-    use crate::utils::{get_integer, test_utils::*};
+    use crate::utils::{get_integer, get_relocatable, test_utils::*};
     use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
     use cairo_rs::vm::errors::memory_errors::MemoryError;
     use cairo_rs::vm::errors::vm_errors::VirtualMachineError;
@@ -889,13 +889,21 @@ mod tests {
             Ok(())
         );
 
-        let addr = Relocatable::from(&(syscall_ptr + 5));
+        let addr_0 = Relocatable::from(&(syscall_ptr + 5));
         assert_eq!(
-            vm.get_relocatable(&addr),
+            vm.get_relocatable(&addr_0),
             Ok(Relocatable {
                 segment_index: -1,
                 offset: 0
             })
-        )
+        );
+        let addr_1 = Relocatable::from(&(syscall_ptr + 6));
+        assert_eq!(
+            get_relocatable(&vm, &addr_0),
+            Ok(Relocatable {
+                segment_index: -1,
+                offset: 0
+            })
+        );
     }
 }

--- a/src/core/syscalls/syscall_response.rs
+++ b/src/core/syscalls/syscall_response.rs
@@ -119,13 +119,13 @@ impl WriteSyscallResponse for CallContractResponse {
         vm: &mut VirtualMachine,
         syscall_ptr: Relocatable,
     ) -> Result<(), SyscallHandlerError> {
-        vm.insert_value(
-            &(syscall_ptr + CallContractRequest::count_fields()),
-            &self.retdata,
-        )?;
         vm.insert_value::<Felt>(
-            &(syscall_ptr + CallContractRequest::count_fields() + 1),
+            &(syscall_ptr + CallContractRequest::count_fields()),
             self.retdata_size.into(),
+        )?;
+        vm.insert_value(
+            &(syscall_ptr + CallContractRequest::count_fields() + 1),
+            &self.retdata,
         )?;
         Ok(())
     }

--- a/src/core/syscalls/syscall_response.rs
+++ b/src/core/syscalls/syscall_response.rs
@@ -123,6 +123,10 @@ impl WriteSyscallResponse for CallContractResponse {
             &(syscall_ptr + CallContractRequest::count_fields()),
             &self.retdata,
         )?;
+        vm.insert_value::<Felt>(
+            &(syscall_ptr + CallContractRequest::count_fields() + 1),
+            self.retdata_size.into(),
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR removes:
 - Removes unused implementations, and use the default one.
 - Adds a Default impl for OsSyscallHandler struct, and replace the `new` method calls in tests.
 - Adds tests for `OsSyscallHandler::_call_contract_and_write_response`.