### PR TITLE
Add Codecov token from GitHub Actions secrets

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -90,3 +90,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Plus I added the token, retrieved from codecov, on a GitHub Action secret for this repository.

Reference: https://github.com/codecov/codecov-action#usage