### PR TITLE
add test for the read_abi function in contract_abi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check clean clippy compile-cairo compile-starknet coverage deps deps-macos remove-venv test heaptrack check-python-version compile-abi
+.PHONY: build check clean clippy compile-cairo compile-starknet coverage deps test heaptrack check-python-version compile-abi
 
 
 OS := $(shell uname)
@@ -44,19 +44,10 @@ starknet_programs/%.json: starknet_programs/%.cairo
 #
 
 compile-abi:
-	starknet-compile starknet_programs/fibonacci.cairo \
+	. starknet-venv/bin/activate && cd cairo_programs/ && starknet-compile starknet_programs/fibonacci.cairo \
 		--output starknet_programs/fibonacci_compiled.json \
 		--abi starknet_programs/fibonacci_abi.json
 # This abi file is used for the `test_read_abi` test in contract_abi.rs
-
-check-python-version:
-	@python_version=`python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'`; \
-	if python -c "import sys; exit(0) if (3, 8) <= sys.version_info < (3, 10) else exit(1)"; then \
-		echo "Installed Python version ($$python_version) is correct"; \
-	else \
-		echo "Error: Installed Python version ($$python_version) is not 3.8 or 3.9"; \
-		exit 1; \
-	fi
 
 build: compile-cairo compile-starknet
 	cargo build --release --all
@@ -79,7 +70,7 @@ clean:
 clippy: compile-cairo compile-starknet
 	cargo clippy --all --all-targets -- -D warnings
 
-test: deps compile-cairo compile-starknet compile-abi
+test: compile-cairo compile-starknet compile-abi
 	cargo test
 
 test-py: compile-cairo compile-starknet

--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ compile-abi:
 
 check-python-version:
 	@python_version=`python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'`; \
-	if python -c "import sys; exit(0) if sys.version_info >= (3, 9) else exit(1)"; then \
-		echo "Installed Python version ($$python_version) is correct or higher"; \
+	if python -c "import sys; exit(0) if (3, 8) <= sys.version_info < (3, 10) else exit(1)"; then \
+		echo "Installed Python version ($$python_version) is correct"; \
 	else \
-		echo "Error: Installed Python version ($$python_version) is lower than required version (3.9)"; \
+		echo "Error: Installed Python version ($$python_version) is not 3.8 or 3.9"; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-py: compile-cairo compile-starknet
 	. starknet-venv/bin/activate
 	cargo test -p starknet-rs-py --no-default-features --features embedded-python
 
-coverage: compile-cairo compile-starknet
+coverage: compile-cairo compile-starknet compile-abi
 	cargo tarpaulin
 	-rm -f default.profraw
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ starknet_programs/%.json: starknet_programs/%.cairo
 #
 
 compile-abi:
+	. starknet-venv/bin/activate
 	starknet-compile starknet_programs/fibonacci.cairo \
 		--output starknet_programs/fibonacci_compiled.json \
 		--abi starknet_programs/fibonacci_abi.json

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ starknet_programs/%.json: starknet_programs/%.cairo
 #
 
 compile-abi:
-	. starknet-venv/bin/activate
 	starknet-compile starknet_programs/fibonacci.cairo \
 		--output starknet_programs/fibonacci_compiled.json \
 		--abi starknet_programs/fibonacci_abi.json
@@ -80,7 +79,7 @@ clean:
 clippy: compile-cairo compile-starknet
 	cargo clippy --all --all-targets -- -D warnings
 
-test: compile-cairo compile-starknet compile-abi
+test: deps compile-cairo compile-starknet compile-abi
 	cargo test
 
 test-py: compile-cairo compile-starknet

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check clean clippy compile-cairo compile-starknet coverage deps deps-macos remove-venv test heaptrack	
+.PHONY: build check clean clippy compile-cairo compile-starknet coverage deps deps-macos remove-venv test heaptrack check-python-version compile-abi
 
 
 OS := $(shell uname)
@@ -37,11 +37,26 @@ cairo_programs/%.json: cairo_programs/%.cairo
 
 starknet_programs/%.json: starknet_programs/%.cairo
 	. starknet-venv/bin/activate && cd starknet_programs/ && starknet-compile $(shell grep "^// @compile-flags += .*$$" $< | cut -c 22-) ../$< --output ../$@ || rm ../$@
-
+# Compiles .cairo files into .json files. if the command fails, then it removes all of the .json files
 
 #
 # Normal rules.
 #
+
+compile-abi:
+	starknet-compile starknet_programs/fibonacci.cairo \
+		--output starknet_programs/fibonacci_compiled.json \
+		--abi starknet_programs/fibonacci_abi.json
+# This abi file is used for the `test_read_abi` test in contract_abi.rs
+
+check-python-version:
+	@python_version=`python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'`; \
+	if python -c "import sys; exit(0) if sys.version_info >= (3, 9) else exit(1)"; then \
+		echo "Installed Python version ($$python_version) is correct or higher"; \
+	else \
+		echo "Error: Installed Python version ($$python_version) is lower than required version (3.9)"; \
+		exit 1; \
+	fi
 
 build: compile-cairo compile-starknet
 	cargo build --release --all
@@ -49,12 +64,11 @@ build: compile-cairo compile-starknet
 check: compile-cairo compile-starknet
 	cargo check --all
 
-deps:
+deps: check-python-version 
 	cargo install cargo-tarpaulin --version 0.23.1
 	cargo install flamegraph --version 0.6.2
 	python3 -m venv starknet-venv
 	. starknet-venv/bin/activate && $(MAKE) deps-venv
-
 
 clean:
 	-rm -rf starknet-venv/
@@ -65,7 +79,7 @@ clean:
 clippy: compile-cairo compile-starknet
 	cargo clippy --all --all-targets -- -D warnings
 
-test: compile-cairo compile-starknet
+test: compile-cairo compile-starknet compile-abi
 	cargo test
 
 test-py: compile-cairo compile-starknet
@@ -81,3 +95,4 @@ heaptrack:
 
 flamegraph: compile-cairo compile-starknet
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --root --bench internals
+

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ starknet_programs/%.json: starknet_programs/%.cairo
 #
 
 compile-abi:
-	. starknet-venv/bin/activate && cd cairo_programs/ && starknet-compile starknet_programs/fibonacci.cairo \
-		--output starknet_programs/fibonacci_compiled.json \
-		--abi starknet_programs/fibonacci_abi.json
+	. starknet-venv/bin/activate && cd starknet_programs/ && starknet-compile fibonacci.cairo \
+		--output fibonacci_compiled.json \
+		--abi fibonacci_abi.json
 # This abi file is used for the `test_read_abi` test in contract_abi.rs
 
 build: compile-cairo compile-starknet

--- a/src/serde_structs/contract_abi.rs
+++ b/src/serde_structs/contract_abi.rs
@@ -38,3 +38,17 @@ pub fn read_abi(abi_name: &PathBuf) -> HashMap<String, (usize, EntryPointType)> 
 
     result_hash_map
 }
+
+#[test]
+fn test_read_abi() {
+    let path_a = PathBuf::from(r"starknet_programs/fibonacci_abi.json");
+    // using the function to read an abi
+    let result = read_abi(&path_a);
+
+    // this is the expected result of the function above
+    let expected_result: HashMap<String, (usize, EntryPointType)> =
+        HashMap::from([(String::from("fib"), (0_usize, EntryPointType::External))]);
+
+    // final check
+    assert_eq!(result, expected_result)
+}


### PR DESCRIPTION
Modifies the Makefile so that `make test` creates an abi file that is then used in the read_abi test.