### PR TITLE
Implement StateReader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,13 +130,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
-name = "cairo-rs"
+name = "cairo-felt"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs#9bf61ea567b4ee825257672c206473e4c79d301f"
+source = "git+https://github.com/lambdaclass/cairo-rs#359a350e8ac9e46ebe29971241e208462f9d4ef3"
+dependencies = [
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "cairo-vm"
+version = "0.1.1"
+source = "git+https://github.com/lambdaclass/cairo-rs#359a350e8ac9e46ebe29971241e208462f9d4ef3"
 dependencies = [
  "bincode",
+ "cairo-felt",
  "clap",
- "felt",
  "generic-array",
  "hex",
  "keccak",
@@ -299,18 +311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "felt"
-version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs#9bf61ea567b4ee825257672c206473e4c79d301f"
-dependencies = [
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,9 +433,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d1c67deb83e6b75fa4fe3309e09cfeade12e7721d95322af500d3814ea60c9"
+checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
 dependencies = [
  "cc",
  "libc",
@@ -458,9 +458,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2374e2999959a7b583e1811a1ddbf1d3a4b9496eceb9746f1192a59d871eca"
+checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -479,9 +479,9 @@ checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -539,7 +539,7 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs#9bf61ea567b4ee825257672c206473e4c79d301f"
+source = "git+https://github.com/lambdaclass/cairo-rs#359a350e8ac9e46ebe29971241e208462f9d4ef3"
 dependencies = [
  "nom",
 ]
@@ -551,15 +551,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
-name = "patricia-tree"
-version = "0.1.0"
-source = "git+https://github.com/lambdaclass/patricia-tree#284cfdfcfc43639845eb0d565b725144cbe65b6d"
-
-[[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -833,13 +828,13 @@ dependencies = [
 name = "starknet-rs"
 version = "0.1.0"
 dependencies = [
- "cairo-rs",
- "felt",
+ "cairo-felt",
+ "cairo-vm",
  "num-bigint",
  "num-integer",
  "num-traits",
- "patricia-tree",
  "rusty-hook",
+ "serde",
  "serde_json",
  "starknet-crypto",
  "thiserror",
@@ -882,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs" }
-felt = { git = "https://github.com/lambdaclass/cairo-rs/" }
-patricia-tree = { git = "https://github.com/lambdaclass/patricia-tree" }    
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs", package = "cairo-vm" }
+felt = { git = "https://github.com/lambdaclass/cairo-rs", package = "cairo-felt" }
 num-bigint = { version = "0.4", features = ["serde"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 thiserror = { version = "1.0.32" }
 num-traits = "0.2.15"
 num-integer = "0.1.45"
 starknet-crypto = "0.2.0"
+serde = { version = "1.0.152", features = ["derive"] }
 
 [dev-dependencies.rusty-hook]
 version = "0.11"

--- a/src/business_logic/fact_state/contract_state.rs
+++ b/src/business_logic/fact_state/contract_state.rs
@@ -23,7 +23,7 @@ impl ContractState {
     }
 
     fn initialized(&self) -> bool {
-        !(self.contract_hash == UNINITIALIZED_CLASS_HASH)
+        self.contract_hash != UNINITIALIZED_CLASS_HASH
     }
 
     fn is_empty(&self) -> bool {

--- a/src/business_logic/fact_state/contract_state.rs
+++ b/src/business_logic/fact_state/contract_state.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::business_logic::state::cached_state::UNINITIALIZED_CLASS_HASH;
 
-#[derive(Deserialize, Serialize, PartialEq, Debug)]
-pub(crate) struct ContractState {
-    contract_hash: Vec<u8>,
-    nonce: Felt,
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct ContractState {
+    pub(crate) contract_hash: Vec<u8>,
+    pub(crate) nonce: Felt,
 }
 
 impl ContractState {

--- a/src/business_logic/fact_state/contract_state.rs
+++ b/src/business_logic/fact_state/contract_state.rs
@@ -1,14 +1,16 @@
 use felt::Felt;
+use serde::{Deserialize, Serialize};
 
 use crate::business_logic::state::cached_state::UNINITIALIZED_CLASS_HASH;
 
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub(crate) struct ContractState {
     contract_hash: Vec<u8>,
     nonce: Felt,
 }
 
 impl ContractState {
-    fn create(contract_hash: Vec<u8>, nonce: Felt) -> Self {
+    pub(crate) fn create(contract_hash: Vec<u8>, nonce: Felt) -> Self {
         Self {
             contract_hash,
             nonce,

--- a/src/business_logic/fact_state/contract_state.rs
+++ b/src/business_logic/fact_state/contract_state.rs
@@ -1,0 +1,32 @@
+use felt::Felt;
+
+use crate::business_logic::state::cached_state::UNINITIALIZED_CLASS_HASH;
+
+pub(crate) struct ContractState {
+    contract_hash: Vec<u8>,
+    nonce: Felt,
+}
+
+impl ContractState {
+    fn create(contract_hash: Vec<u8>, nonce: Felt) -> Self {
+        Self {
+            contract_hash,
+            nonce,
+        }
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self {
+            contract_hash: UNINITIALIZED_CLASS_HASH.to_vec(),
+            nonce: 0.into(),
+        }
+    }
+
+    fn initialized(&self) -> bool {
+        !(self.contract_hash == UNINITIALIZED_CLASS_HASH)
+    }
+
+    fn is_empty(&self) -> bool {
+        !self.initialized()
+    }
+}

--- a/src/business_logic/fact_state/mod.rs
+++ b/src/business_logic/fact_state/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod contract_state;
 pub mod state;
+pub(crate) mod state_reader;

--- a/src/business_logic/fact_state/mod.rs
+++ b/src/business_logic/fact_state/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod contract_state;
 pub mod state;

--- a/src/business_logic/fact_state/state.rs
+++ b/src/business_logic/fact_state/state.rs
@@ -1,5 +1,4 @@
 use felt::Felt;
-use patricia_tree::PatriciaTree;
 use std::{borrow::Borrow, collections::HashMap, hash, ops::Deref, rc::Rc, thread::current};
 
 use crate::{
@@ -13,6 +12,8 @@ use crate::{
     starknet_storage::storage::{FactFetchingContext, Storage},
     utils::to_state_diff_storage_mapping,
 };
+
+use super::contract_state::ContractState;
 
 #[derive(Debug, Default)]
 pub struct ExecutionResourcesManager(HashMap<String, u64>);
@@ -87,12 +88,12 @@ impl<T: StateReader + Clone> CarriedState<T> {
 //      SHARED STATE
 // ----------------------
 
-pub(crate) struct SharedState<T> {
-    contract_states: PatriciaTree<T>,
+pub(crate) struct SharedState {
+    contract_states: HashMap<Felt, ContractState>,
     block_info: BlockInfo,
 }
 
-impl<T> SharedState<T> {
+impl SharedState {
     pub fn empty<S>(ffc: FactFetchingContext<S>, general_config: StarknetGeneralConfig) -> Self
     where
         S: Storage,

--- a/src/business_logic/fact_state/state_reader.rs
+++ b/src/business_logic/fact_state/state_reader.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use felt::Felt;
+
+use crate::{core::errors::state_errors::StateError, starknet_storage::storage::Storage};
+
+use super::contract_state::ContractState;
+
+pub(crate) struct StateReader<S1: Storage, S2: Storage> {
+    global_state_root: HashMap<Felt, [u8; 32]>,
+    ffc: S1,
+    contract_states: HashMap<Felt, ContractState>,
+    contract_class_storage: S2,
+}
+
+impl<S1: Storage, S2: Storage> StateReader<S1, S2> {
+    pub(crate) fn new(
+        global_state_root: HashMap<Felt, [u8; 32]>,
+        ffc: S1,
+        contract_class_storage: S2,
+    ) -> Self {
+        Self {
+            global_state_root,
+            ffc,
+            contract_states: HashMap::new(),
+            contract_class_storage,
+        }
+    }
+
+    pub(crate) fn get_class_hash_at(
+        &self,
+        contract_address: &Felt,
+    ) -> Result<&ContractState, StateError> {
+        if !self.contract_states.contains_key(contract_address) {
+            let key = self.global_state_root.get(contract_address).unwrap();
+            let result = self.ffc.get_value_or_fail(key).unwrap();
+            todo!()
+        }
+
+        Ok(self.contract_states.get(contract_address).unwrap())
+    }
+}

--- a/src/business_logic/fact_state/state_reader.rs
+++ b/src/business_logic/fact_state/state_reader.rs
@@ -60,3 +60,45 @@ impl<S1: Storage, S2: Storage> StateReader<S1, S2> {
         Ok(&self.get_contract_state(contract_address)?.nonce)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use felt::NewFelt;
+
+    use crate::starknet_storage::dict_storage::DictStorage;
+
+    use super::*;
+
+    #[test]
+    fn get_contract_state_test() {
+        let mut state_reader =
+            StateReader::new(HashMap::new(), DictStorage::new(), DictStorage::new());
+
+        let contract_address = Felt::new(32123);
+        let contract_state = ContractState::create(vec![1, 2, 3], Felt::new(109));
+
+        state_reader
+            .global_state_root
+            .insert(contract_address.clone(), [0; 32]);
+        state_reader
+            .ffc
+            .set_contract_state(&[0; 32], &contract_state);
+
+        assert_eq!(
+            state_reader.get_contract_state(&contract_address),
+            Ok(&contract_state)
+        );
+        assert_eq!(
+            state_reader.get_class_hash_at(&contract_address),
+            Ok(&contract_state.contract_hash)
+        );
+        assert_eq!(
+            state_reader.get_nonce_at(&contract_address),
+            Ok(&contract_state.nonce)
+        );
+        assert_eq!(
+            state_reader.contract_states,
+            HashMap::from([(contract_address, contract_state)])
+        );
+    }
+}

--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -13,7 +13,7 @@ use super::{
 
 pub(crate) type ContractClassCache = HashMap<Vec<u8>, ContractClass>;
 
-const UNINITIALIZED_CLASS_HASH: [u8; 32] = [b'0'; 32];
+pub(crate) const UNINITIALIZED_CLASS_HASH: [u8; 32] = [b'0'; 32];
 
 #[derive(Debug, Clone)]
 pub(crate) struct CachedState<T: StateReader + Clone> {

--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -1,7 +1,10 @@
 use felt::Felt;
 use thiserror::Error;
 
-use crate::business_logic::state::state_cache::StorageEntry;
+use crate::{
+    business_logic::{fact_state::contract_state::ContractState, state::state_cache::StorageEntry},
+    starknet_storage::errors::storage_errors::StorageError,
+};
 
 #[derive(Debug, PartialEq, Error)]
 pub enum StateError {
@@ -15,6 +18,8 @@ pub enum StateError {
     ParentCarriedStateIsNone,
     #[error("Cache already initialized")]
     StateCacheAlreadyInitialized,
+    #[error("No contract state assigned for contact address: {0:?}")]
+    NoneContractState(Felt),
     #[error("No class hash assigned for contact address: {0}")]
     NoneClassHash(Felt),
     #[error("No nonce assigned for contact address: {0}")]
@@ -25,4 +30,6 @@ pub enum StateError {
     ContractAddressOutOfRangeAddress(Felt),
     #[error("Requested contract address {0} is unavailable for deployment")]
     ContractAddressUnavailable(Felt),
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod hash_utils;
 pub mod public;
 pub mod services;
 pub mod starknet_storage;
+pub mod starkware_utils;
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,4 @@ pub mod hash_utils;
 pub mod public;
 pub mod services;
 pub mod starknet_storage;
-pub mod starkware_utils;
 pub mod utils;

--- a/src/starknet_storage/errors/storage_errors.rs
+++ b/src/starknet_storage/errors/storage_errors.rs
@@ -10,4 +10,12 @@ pub enum StorageError {
     IncorrectUtf8Enconding,
     #[error("Attempt to remove missing key")]
     RemoveMissingKey,
+    #[error("Serde error: {0}")]
+    SerdeError(String),
+}
+
+impl From<serde_json::Error> for StorageError {
+    fn from(error: serde_json::Error) -> Self {
+        StorageError::SerdeError(error.to_string())
+    }
 }

--- a/src/starknet_storage/storage.rs
+++ b/src/starknet_storage/storage.rs
@@ -1,4 +1,7 @@
-use super::errors::storage_errors::StorageError;
+use super::{
+    dict_storage::{Prefix, StorageKey},
+    errors::storage_errors::StorageError,
+};
 use std::str;
 
 /* -----------------------------------------------------------------------------------
@@ -28,21 +31,23 @@ use std::str;
 //* ------------------
 
 pub(crate) trait Storage {
-    fn set_value(&mut self, key: &[u8; 32], value: Vec<u8>) -> Result<(), StorageError>;
-    fn get_value(&self, key: &[u8; 32]) -> Option<Vec<u8>>;
-    fn delete_value(&mut self, key: &[u8; 32]) -> Result<Vec<u8>, StorageError>;
+    fn set_value(&mut self, key: &StorageKey, value: Vec<u8>) -> Result<(), StorageError>;
+    fn get_value(&self, key: &StorageKey) -> Option<Vec<u8>>;
+    fn delete_value(&mut self, key: &StorageKey) -> Result<Vec<u8>, StorageError>;
 
-    fn get_value_or_fail(&self, key: &[u8; 32]) -> Result<Vec<u8>, StorageError> {
+    fn get_value_or_fail(&self, key: &StorageKey) -> Result<Vec<u8>, StorageError> {
         self.get_value(key).ok_or(StorageError::ErrorFetchingData)
     }
 
     fn set_int(&mut self, key: &[u8; 32], value: i32) -> Result<(), StorageError> {
         let val = value.to_ne_bytes().to_vec();
-        self.set_value(key, val)
+        self.set_value(&(Prefix::Int, *key), val)
     }
 
     fn get_int(&self, key: &[u8; 32]) -> Result<i32, StorageError> {
-        let value = self.get_value(key).ok_or(StorageError::ErrorFetchingData)?;
+        let value = self
+            .get_value(&(Prefix::Int, *key))
+            .ok_or(StorageError::ErrorFetchingData)?;
         let slice: [u8; 4] = value
             .try_into()
             .map_err(|_| StorageError::IncorrectDataSize)?;
@@ -50,7 +55,7 @@ pub(crate) trait Storage {
     }
 
     fn get_int_or_default(&self, key: &[u8; 32], default: i32) -> Result<i32, StorageError> {
-        match self.get_value(key) {
+        match self.get_value(&(Prefix::Int, *key)) {
             Some(val) => {
                 let slice: [u8; 4] = val
                     .try_into()
@@ -62,7 +67,7 @@ pub(crate) trait Storage {
     }
 
     fn get_int_or_fail(&self, key: &[u8; 32]) -> Result<i32, StorageError> {
-        let val = self.get_value_or_fail(key)?;
+        let val = self.get_value_or_fail(&(Prefix::Int, *key))?;
         let slice: [u8; 4] = val
             .try_into()
             .map_err(|_| StorageError::IncorrectDataSize)?;
@@ -71,11 +76,13 @@ pub(crate) trait Storage {
 
     fn set_float(&mut self, key: &[u8; 32], value: f64) -> Result<(), StorageError> {
         let val = value.to_bits().to_be_bytes().to_vec();
-        self.set_value(key, val)
+        self.set_value(&(Prefix::Float, *key), val)
     }
 
     fn get_float(&self, key: &[u8; 32]) -> Result<f64, StorageError> {
-        let val = self.get_value(key).ok_or(StorageError::ErrorFetchingData)?;
+        let val = self
+            .get_value(&(Prefix::Float, *key))
+            .ok_or(StorageError::ErrorFetchingData)?;
         let float_bytes: [u8; 8] = val
             .try_into()
             .map_err(|_| StorageError::IncorrectDataSize)?;
@@ -85,11 +92,13 @@ pub(crate) trait Storage {
 
     fn set_str(&mut self, key: &[u8; 32], value: &str) -> Result<(), StorageError> {
         let val = value.as_bytes().to_vec();
-        self.set_value(key, val)
+        self.set_value(&(Prefix::Str, *key), val)
     }
 
     fn get_str(&self, key: &[u8; 32]) -> Result<String, StorageError> {
-        let val = self.get_value(key).ok_or(StorageError::ErrorFetchingData)?;
+        let val = self
+            .get_value(&(Prefix::Str, *key))
+            .ok_or(StorageError::ErrorFetchingData)?;
         let str = str::from_utf8(&val[..]).map_err(|_| StorageError::IncorrectUtf8Enconding)?;
         Ok(String::from(str))
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -149,7 +149,7 @@ pub mod test_utils {
     macro_rules! vm {
         () => {{
             use felt::{Felt, NewFelt};
-            VirtualMachine::new(false, Vec::new())
+            VirtualMachine::new(false)
         }};
 
         ($use_trace:expr) => {{


### PR DESCRIPTION
* Modify Storage:
  * Keys now have type:  `type Prefix + key`
  * Add set_contract_state and get_contract_state methods
* Create StateReader with the following implementations:
  * get_contract_state
  * get_class_hash_at
  * get_nonce_at
[See Python implementation](https://github.com/starkware-libs/cairo-lang/blob/de741b92657f245a50caab99cfaef093152fd8be/src/starkware/starknet/business_logic/fact_state/patricia_state.py#L18-L19)
* Naive implementation of ContractState struct

StateReader remaining implementations(will be done in another PR): 
  [-] get_contract_class
  [-] get_storage_at
