### PR TITLE
updated installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,36 @@ It makes use of [cairo-rs](https://github.com/lambdaclass/cairo-rs), the Rust im
 
 ### Installation
 
-Run the following make targets to have a working environment:
+Run the following make targets to have a working environment (if in Mac or if you encounter an error, see the subsection below):
 ```bash
 $ make deps
 $ source starknet-in-rs-venv/bin/activate
-$ make compile_cairo
+$ make compile-cairo
 $ deactivate
 $ make build
 ```
-
 Check the [Makefile](/Makefile) for additional targets.
+
+#### How to manually install the script dependencies
+
+`cairo-lang` requires the `gmp` library to build.
+You can install it on Debian-based GNU/Linux distributions with:
+```shell
+sudo apt install -y libgmp3-dev
+```
+
+In Mac you can use Homebrew:
+```shell
+brew install gmp
+```
+
+In Mac you'll also need to tell the script where to find the gmp lib:
+```shell
+export CFLAGS=-I/opt/homebrew/opt/gmp/include LDFLAGS=-L/opt/homebrew/opt/gmp/lib
+sh build_envs.sh
+```
+
+
 
 ## 🚀 Usage
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ brew install gmp
 In Mac you'll also need to tell the script where to find the gmp lib:
 ```shell
 export CFLAGS=-I/opt/homebrew/opt/gmp/include LDFLAGS=-L/opt/homebrew/opt/gmp/lib
-sh build_envs.sh
 ```
 
 


### PR DESCRIPTION
Stole the ####How to manually install the script dependencies section from the cairo-rs-py repo

Fixed typo: the `make compile_cairo` command should say `make compile-cairo`