### PR TITLE
[pyo3] Add internal transaction types

### DIFF
--- a/crates/starknet-rs-py/src/cached_state.rs
+++ b/crates/starknet-rs-py/src/cached_state.rs
@@ -58,3 +58,9 @@ impl PyCachedState {
         );
     }
 }
+
+impl<'a> From<&'a mut PyCachedState> for &'a mut InnerCachedState<InMemoryStateReader> {
+    fn from(py_state: &'a mut PyCachedState) -> Self {
+        &mut py_state.state
+    }
+}

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -4,7 +4,10 @@ mod cached_state;
 mod starknet_state;
 mod types;
 
-use crate::types::transactions::{declare::PyInternalDeclare, deploy::PyInternalDeploy};
+use crate::types::transactions::{
+    declare::PyInternalDeclare, deploy::PyInternalDeploy, deploy_account::PyInternalDeployAccount,
+    invoke_function::PyInternalInvokeFunction,
+};
 
 use self::{
     cached_state::PyCachedState,
@@ -45,8 +48,11 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyOrderedEvent>()?;
     m.add_class::<PyOrderedL2ToL1Message>()?;
     m.add_class::<PyCallInfo>()?;
+
     m.add_class::<PyInternalDeclare>()?;
     m.add_class::<PyInternalDeploy>()?;
+    m.add_class::<PyInternalDeployAccount>()?;
+    m.add_class::<PyInternalInvokeFunction>()?;
 
     //  starkware.starknet.core.os.transaction_hash.transaction_hash
     // m.add_class::<PyTransactionHashPrefix>()?;
@@ -155,8 +161,6 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     //  starkware.starknet.business_logic.transaction.objects
     // m.add_class::<PyInternalL1Handler>()?;
     // m.add_class::<PyInternalAccountTransaction>()?;
-    // m.add_class::<PyInternalDeployAccount>()?;
-    // m.add_class::<PyInternalInvokeFunction>()?;
     // m.add_class::<PyInternalTransaction>()?;
     // m.add_class::<PyTransactionExecutionInfo>()?;
 

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -52,15 +52,16 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyOrderedL2ToL1Message>()?;
     m.add_class::<PyCallInfo>()?;
 
-    //  starkware.starknet.business_logic.transaction.objects
-    // m.add_class::<PyInternalL1Handler>()?;
-    // m.add_class::<PyInternalAccountTransaction>()?;
-    // m.add_class::<PyInternalTransaction>()?;
     m.add_class::<PyTransactionExecutionInfo>()?;
     m.add_class::<PyInternalDeclare>()?;
     m.add_class::<PyInternalDeploy>()?;
     m.add_class::<PyInternalDeployAccount>()?;
     m.add_class::<PyInternalInvokeFunction>()?;
+
+    //  starkware.starknet.business_logic.transaction.objects
+    // m.add_class::<PyInternalTransaction>()?; // Is just used for type checking
+    // m.add_class::<PyInternalAccountTransaction>()?;
+    // m.add_class::<PyInternalL1Handler>()?;  // isn't implemented
 
     //  starkware.starknet.core.os.transaction_hash.transaction_hash
     // m.add_class::<PyTransactionHashPrefix>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -4,6 +4,8 @@ mod cached_state;
 mod starknet_state;
 mod types;
 
+use crate::types::transactions::declare::PyInternalDeclare;
+
 use self::{
     cached_state::PyCachedState,
     types::{
@@ -151,7 +153,7 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     //  starkware.starknet.business_logic.transaction.objects
     // m.add_class::<PyInternalL1Handler>()?;
     // m.add_class::<PyInternalAccountTransaction>()?;
-    // m.add_class::<PyInternalDeclare>()?;
+    m.add_class::<PyInternalDeclare>()?;
     // m.add_class::<PyInternalDeploy>()?;
     // m.add_class::<PyInternalDeployAccount>()?;
     // m.add_class::<PyInternalInvokeFunction>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -4,7 +4,7 @@ mod cached_state;
 mod starknet_state;
 mod types;
 
-use crate::types::transactions::declare::PyInternalDeclare;
+use crate::types::transactions::{declare::PyInternalDeclare, deploy::PyInternalDeploy};
 
 use self::{
     cached_state::PyCachedState,
@@ -45,6 +45,8 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyOrderedEvent>()?;
     m.add_class::<PyOrderedL2ToL1Message>()?;
     m.add_class::<PyCallInfo>()?;
+    m.add_class::<PyInternalDeclare>()?;
+    m.add_class::<PyInternalDeploy>()?;
 
     //  starkware.starknet.core.os.transaction_hash.transaction_hash
     // m.add_class::<PyTransactionHashPrefix>()?;
@@ -153,8 +155,6 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     //  starkware.starknet.business_logic.transaction.objects
     // m.add_class::<PyInternalL1Handler>()?;
     // m.add_class::<PyInternalAccountTransaction>()?;
-    m.add_class::<PyInternalDeclare>()?;
-    // m.add_class::<PyInternalDeploy>()?;
     // m.add_class::<PyInternalDeployAccount>()?;
     // m.add_class::<PyInternalInvokeFunction>()?;
     // m.add_class::<PyInternalTransaction>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -4,9 +4,12 @@ mod cached_state;
 mod starknet_state;
 mod types;
 
-use crate::types::transactions::{
-    declare::PyInternalDeclare, deploy::PyInternalDeploy, deploy_account::PyInternalDeployAccount,
-    invoke_function::PyInternalInvokeFunction,
+use crate::types::{
+    transaction_execution_info::PyTransactionExecutionInfo,
+    transactions::{
+        declare::PyInternalDeclare, deploy::PyInternalDeploy,
+        deploy_account::PyInternalDeployAccount, invoke_function::PyInternalInvokeFunction,
+    },
 };
 
 use self::{
@@ -49,6 +52,11 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyOrderedL2ToL1Message>()?;
     m.add_class::<PyCallInfo>()?;
 
+    //  starkware.starknet.business_logic.transaction.objects
+    // m.add_class::<PyInternalL1Handler>()?;
+    // m.add_class::<PyInternalAccountTransaction>()?;
+    // m.add_class::<PyInternalTransaction>()?;
+    m.add_class::<PyTransactionExecutionInfo>()?;
     m.add_class::<PyInternalDeclare>()?;
     m.add_class::<PyInternalDeploy>()?;
     m.add_class::<PyInternalDeployAccount>()?;
@@ -157,12 +165,6 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     // m.add_class::<PyInvokeFunction>()?;
     // m.add_class::<PyDeploy>()?;
     // m.add_class::<PyTransaction>()?;
-
-    //  starkware.starknet.business_logic.transaction.objects
-    // m.add_class::<PyInternalL1Handler>()?;
-    // m.add_class::<PyInternalAccountTransaction>()?;
-    // m.add_class::<PyInternalTransaction>()?;
-    // m.add_class::<PyTransactionExecutionInfo>()?;
 
     //  starkware.starknet.testing.contract
     // m.add_class::<PyStarknetContract>()?;

--- a/crates/starknet-rs-py/src/types.rs
+++ b/crates/starknet-rs-py/src/types.rs
@@ -7,3 +7,4 @@ pub mod general_config;
 pub mod ordered_event;
 pub mod ordered_l2_to_l1_message;
 pub mod transaction_execution_info;
+pub mod transactions;

--- a/crates/starknet-rs-py/src/types/general_config.rs
+++ b/crates/starknet-rs-py/src/types/general_config.rs
@@ -109,6 +109,12 @@ impl PyStarknetGeneralConfig {
     }
 }
 
+impl<'a> From<&'a PyStarknetGeneralConfig> for &'a StarknetGeneralConfig {
+    fn from(value: &'a PyStarknetGeneralConfig) -> Self {
+        &value.inner
+    }
+}
+
 #[pyclass]
 #[pyo3(name = "StarknetOsConfig")]
 #[derive(Debug, Clone, Default)]

--- a/crates/starknet-rs-py/src/types/transactions/declare.rs
+++ b/crates/starknet-rs-py/src/types/transactions/declare.rs
@@ -62,11 +62,6 @@ impl PyInternalDeclare {
     }
 
     #[getter]
-    fn contract_address(&self) -> BigUint {
-        self.inner.sender_address.0.to_biguint()
-    }
-
-    #[getter]
     fn signature(&self) -> Vec<BigUint> {
         self.inner
             .signature

--- a/crates/starknet-rs-py/src/types/transactions/declare.rs
+++ b/crates/starknet-rs-py/src/types/transactions/declare.rs
@@ -1,0 +1,87 @@
+use cairo_felt::Felt252;
+use num_bigint::BigUint;
+use pyo3::prelude::*;
+use starknet_rs::{
+    business_logic::transaction::objects::internal_declare::InternalDeclare,
+    definitions::{
+        constants::VALIDATE_DECLARE_ENTRY_POINT_SELECTOR, transaction_type::TransactionType,
+    },
+    services::api::contract_class::ContractClass,
+    utils::{Address, ClassHash},
+};
+
+#[pyclass]
+pub struct PyInternalDeclare {
+    inner: InternalDeclare,
+}
+
+#[pymethods]
+impl PyInternalDeclare {
+    #[new]
+    fn new(
+        hash_value: BigUint,
+        version: u64,
+        max_fee: u64,
+        signature: Vec<BigUint>,
+        nonce: BigUint,
+        class_hash: ClassHash,
+        sender_address: BigUint,
+    ) -> Self {
+        let sender_address = Address(Felt252::from(sender_address));
+        let signature = signature.into_iter().map(Felt252::from).collect();
+        let nonce = Felt252::from(nonce);
+        let hash_value = Felt252::from(hash_value);
+        let contract_class =
+            ContractClass::new(Default::default(), Default::default(), None).unwrap();
+
+        let inner = InternalDeclare {
+            class_hash,
+            sender_address,
+            tx_type: TransactionType::Declare,
+            validate_entry_point_selector: VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone(),
+            version,
+            max_fee,
+            signature,
+            nonce,
+            hash_value,
+            contract_class,
+        };
+
+        Self { inner }
+    }
+
+    #[getter]
+    fn class_hash(&self) -> ClassHash {
+        self.inner.class_hash
+    }
+
+    #[getter]
+    fn hash_value(&self) -> BigUint {
+        self.inner.hash_value.to_biguint()
+    }
+
+    #[getter]
+    fn contract_address(&self) -> BigUint {
+        self.inner.sender_address.0.to_biguint()
+    }
+
+    #[getter]
+    fn signature(&self) -> Vec<BigUint> {
+        self.inner
+            .signature
+            .iter()
+            .map(Felt252::to_biguint)
+            .collect()
+    }
+
+    // fn apply_state_updates(
+    //     &self,
+    //     state: PyStarknetState,
+    //     general_config: PyStarknetGeneralConfig,
+    // ) -> PyResult<PyTransactionExecutionInfo> {
+    //     // TODO: check if this is really equivalent
+    //     self.inner
+    //         .execute(state, general_config.into())
+    //         .map_err(|e| PyValueError::new_err(e.to_string()))
+    // }
+}

--- a/crates/starknet-rs-py/src/types/transactions/declare.rs
+++ b/crates/starknet-rs-py/src/types/transactions/declare.rs
@@ -10,7 +10,8 @@ use starknet_rs::{
     utils::{Address, ClassHash},
 };
 
-#[pyclass]
+#[pyclass(subclass)]
+#[pyo3(name = "InternalDeclare")]
 pub struct PyInternalDeclare {
     inner: InternalDeclare,
 }

--- a/crates/starknet-rs-py/src/types/transactions/declare.rs
+++ b/crates/starknet-rs-py/src/types/transactions/declare.rs
@@ -1,8 +1,18 @@
+use crate::{
+    cached_state::PyCachedState,
+    types::{
+        general_config::PyStarknetGeneralConfig,
+        transaction_execution_info::PyTransactionExecutionInfo,
+    },
+};
 use cairo_felt::Felt252;
 use num_bigint::BigUint;
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyValueError, prelude::*};
 use starknet_rs::{
-    business_logic::transaction::objects::internal_declare::InternalDeclare,
+    business_logic::{
+        fact_state::in_memory_state_reader::InMemoryStateReader, state::cached_state::CachedState,
+        transaction::objects::internal_declare::InternalDeclare,
+    },
     definitions::{
         constants::VALIDATE_DECLARE_ENTRY_POINT_SELECTOR, transaction_type::TransactionType,
     },
@@ -70,14 +80,15 @@ impl PyInternalDeclare {
             .collect()
     }
 
-    // fn apply_state_updates(
-    //     &self,
-    //     state: PyStarknetState,
-    //     general_config: PyStarknetGeneralConfig,
-    // ) -> PyResult<PyTransactionExecutionInfo> {
-    //     // TODO: check if this is really equivalent
-    //     self.inner
-    //         .execute(state, general_config.into())
-    //         .map_err(|e| PyValueError::new_err(e.to_string()))
-    // }
+    fn apply_state_updates(
+        &self,
+        state: &mut PyCachedState,
+        general_config: &PyStarknetGeneralConfig,
+    ) -> PyResult<PyTransactionExecutionInfo> {
+        let state: &mut CachedState<InMemoryStateReader> = state.into();
+        match self.inner.execute(state, general_config.into()) {
+            Ok(res) => Ok(res.into()),
+            Err(err) => Err(PyValueError::new_err(err.to_string())),
+        }
+    }
 }

--- a/crates/starknet-rs-py/src/types/transactions/deploy.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy.rs
@@ -60,11 +60,6 @@ impl PyInternalDeploy {
         self.inner.contract_address.0.to_biguint()
     }
 
-    #[getter]
-    fn signature(&self) -> Vec<BigUint> {
-        Default::default()
-    }
-
     // fn apply_state_updates(
     //     &self,
     //     state: PyStarknetState,

--- a/crates/starknet-rs-py/src/types/transactions/deploy.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy.rs
@@ -1,0 +1,78 @@
+use cairo_felt::Felt252;
+use num_bigint::BigUint;
+use pyo3::prelude::*;
+use starknet_rs::{
+    business_logic::transaction::objects::internal_deploy::InternalDeploy,
+    definitions::transaction_type::TransactionType,
+    utils::{Address, ClassHash},
+};
+
+#[pyclass(subclass)]
+#[pyo3(name = "InternalDeploy")]
+pub struct PyInternalDeploy {
+    inner: InternalDeploy,
+}
+
+#[pymethods]
+impl PyInternalDeploy {
+    #[new]
+    fn new(
+        contract_address: BigUint,
+        contract_hash: ClassHash,
+        contract_address_salt: BigUint,
+        hash_value: BigUint,
+        version: u64,
+        constructor_calldata: Vec<BigUint>,
+    ) -> Self {
+        let contract_address = Address(Felt252::from(contract_address));
+        let contract_address_salt = Address(Felt252::from(contract_address_salt));
+        let constructor_calldata = constructor_calldata
+            .into_iter()
+            .map(Felt252::from)
+            .collect();
+        let hash_value = Felt252::from(hash_value);
+
+        let inner = InternalDeploy {
+            hash_value,
+            version,
+            contract_address,
+            contract_address_salt,
+            contract_hash,
+            constructor_calldata,
+            tx_type: TransactionType::Deploy,
+        };
+
+        Self { inner }
+    }
+
+    #[getter]
+    fn class_hash(&self) -> ClassHash {
+        self.inner.class_hash()
+    }
+
+    #[getter]
+    fn hash_value(&self) -> BigUint {
+        self.inner.hash_value.to_biguint()
+    }
+
+    #[getter]
+    fn contract_address(&self) -> BigUint {
+        self.inner.contract_address.0.to_biguint()
+    }
+
+    #[getter]
+    fn signature(&self) -> Vec<BigUint> {
+        Default::default()
+    }
+
+    // fn apply_state_updates(
+    //     &self,
+    //     state: PyStarknetState,
+    //     general_config: PyStarknetGeneralConfig,
+    // ) -> PyResult<PyTransactionExecutionInfo> {
+    //     // TODO: check if this is really equivalent
+    //     self.inner
+    //         .execute(state, general_config.into())
+    //         .map_err(|e| PyValueError::new_err(e.to_string()))
+    // }
+}

--- a/crates/starknet-rs-py/src/types/transactions/deploy.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy.rs
@@ -1,10 +1,21 @@
 use cairo_felt::Felt252;
 use num_bigint::BigUint;
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyValueError, prelude::*};
 use starknet_rs::{
-    business_logic::transaction::objects::internal_deploy::InternalDeploy,
+    business_logic::{
+        fact_state::in_memory_state_reader::InMemoryStateReader, state::cached_state::CachedState,
+        transaction::objects::internal_deploy::InternalDeploy,
+    },
     definitions::transaction_type::TransactionType,
     utils::{Address, ClassHash},
+};
+
+use crate::{
+    cached_state::PyCachedState,
+    types::{
+        general_config::PyStarknetGeneralConfig,
+        transaction_execution_info::PyTransactionExecutionInfo,
+    },
 };
 
 #[pyclass(subclass)]
@@ -60,14 +71,15 @@ impl PyInternalDeploy {
         self.inner.contract_address.0.to_biguint()
     }
 
-    // fn apply_state_updates(
-    //     &self,
-    //     state: PyStarknetState,
-    //     general_config: PyStarknetGeneralConfig,
-    // ) -> PyResult<PyTransactionExecutionInfo> {
-    //     // TODO: check if this is really equivalent
-    //     self.inner
-    //         .execute(state, general_config.into())
-    //         .map_err(|e| PyValueError::new_err(e.to_string()))
-    // }
+    fn apply_state_updates(
+        &self,
+        state: &mut PyCachedState,
+        general_config: &PyStarknetGeneralConfig,
+    ) -> PyResult<PyTransactionExecutionInfo> {
+        let state: &mut CachedState<InMemoryStateReader> = state.into();
+        match self.inner.execute(state, general_config.into()) {
+            Ok(res) => Ok(res.into()),
+            Err(err) => Err(PyValueError::new_err(err.to_string())),
+        }
+    }
 }

--- a/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
@@ -1,9 +1,20 @@
 use cairo_felt::Felt252;
 use num_bigint::BigUint;
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyValueError, prelude::*};
 use starknet_rs::{
-    business_logic::transaction::objects::internal_deploy_account::InternalDeployAccount,
+    business_logic::{
+        fact_state::in_memory_state_reader::InMemoryStateReader, state::cached_state::CachedState,
+        transaction::objects::internal_deploy_account::InternalDeployAccount,
+    },
     utils::ClassHash,
+};
+
+use crate::{
+    cached_state::PyCachedState,
+    types::{
+        general_config::PyStarknetGeneralConfig,
+        transaction_execution_info::PyTransactionExecutionInfo,
+    },
 };
 
 #[pyclass(subclass)]
@@ -34,14 +45,15 @@ impl PyInternalDeployAccount {
         self.inner.hash_value().to_biguint()
     }
 
-    // fn apply_state_updates(
-    //     &self,
-    //     state: PyStarknetState,
-    //     general_config: PyStarknetGeneralConfig,
-    // ) -> PyResult<PyTransactionExecutionInfo> {
-    //     // TODO: check if this is really equivalent
-    //     self.inner
-    //         .execute(state, general_config.into())
-    //         .map_err(|e| PyValueError::new_err(e.to_string()))
-    // }
+    fn apply_state_updates(
+        &self,
+        state: &mut PyCachedState,
+        general_config: &PyStarknetGeneralConfig,
+    ) -> PyResult<PyTransactionExecutionInfo> {
+        let state: &mut CachedState<InMemoryStateReader> = state.into();
+        match self.inner.execute(state, general_config.into()) {
+            Ok(res) => Ok(res.into()),
+            Err(err) => Err(PyValueError::new_err(err.to_string())),
+        }
+    }
 }

