### PR TITLE
Implementation of InternalState

### DIFF
--- a/src/business_logic/execution/execution_errors.rs
+++ b/src/business_logic/execution/execution_errors.rs
@@ -1,3 +1,5 @@
+use std::error;
+
 use thiserror::Error;
 
 use crate::core::errors;
@@ -11,4 +13,8 @@ pub enum ExecutionError {
     NotARelocatableValue,
     #[error("Error converting from {0} to {1}")]
     ErrorInDataConversion(String, String),
+    #[error("Unexpected holes in the event order")]
+    UnexpectedHolesInEventOrder,
+    #[error("Unexpected holes in the L2-to-L1 message order.")]
+    UnexpectedHolesL2toL1Messages,
 }

--- a/src/business_logic/execution/objects.rs
+++ b/src/business_logic/execution/objects.rs
@@ -575,7 +575,7 @@ mod tests {
         child2.internal_calls = [child5.clone(), child6.clone()].to_vec();
         call_root.internal_calls = [child1.clone(), child2.clone()].to_vec();
 
-        // DFS recursible stores from the root to the leftmost child,
+        // DFS recursibly stores from the root to the leftmost child,
         // then goes to the right child and repeats the procedure.
         // expected result of DFS (pre-order) = [call_root, child1, child3, child4, child2, child5, child6]
 

--- a/src/business_logic/execution/objects.rs
+++ b/src/business_logic/execution/objects.rs
@@ -55,7 +55,7 @@ impl CallInfo {
     ///Yields the contract calls in DFS (preorder).
     pub fn gen_call_topology(&self) -> Vec<CallInfo> {
         let mut calls = Vec::new();
-        if self.internal_calls.len() == 0 {
+        if self.internal_calls.is_empty() {
             calls.push(self.clone())
         } else {
             calls.push(self.clone());
@@ -82,9 +82,7 @@ impl CallInfo {
             }
         }
 
-        let are_all_some = starknet_events
-            .iter()
-            .fold(true, |acc, e| acc && e.is_some());
+        let are_all_some = starknet_events.iter().all(|e| e.is_some());
 
         if !are_all_some {
             return Err(ExecutionError::UnexpectedHolesInEventOrder);
@@ -112,9 +110,7 @@ impl CallInfo {
             }
         }
 
-        let are_all_some = starknet_events
-            .iter()
-            .fold(true, |acc, e| acc && e.is_some());
+        let are_all_some = starknet_events.iter().all(|e| e.is_some());
 
         if !are_all_some {
             return Err(ExecutionError::UnexpectedHolesL2toL1Messages);
@@ -176,7 +172,7 @@ impl Default for CallInfo {
 //  Events Structures
 // -------------------------
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct OrderedEvent {
     order: u64,
     keys: Vec<Felt>,
@@ -186,16 +182,6 @@ pub struct OrderedEvent {
 impl OrderedEvent {
     pub fn new(order: u64, keys: Vec<Felt>, data: Vec<Felt>) -> Self {
         OrderedEvent { order, keys, data }
-    }
-}
-
-impl Default for OrderedEvent {
-    fn default() -> Self {
-        OrderedEvent {
-            order: 0,
-            keys: Vec::new(),
-            data: Vec::new(),
-        }
     }
 }
 
@@ -628,10 +614,10 @@ mod tests {
 
         // events
 
-        let event1 = Event::new(ord_event1.clone(), child2.caller_address.clone());
-        let event2 = Event::new(ord_event2.clone(), child2.caller_address.clone());
-        let event3 = Event::new(ord_event3.clone(), child1.caller_address.clone());
-        let event4 = Event::new(ord_event4.clone(), child1.caller_address.clone());
+        let event1 = Event::new(ord_event1, child2.caller_address.clone());
+        let event2 = Event::new(ord_event2, child2.caller_address);
+        let event3 = Event::new(ord_event3, child1.caller_address.clone());
+        let event4 = Event::new(ord_event4, child1.caller_address);
 
         assert_eq!(
             call_root.get_sorted_events().unwrap(),
@@ -668,10 +654,10 @@ mod tests {
 
         // events
 
-        let event1 = Event::new(ord_event1.clone(), child2.caller_address.clone());
-        let event2 = Event::new(ord_event2.clone(), child2.caller_address.clone());
-        let event3 = Event::new(ord_event3.clone(), child1.caller_address.clone());
-        let event4 = Event::new(ord_event4.clone(), child1.caller_address.clone());
+        let event1 = Event::new(ord_event1, child2.caller_address.clone());
+        let event2 = Event::new(ord_event2, child2.caller_address);
+        let event3 = Event::new(ord_event3, child1.caller_address.clone());
+        let event4 = Event::new(ord_event4, child1.caller_address);
 
         assert!(call_root.get_sorted_events().is_err())
     }
@@ -705,10 +691,10 @@ mod tests {
 
         // events
 
-        let msg1 = L2toL1MessageInfo::new(ord_msg1.clone(), child2.caller_address.clone());
-        let msg2 = L2toL1MessageInfo::new(ord_msg2.clone(), child2.caller_address.clone());
-        let msg3 = L2toL1MessageInfo::new(ord_msg3.clone(), child1.caller_address.clone());
-        let msg4 = L2toL1MessageInfo::new(ord_msg4.clone(), child1.caller_address.clone());
+        let msg1 = L2toL1MessageInfo::new(ord_msg1, child2.caller_address.clone());
+        let msg2 = L2toL1MessageInfo::new(ord_msg2, child2.caller_address);
+        let msg3 = L2toL1MessageInfo::new(ord_msg3, child1.caller_address.clone());
+        let msg4 = L2toL1MessageInfo::new(ord_msg4, child1.caller_address);
 
         assert_eq!(
             call_root.get_sorted_l2_to_l1_messages().unwrap(),
@@ -745,10 +731,10 @@ mod tests {
 
         // events
 
-        let msg1 = L2toL1MessageInfo::new(ord_msg1.clone(), child2.caller_address.clone());
-        let msg2 = L2toL1MessageInfo::new(ord_msg2.clone(), child2.caller_address.clone());
-        let msg3 = L2toL1MessageInfo::new(ord_msg3.clone(), child1.caller_address.clone());
-        let msg4 = L2toL1MessageInfo::new(ord_msg4.clone(), child1.caller_address.clone());
+        let msg1 = L2toL1MessageInfo::new(ord_msg1, child2.caller_address.clone());
+        let msg2 = L2toL1MessageInfo::new(ord_msg2, child2.caller_address);
+        let msg3 = L2toL1MessageInfo::new(ord_msg3, child1.caller_address.clone());
+        let msg4 = L2toL1MessageInfo::new(ord_msg4, child1.caller_address);
 
         assert!(call_root.get_sorted_l2_to_l1_messages().is_err())
     }

--- a/src/business_logic/transaction/state_objects.rs
+++ b/src/business_logic/transaction/state_objects.rs
@@ -3,10 +3,9 @@ use std::collections::HashMap;
 
 use crate::{
     business_logic::{
-        execution::objects::TransactionExecutionInfo,
+        execution::objects::{CallInfo, TransactionExecutionInfo},
         state::{state_api::State, update_tracker_state::UpdatesTrackerState},
     },
-    core::syscalls::os_syscall_handler::CallInfo,
     definitions::general_config::{self, StarknetGeneralConfig},
 };
 

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -10,6 +10,7 @@ use crate::business_logic::state::state_api_objects::BlockInfo;
 use crate::core::errors::syscall_handler_errors::SyscallHandlerError;
 use crate::definitions::general_config::StarknetGeneralConfig;
 use crate::hash_utils::calculate_contract_address_from_hash;
+use crate::services::api::contract_class::EntryPointType;
 use crate::utils::*;
 use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_rs::vm::vm_core::VirtualMachine;

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -1,6 +1,7 @@
 use super::syscall_handler::SyscallHandler;
 use super::syscall_request::SyscallRequest;
 use super::syscall_response::WriteSyscallResponse;
+use crate::business_logic::execution::objects::TransactionExecutionInfo;
 use crate::business_logic::state::state_api_objects::BlockInfo;
 use crate::core::errors::syscall_handler_errors::SyscallHandlerError;
 use crate::services::api::contract_class::EntryPointType;
@@ -12,7 +13,7 @@ use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct CallInfo {
+pub struct CallInfo {
     caller_address: Address,
     contract_address: Address,
     internal_calls: Vec<CallInfo>,
@@ -36,9 +37,6 @@ impl Default for CallInfo {
 
 #[derive(Debug)]
 pub(crate) struct OsSingleStarknetStorage;
-
-#[derive(Debug, PartialEq)]
-pub struct TransactionExecutionInfo;
 
 impl OsSingleStarknetStorage {
     // Writes the given value in the given key in ongoing_storage_changes and returns the
@@ -366,6 +364,7 @@ impl OsSyscallHandler {
 
 #[cfg(test)]
 mod tests {
+    use crate::business_logic::execution::objects::TransactionExecutionInfo;
     use crate::business_logic::state::state_api_objects::BlockInfo;
     use crate::core::errors::syscall_handler_errors::SyscallHandlerError;
     use crate::core::syscalls::syscall_handler::{SyscallHandler, SyscallHintProcessor};
@@ -378,7 +377,7 @@ mod tests {
     use std::any::Any;
     use std::collections::{HashMap, VecDeque};
 
-    use super::{CallInfo, OsSyscallHandler, TransactionExecutionInfo};
+    use super::{CallInfo, OsSyscallHandler};
     use crate::core::syscalls::hint_code::GET_BLOCK_NUMBER;
     use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use cairo_rs::hint_processor::hint_processor_definition::HintProcessor;
@@ -470,7 +469,6 @@ mod tests {
     #[test]
     fn end_tx_err_tx_execution_info() {
         let mut handler = OsSyscallHandler {
-            tx_execution_info: Some(TransactionExecutionInfo),
             ..Default::default()
         };
 
@@ -516,7 +514,9 @@ mod tests {
 
     #[test]
     fn start_tx_err_tx_execution_info() {
-        let tx_execution_info = Some(TransactionExecutionInfo);
+        let tx_execution_info = Some(TransactionExecutionInfo {
+            ..Default::default()
+        });
 
         let mut handler = OsSyscallHandler {
             tx_execution_info,
@@ -551,13 +551,20 @@ mod tests {
     #[test]
     fn skip_tx() {
         let mut tx_execution_info_iterator = VecDeque::new();
-        tx_execution_info_iterator.push_back(TransactionExecutionInfo);
+        tx_execution_info_iterator.push_back(TransactionExecutionInfo {
+            ..Default::default()
+        });
         let mut handler = OsSyscallHandler {
             tx_execution_info_iterator,
             ..Default::default()
         };
 
-        assert_eq!(handler.skip_tx(), Some(TransactionExecutionInfo));
+        assert_eq!(
+            handler.skip_tx(),
+            Some(TransactionExecutionInfo {
+                ..Default::default()
+            })
+        );
         assert_eq!(handler.skip_tx(), None)
     }
 

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -465,7 +465,6 @@ mod tests {
             }),
             ..Default::default()
         };
-        println!("{:?}", handler);
         assert_eq!(
             handler.end_tx(),
             Err(SyscallHandlerError::ShouldBeNone(String::from(

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -460,6 +460,9 @@ mod tests {
     #[test]
     fn end_tx_err_tx_execution_info() {
         let mut handler = OsSyscallHandler {
+            tx_execution_info: Some(TransactionExecutionInfo {
+                ..Default::default()
+            }),
             ..Default::default()
         };
         println!("{:?}", handler);

--- a/src/core/syscalls/os_syscall_handler.rs
+++ b/src/core/syscalls/os_syscall_handler.rs
@@ -462,7 +462,7 @@ mod tests {
         let mut handler = OsSyscallHandler {
             ..Default::default()
         };
-
+        println!("{:?}", handler);
         assert_eq!(
             handler.end_tx(),
             Err(SyscallHandlerError::ShouldBeNone(String::from(

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -1,2 +1,3 @@
 pub mod constants;
 pub mod general_config;
+pub mod transaction_type;

--- a/src/definitions/transaction_type.rs
+++ b/src/definitions/transaction_type.rs
@@ -1,0 +1,13 @@
+use crate::{business_logic::state::state_api_objects::BlockInfo, utils::Address};
+
+#[derive(Debug, PartialEq, Default)]
+
+// TODO: this are not the actual types, just speculation
+pub struct TransactionType {
+    declare: usize,
+    deploy: usize,
+    deploy_account: Address,
+    initialize_block_info: BlockInfo,
+    l1_handler: String,
+    invoke_function: String,
+}

--- a/src/definitions/transaction_type.rs
+++ b/src/definitions/transaction_type.rs
@@ -1,13 +1,9 @@
-use crate::{business_logic::state::state_api_objects::BlockInfo, utils::Address};
-
-#[derive(Debug, PartialEq, Default)]
-
-// TODO: this are not the actual types, just speculation
-pub struct TransactionType {
-    declare: usize,
-    deploy: usize,
-    deploy_account: Address,
-    initialize_block_info: BlockInfo,
-    l1_handler: String,
-    invoke_function: String,
+#[derive(Debug, PartialEq)]
+pub enum TransactionType {
+    Declare,
+    Deploy,
+    DeployAccount,
+    InitializeBlockInfo,
+    InvokeFunction,
+    L1Handler,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@ use num_traits::ToPrimitive;
 //*
 //* -------------------
 
-#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Default)]
 pub struct Address(pub Felt);
 
 //* -------------------


### PR DESCRIPTION
* Implement the logic of TransactionExecutionInfo and CallInfo
* This logic is used in the functions of InternalState that were implemented.

CallInfo has complex logic and uses a DFS search to sort the call_info in order to get the events and the l2tol1message.  TransactionExecution makes use of this functions to return the events and messages in ordered manner.