### PR TITLE
Update rust toolchain github action

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true


### PR DESCRIPTION
[`actions-rs/toolchain`](https://github.com/actions-rs/toolchain/tree/master) is unmantained since before 2021. This PR changes them to [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain).