### PR TITLE
rename calculate_contract_address

### DIFF
--- a/src/business_logic/transaction/internal_objects.rs
+++ b/src/business_logic/transaction/internal_objects.rs
@@ -12,7 +12,7 @@ use crate::core::transaction_hash::starknet_transaction_hash::calculate_deploy_t
 use crate::definitions::constants::TRANSACTION_VERSION;
 use crate::definitions::general_config::{self, StarknetGeneralConfig};
 use crate::definitions::transaction_type::TransactionType;
-use crate::hash_utils::calculate_contract_address_from_hash;
+use crate::hash_utils::calculate_contract_address;
 use crate::services::api::contract_class::{self, ContractClass};
 use crate::starknet_storage::storage::{FactFetchingContext, Storage};
 use crate::starkware_utils::starkware_errors::StarkwareError;
@@ -52,7 +52,7 @@ impl InternalDeploy {
             .as_bytes()
             .try_into()
             .map_err(|_| UtilsError::FeltToFixBytesArrayFail(class_hash.clone()))?;
-        let contract_address = Address(calculate_contract_address_from_hash(
+        let contract_address = Address(calculate_contract_address(
             &contract_address_salt,
             &class_hash,
             &constructor_calldata[..],

--- a/src/core/contract_address/starknet_contract_address.rs
+++ b/src/core/contract_address/starknet_contract_address.rs
@@ -19,7 +19,7 @@ use num_traits::{pow, Num};
 
 use crate::{
     core::errors::contract_address_errors::ContractAddressError,
-    hash_utils::calculate_contract_address_from_hash,
+    hash_utils::{calculate_contract_address, compute_hash_on_elements},
     services::api::contract_class::{ContractClass, ContractEntryPoint, EntryPointType},
     utils::Address,
 };
@@ -28,26 +28,6 @@ use std::{collections::HashMap, hash::Hash, path::Path};
 
 /// Instead of doing a Mask with 250 bits, we are only masking the most significant byte.
 pub const MASK_3: u8 = 3;
-
-/// Calculates the contract address in the starkNet network - a unique identifier of the contract.
-/// The contract address is a hash chain of the following information:
-///     1. Prefix.
-///     2. Deployer address.
-///     3. Salt.
-///     4. Class hash.
-/// To avoid exceeding the maximum address we take modulus L2_ADDRESS_UPPER_BOUND of the above
-/// result.
-pub(crate) fn calculate_contract_address(
-    salt: &Address,
-    contract_class: &ContractClass,
-    constructor_calldata: &[Felt],
-    deployer_address: Address,
-) -> Result<Felt, ContractAddressError> {
-    let class_hash = compute_class_hash(contract_class)?;
-
-    calculate_contract_address_from_hash(salt, &class_hash, constructor_calldata, deployer_address)
-        .map_err(|err| ContractAddressError::ContractAddressFromHash(err.to_string()))
-}
 
 fn load_program() -> Result<Program, ContractAddressError> {
     Ok(Program::from_file(

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -14,7 +14,7 @@ use crate::business_logic::state::state_api::{State, StateReader};
 use crate::business_logic::state::state_api_objects::BlockInfo;
 use crate::core::errors::syscall_handler_errors::SyscallHandlerError;
 use crate::definitions::general_config::StarknetGeneralConfig;
-use crate::hash_utils::calculate_contract_address_from_hash;
+use crate::hash_utils::calculate_contract_address;
 use crate::services::api::contract_class::EntryPointType;
 use crate::starknet_storage::dict_storage::DictStorage;
 use crate::utils::*;
@@ -177,7 +177,7 @@ impl<T: State + StateReader + Clone> SyscallHandler for BusinessLogicSyscallHand
             Address(0.into())
         };
 
-        let _contract_address = calculate_contract_address_from_hash(
+        let _contract_address = calculate_contract_address(
             &Address(request.contract_address_salt),
             class_hash,
             &constructor_calldata,

--- a/src/hash_utils.rs
+++ b/src/hash_utils.rs
@@ -7,7 +7,7 @@ use starknet_crypto::{pedersen_hash, FieldElement};
 
 use crate::{core::errors::syscall_handler_errors::SyscallHandlerError, utils::Address};
 
-pub fn calculate_contract_address_from_hash(
+pub fn calculate_contract_address(
     salt: &Address,
     class_hash: &Felt,
     constructor_calldata: &[Felt],
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_calculate_contract_address_from_hash() {
-        let result_1 = calculate_contract_address_from_hash(
+        let result_1 = calculate_contract_address(
             &Address(1.into()),
             &2.into(),
             &[3.into(), 4.into()],
@@ -112,7 +112,7 @@ mod tests {
             ))
         );
 
-        let result_2 = calculate_contract_address_from_hash(
+        let result_2 = calculate_contract_address(
             &Address(756.into()),
             &543.into(),
             &[124543.into(), 5345345.into(), 89.into()],


### PR DESCRIPTION
- Rename `calculate_contract_address_from_hash` function into `calculate_contract_address`.
- Delete old `calculate_contract_address` function.