### PR TITLE
Bump pyo3 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a3d8e8a46ab2738109347433cb7b96dffda2e4a218b03ef27090238886b147"
+checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75439f995d07ddfad42b192dfcf3bc66a7ecfd8b4a1f5f6f046aa5c2c5d7677d"
+checksum = "98a42e7f42e917ce6664c832d5eee481ad514c98250c49e0b03b20593e2c7ed0"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1880,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839526a5c07a17ff44823679b68add4a58004de00512a95b6c1c98a6dcac0ee5"
+checksum = "a0707f0ab26826fe4ccd59b69106e9df5e12d097457c7b8f9c0fd1d2743eec4d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd44cf207476c6a9760c4653559be4f206efafb924d3e4cbf2721475fc0d6cc5"
+checksum = "978d18e61465ecd389e1f235ff5a467146dc4e3c3968b90d274fe73a5dd4a438"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1902,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1f43d8e30460f36350d18631ccf85ded64c059829208fe680904c65bcd0a4c"
+checksum = "8e0e1128f85ce3fca66e435e08aa2089a2689c1c48ce97803e13f63124058462"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/starknet-rs-py/Cargo.toml
+++ b/crates/starknet-rs-py/Cargo.toml
@@ -28,7 +28,7 @@ rev = "8dba86dbec935fa04a255e2edf3d5d184950fa22"
 
 [dependencies.pyo3]
 features = ["num-bigint"]
-version = "0.18.1"
+version = "0.18.2"
 
 [dependencies.starknet-rs]
 path = "../.."

--- a/crates/starknet-rs-py/src/types/general_config.rs
+++ b/crates/starknet-rs-py/src/types/general_config.rs
@@ -1,6 +1,3 @@
-// TODO: remove when pyo3 v0.18.2 releases (https://github.com/PyO3/pyo3/pull/3028)
-#![allow(clippy::redundant_closure)]
-
 use cairo_felt::Felt;
 use num_bigint::BigUint;
 use pyo3::{prelude::*, types::PyDict};


### PR DESCRIPTION
This PR bumps the _pyo3_ version to the latest one released. Among other changes, this fixes the "redundant_closure" clippy warning that appeared when using `#[pyo3(signature = ...)]` with default arguments, and so we don't need this allow anymore.