### PR TITLE
ci: speedup (#1)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -8,31 +8,85 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: 1.62.0
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install Rust 1.62.0
+    - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.62.0
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
           components: rustfmt, clippy
-    - uses: actions/checkout@v3
-    - name: Format
-      run: cargo fmt --all -- --check
-    - name: Deps
-      run: make deps
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Build
       run: make build
+    - name: Deps
+      run: make deps
+
+  format:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rustfmt, clippy
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Format
+      run: cargo fmt --all -- --check
     - name: Run clippy
       run: make clippy
+
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rustfmt, clippy
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Deps
+      run: make deps
     - name: Run tests
       run: make test
+
+  coverage:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rustfmt, clippy
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Deps
+      run: make deps
     - name: Coverage
       run: make coverage
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error:     true
+        fail_ci_if_error: true


### PR DESCRIPTION
Resolves #131.

This PR splits the one big CI job into 4 smaller ones (build, format, tests, coverage) so they can run in parallel. Furthermore, it uses the [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) action to cache rust artifacts. The whole CI now takes [about 8 minutes](https://github.com/milancermak/starknet_in_rust/actions/runs/4245145016).