### PR TITLE
Add missing method to pycached state

### DIFF
--- a/crates/starknet-rs-py/src/cached_state.rs
+++ b/crates/starknet-rs-py/src/cached_state.rs
@@ -46,9 +46,17 @@ impl PyCachedState {
             .to_biguint())
     }
 
-    fn set_contract_class(&mut self, _address: BigUint, _contract_class: &PyContractClass) {
-        // self.state.set_contract_class(class_hash, contract_class)
-        todo!()
+    fn set_contract_class(
+        &mut self,
+        address: BigUint,
+        contract_class: &PyContractClass,
+    ) -> PyResult<()> {
+        let address = felt_to_hash(&Felt::from(address));
+        let contract_class = contract_class.inner.clone();
+        self.state
+            .set_contract_class(&address, &contract_class)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
     }
 
     fn set_storage_at(&mut self, address: BigUint, key: BigUint, value: BigUint) {

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -4,6 +4,8 @@ mod cached_state;
 mod starknet_state;
 mod types;
 
+use std::ops::Shl;
+
 use self::{
     cached_state::PyCachedState,
     types::{
@@ -18,8 +20,7 @@ use starknet_rs::{
     business_logic::state::cached_state::UNINITIALIZED_CLASS_HASH,
     definitions::constants::{
         DEFAULT_CONTRACT_STORAGE_COMMITMENT_TREE_HEIGHT, DEFAULT_GAS_PRICE,
-        DEFAULT_SEQUENCER_ADDRESS, DEFAULT_VALIDATE_MAX_N_STEPS, N_STEPS_FEE_WEIGHT,
-        TRANSACTION_VERSION,
+        DEFAULT_SEQUENCER_ADDRESS, DEFAULT_VALIDATE_MAX_N_STEPS, TRANSACTION_VERSION,
     },
     services::api::contract_class::ContractClass,
 };
@@ -230,7 +231,7 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("UNINITIALIZED_CLASS_HASH", *UNINITIALIZED_CLASS_HASH)?;
 
     // Indentation for transactions meant to query and not addressed to the OS.
-    let query_version_base: Felt = Felt::from(1 << 128);
+    let query_version_base: Felt = Felt::from(1).shl(128_usize);
     let query_version = query_version_base + Felt::from(TRANSACTION_VERSION);
     m.add("QUERY_VERSION", query_version.to_biguint())?;
 


### PR DESCRIPTION
set_contract_class was a missing method of PyCachedState required to store the contract classes to execute