### PR TITLE
move the StateSelector struct

### DIFF
--- a/src/business_logic/fact_state/contract_state.rs
+++ b/src/business_logic/fact_state/contract_state.rs
@@ -1,7 +1,0 @@
-use crate::utils::{Address, ClassHash};
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StateSelector {
-    pub contract_addresses: Vec<Address>,
-    pub class_hashes: Vec<ClassHash>,
-}

--- a/src/business_logic/fact_state/mod.rs
+++ b/src/business_logic/fact_state/mod.rs
@@ -1,3 +1,2 @@
-pub mod contract_state;
 pub mod in_memory_state_reader;
 pub mod state;

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -5,7 +5,7 @@ use crate::{
             execution_entry_point::ExecutionEntryPoint,
             objects::{CallInfo, TransactionExecutionContext, TransactionExecutionInfo},
         },
-        fact_state::{contract_state::StateSelector, state::ExecutionResourcesManager},
+        fact_state::state::ExecutionResourcesManager,
         state::state_api::{State, StateReader},
         transaction::{
             error::TransactionError,
@@ -29,6 +29,12 @@ use felt::Felt;
 use getset::Getters;
 use num_traits::Zero;
 use std::collections::HashMap;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StateSelector {
+    pub contract_addresses: Vec<Address>,
+    pub class_hashes: Vec<ClassHash>,
+}
 
 #[derive(Clone, Debug, Getters)]
 pub struct InternalDeployAccount {


### PR DESCRIPTION
Delete the file src/business_logic/fact_state/contract_state.rs, which contains only the StateSelector struct, and move the StateSelector struct to where it's used.