--- a/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
@@ -1,0 +1,36 @@
+use num_bigint::BigUint;
+use pyo3::prelude::*;
+use starknet_rs::{
+    business_logic::transaction::objects::internal_deploy_account::InternalDeployAccount,
+    utils::ClassHash,
+};
+
+#[pyclass(subclass)]
+#[pyo3(name = "InternalDeployAccount")]
+pub struct PyInternalDeployAccount {
+    inner: InternalDeployAccount,
+}
+
+#[pymethods]
+impl PyInternalDeployAccount {
+    #[getter]
+    fn class_hash(&self) -> ClassHash {
+        *self.inner.class_hash()
+    }
+
+    #[getter]
+    fn signature(&self) -> Vec<BigUint> {
+        Default::default()
+    }
+
+    // fn apply_state_updates(
+    //     &self,
+    //     state: PyStarknetState,
+    //     general_config: PyStarknetGeneralConfig,
+    // ) -> PyResult<PyTransactionExecutionInfo> {
+    //     // TODO: check if this is really equivalent
+    //     self.inner
+    //         .execute(state, general_config.into())
+    //         .map_err(|e| PyValueError::new_err(e.to_string()))
+    // }
+}

--- a/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
@@ -1,3 +1,4 @@
+use cairo_felt::Felt252;
 use num_bigint::BigUint;
 use pyo3::prelude::*;
 use starknet_rs::{
@@ -20,7 +21,11 @@ impl PyInternalDeployAccount {
 
     #[getter]
     fn signature(&self) -> Vec<BigUint> {
-        Default::default()
+        self.inner
+            .signature()
+            .iter()
+            .map(Felt252::to_biguint)
+            .collect()
     }
 
     // fn apply_state_updates(

--- a/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy_account.rs
@@ -14,6 +14,7 @@ pub struct PyInternalDeployAccount {
 
 #[pymethods]
 impl PyInternalDeployAccount {
+    // TODO: maybe unused
     #[getter]
     fn class_hash(&self) -> ClassHash {
         *self.inner.class_hash()
@@ -26,6 +27,11 @@ impl PyInternalDeployAccount {
             .iter()
             .map(Felt252::to_biguint)
             .collect()
+    }
+
+    #[getter]
+    fn hash_value(&self) -> BigUint {
+        self.inner.hash_value().to_biguint()
     }
 
     // fn apply_state_updates(

--- a/crates/starknet-rs-py/src/types/transactions/invoke_function.rs
+++ b/crates/starknet-rs-py/src/types/transactions/invoke_function.rs
@@ -17,11 +17,6 @@ impl PyInternalInvokeFunction {
     }
 
     #[getter]
-    fn contract_address(&self) -> BigUint {
-        self.inner.contract_address().0.to_biguint()
-    }
-
-    #[getter]
     fn signature(&self) -> Vec<BigUint> {
         self.inner
             .signature()

--- a/crates/starknet-rs-py/src/types/transactions/invoke_function.rs
+++ b/crates/starknet-rs-py/src/types/transactions/invoke_function.rs
@@ -1,0 +1,43 @@
+use cairo_felt::Felt252;
+use num_bigint::BigUint;
+use pyo3::prelude::*;
+use starknet_rs::business_logic::transaction::objects::internal_invoke_function::InternalInvokeFunction;
+
+#[pyclass(subclass)]
+#[pyo3(name = "InternalInvokeFunction")]
+pub struct PyInternalInvokeFunction {
+    inner: InternalInvokeFunction,
+}
+
+#[pymethods]
+impl PyInternalInvokeFunction {
+    #[getter]
+    fn hash_value(&self) -> BigUint {
+        self.inner.hash_value().to_biguint()
+    }
+
+    #[getter]
+    fn contract_address(&self) -> BigUint {
+        self.inner.contract_address().0.to_biguint()
+    }
+
+    #[getter]
+    fn signature(&self) -> Vec<BigUint> {
+        self.inner
+            .signature()
+            .iter()
+            .map(Felt252::to_biguint)
+            .collect()
+    }
+
+    // fn apply_state_updates(
+    //     &self,
+    //     state: PyStarknetState,
+    //     general_config: PyStarknetGeneralConfig,
+    // ) -> PyResult<PyTransactionExecutionInfo> {
+    //     // TODO: check if this is really equivalent
+    //     self.inner
+    //         .execute(state, general_config.into())
+    //         .map_err(|e| PyValueError::new_err(e.to_string()))
+    // }
+}

--- a/crates/starknet-rs-py/src/types/transactions/mod.rs
+++ b/crates/starknet-rs-py/src/types/transactions/mod.rs
@@ -1,0 +1,1 @@
+pub mod declare;

--- a/crates/starknet-rs-py/src/types/transactions/mod.rs
+++ b/crates/starknet-rs-py/src/types/transactions/mod.rs
@@ -1,3 +1,4 @@
 pub mod declare;
 pub mod deploy;
 pub mod deploy_account;
+pub mod invoke_function;

--- a/crates/starknet-rs-py/src/types/transactions/mod.rs
+++ b/crates/starknet-rs-py/src/types/transactions/mod.rs
@@ -1,2 +1,3 @@
 pub mod declare;
 pub mod deploy;
+pub mod deploy_account;

--- a/crates/starknet-rs-py/src/types/transactions/mod.rs
+++ b/crates/starknet-rs-py/src/types/transactions/mod.rs
@@ -1,1 +1,2 @@
 pub mod declare;
+pub mod deploy;

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -26,13 +26,13 @@ use felt::Felt252;
 use num_traits::Zero;
 
 pub struct InternalDeploy {
-    pub(crate) hash_value: Felt252,
-    pub(crate) version: u64,
-    pub(crate) contract_address: Address,
-    pub(crate) _contract_address_salt: Address,
-    pub(crate) contract_hash: ClassHash,
-    pub(crate) constructor_calldata: Vec<Felt252>,
-    pub(crate) tx_type: TransactionType,
+    pub hash_value: Felt252,
+    pub version: u64,
+    pub contract_address: Address,
+    pub contract_address_salt: Address,
+    pub contract_hash: ClassHash,
+    pub constructor_calldata: Vec<Felt252>,
+    pub tx_type: TransactionType,
 }
 
 impl InternalDeploy {
@@ -65,15 +65,13 @@ impl InternalDeploy {
             hash_value,
             version,
             contract_address,
-            _contract_address_salt: contract_address_salt,
+            contract_address_salt,
             contract_hash,
             constructor_calldata,
             tx_type: TransactionType::Deploy,
         })
     }
 
-    // TODO: Remove warning inhibitor when finally used.
-    #[allow(dead_code)]
     pub fn class_hash(&self) -> ClassHash {
         self.contract_hash
     }
@@ -240,7 +238,7 @@ mod tests {
             hash_value: 0.into(),
             version: 0,
             contract_address: Address(1.into()),
-            _contract_address_salt: Address(0.into()),
+            contract_address_salt: Address(0.into()),
             contract_hash: class_hash,
             constructor_calldata: vec![10.into()],
             tx_type: TransactionType::Deploy,

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -49,6 +49,7 @@ pub struct InternalDeployAccount {
     version: u64,
     nonce: Felt252,
     max_fee: u64,
+    #[getset(get = "pub")]
     signature: Vec<Felt252>,
     chain_id: StarknetChainId,
 }

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -50,6 +50,8 @@ pub struct InternalDeployAccount {
     nonce: Felt252,
     max_fee: u64,
     #[getset(get = "pub")]
+    hash_value: Felt252,
+    #[getset(get = "pub")]
     signature: Vec<Felt252>,
     chain_id: StarknetChainId,
 }
@@ -66,21 +68,33 @@ impl InternalDeployAccount {
         contract_address_salt: Address,
         chain_id: StarknetChainId,
     ) -> Result<Self, SyscallHandlerError> {
-        let contract_address = calculate_contract_address(
+        let contract_address = Address(calculate_contract_address(
             &contract_address_salt,
             &Felt252::from_bytes_be(&class_hash),
             &constructor_calldata,
             Address(Felt252::zero()),
+        )?);
+
+        let hash_value = calculate_deploy_account_transaction_hash(
+            version,
+            &contract_address,
+            Felt252::from_bytes_be(&class_hash),
+            &constructor_calldata,
+            max_fee,
+            nonce.clone(),
+            contract_address_salt.0.clone(),
+            chain_id.to_felt(),
         )?;
 
         Ok(Self {
-            contract_address: Address(contract_address),
+            contract_address,
             contract_address_salt,
             class_hash,
             constructor_calldata,
             version,
             nonce,
             max_fee,
+            hash_value,
             signature,
             chain_id,
         })

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -40,7 +40,9 @@ pub struct InternalInvokeFunction {
     tx_type: TransactionType,
     version: u64,
     validate_entry_point_selector: Felt252,
+    #[getset(get = "pub")]
     hash_value: Felt252,
+    #[getset(get = "pub")]
     signature: Vec<Felt252>,
     max_fee: u64,
     nonce: Option<Felt252>,

--- a/src/services/api/contract_class.rs
+++ b/src/services/api/contract_class.rs
@@ -61,9 +61,7 @@ pub struct ContractClass {
 }
 
 impl ContractClass {
-    // TODO: Remove warning inhibitor when finally used.
-    #[allow(dead_code)]
-    pub(crate) fn new(
+    pub fn new(
         program: Program,
         entry_points_by_type: HashMap<EntryPointType, Vec<ContractEntryPoint>>,
         abi: Option<AbiType>,


### PR DESCRIPTION
~Blocked by https://github.com/lambdaclass/starknet_in_rust/pull/209~

This PR adds wrappers for `InternalDeclare`, `InternalDeploy`, `InternalDeployAccount`, and `InternalInvokeFunction`.