### PR TITLE
Add tests for transaction objects module

### DIFF
--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -858,8 +858,8 @@ mod tests {
 
         // Use max_fee with certain value to make sure that the transaction fails due to weight resources
         let internal_declare = InternalDeclare::new(
-            fib_contract_class.clone(),
-            chain_id.clone(),
+            fib_contract_class,
+            chain_id,
             Address(Felt252::one()),
             1000,
             1,

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -587,7 +587,7 @@ mod tests {
         let chain_id = StarknetChainId::TestNet.to_felt();
         let signature = vec![1.into(), 2.into()];
 
-        // Declare tx should fail because nonce > 0 and version == 0
+        // Declare tx should fail because signature is not empty
         let internal_declare = InternalDeclare::new(
             fib_contract_class,
             chain_id,
@@ -658,7 +658,7 @@ mod tests {
             Vec::new(),
             Felt252::zero(),
         )
-        .expect("REASON");
+        .unwrap();
 
         let internal_declare_error = InternalDeclare::new(
             fib_contract_class,
@@ -669,7 +669,7 @@ mod tests {
             Vec::new(),
             Felt252::one(),
         )
-        .expect("REASON");
+        .unwrap();
 
         internal_declare
             .execute(&mut state, &StarknetGeneralConfig::default())
@@ -689,7 +689,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_transaction_invalid_nonce_should_fail() {
+    fn execute_transaction_twice_should_fail() {
         // accounts contract class must be stored before running declaration of fibonacci
         let path = PathBuf::from("starknet_programs/account_without_validation.json");
         let contract_class = ContractClass::try_from(path).unwrap();
@@ -730,17 +730,6 @@ mod tests {
 
         // Declare same class twice
         let internal_declare = InternalDeclare::new(
-            fib_contract_class.clone(),
-            chain_id.clone(),
-            Address(Felt252::one()),
-            0,
-            1,
-            Vec::new(),
-            Felt252::zero(),
-        )
-        .expect("REASON");
-
-        let internal_declare_error = InternalDeclare::new(
             fib_contract_class,
             chain_id,
             Address(Felt252::one()),
@@ -749,14 +738,14 @@ mod tests {
             Vec::new(),
             Felt252::zero(),
         )
-        .expect("REASON");
+        .unwrap();
 
         internal_declare
             .execute(&mut state, &StarknetGeneralConfig::default())
             .unwrap();
 
         let expected_error =
-            internal_declare_error.execute(&mut state, &StarknetGeneralConfig::default());
+            internal_declare.execute(&mut state, &StarknetGeneralConfig::default());
 
         // ---------------------
         //      Comparison
@@ -793,7 +782,7 @@ mod tests {
             Vec::new(),
             Felt252::zero(),
         )
-        .expect("REASON");
+        .unwrap();
 
         let internal_declare_error =
             internal_declare.execute(&mut state, &StarknetGeneralConfig::default());
@@ -855,7 +844,7 @@ mod tests {
             Vec::new(),
             Felt252::zero(),
         )
-        .expect("REASON");
+        .unwrap();
 
         assert_matches!(
             internal_declare.execute(&mut state, &StarknetGeneralConfig::default()),

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -419,4 +419,9 @@ mod tests {
             transaction_exec_info
         );
     }
+
+    #[test]
+    fn verify_version_zero_should_fail_max_fee() {
+        // create tx with version 0 and a max_fee > 0 to test error
+    }
 }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -478,4 +478,63 @@ mod tests {
         // ---------------------
         assert!(internal_declare.is_err());
     }
+
+    #[test]
+    fn verify_version_zero_should_fail_nonce() {
+        // accounts contract class must be stored before running declaration of fibonacci
+        let path = PathBuf::from("starknet_programs/account_without_validation.json");
+        let contract_class = ContractClass::try_from(path).unwrap();
+
+        // Instantiate CachedState
+        let mut contract_class_cache = HashMap::new();
+
+        //  ------------ contract data --------------------
+        let hash = compute_class_hash(&contract_class).unwrap();
+        let class_hash = felt_to_hash(&hash);
+
+        contract_class_cache.insert(class_hash, contract_class.clone());
+
+        // store sender_address
+        let sender_address = Address(1.into());
+        // this is not conceptually correct as the sender address would be an
+        // Account contract (not the contract that we are currently declaring)
+        // but for testing reasons its ok
+
+        let mut state_reader = InMemoryStateReader::default();
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(sender_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce_mut()
+            .insert(sender_address, Felt252::new(1));
+
+        let _state = CachedState::new(state_reader, Some(contract_class_cache));
+
+        //* ---------------------------------------
+        //*    Test declare with previous data
+        //* ---------------------------------------
+
+        let fib_path = PathBuf::from("starknet_programs/fibonacci.json");
+        let fib_contract_class = ContractClass::try_from(fib_path).unwrap();
+
+        let chain_id = StarknetChainId::TestNet.to_felt();
+        let nonce = Felt252::from(148);
+        let version = 0;
+
+        // Declare tx should fail because nonce > 0 and version == 0
+        let internal_declare = InternalDeclare::new(
+            fib_contract_class,
+            chain_id,
+            Address(Felt252::one()),
+            0,
+            version,
+            Vec::new(),
+            nonce,
+        );
+
+        // ---------------------
+        //      Comparison
+        // ---------------------
+        assert!(internal_declare.is_err());
+    }
 }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -258,7 +258,6 @@ impl InternalDeclare {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         let concurrent_exec_info = self.apply(state, general_config)?;
-        println!("Applied...");
         self.handle_nonce(state)?;
         // Set contract class
         match state.get_contract_class(&self.class_hash) {
@@ -478,9 +477,9 @@ mod tests {
         //      Comparison
         // ---------------------
         assert!(internal_declare.is_err());
-        assert_eq!(
-            internal_declare.unwrap_err().to_string(),
-            "The max_fee field in Declare transactions of version 0 must be 0.".to_string()
+        assert_matches!(
+            internal_declare.unwrap_err(),
+            TransactionError::StarknetError(..)
         );
     }
 
@@ -541,9 +540,9 @@ mod tests {
         //      Comparison
         // ---------------------
         assert!(internal_declare.is_err());
-        assert_eq!(
-            internal_declare.unwrap_err().to_string(),
-            "The nonce field in Declare transactions of version 0 must be 0.".to_string()
+        assert_matches!(
+            internal_declare.unwrap_err(),
+            TransactionError::StarknetError(..)
         );
     }
 
@@ -603,9 +602,9 @@ mod tests {
         //      Comparison
         // ---------------------
         assert!(internal_declare.is_err());
-        assert_eq!(
-            internal_declare.unwrap_err().to_string(),
-            "The signature field in Declare transactions must be an empty list.".to_string()
+        assert_matches!(
+            internal_declare.unwrap_err(),
+            TransactionError::StarknetError(..)
         );
     }
 
@@ -682,15 +681,10 @@ mod tests {
         // ---------------------
         //      Comparison
         // ---------------------
-
-        // Check its an error
         assert!(expected_error.is_err());
-
-        let expected_error_message = "Class hash [7, 55, 55, 162, 154, 114, 149, 224, 190, 50, 42, 227, 53, 175, 167, 128, 209, 137, 185, 51, 48, 175, 237, 255, 228, 31, 217, 227, 155, 190, 192, 57] already declared".to_string();
-        // Check error message
-        assert_eq!(
-            expected_error.unwrap_err().to_string(),
-            expected_error_message
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::ClassAlreadyDeclared(..)
         );
     }
 
@@ -768,15 +762,11 @@ mod tests {
         //      Comparison
         // ---------------------
 
-        // Check its an error
         assert!(expected_error.is_err());
-
-        let expected_error_message = "Invalid transaction nonce. Expected: 1 got 0".to_string();
-        // Check error message
-        assert_eq!(
-            expected_error.unwrap_err().to_string(),
-            expected_error_message
-        );
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::InvalidTransactionNonce(..)
+        )
     }
 
     #[test]
@@ -807,12 +797,11 @@ mod tests {
 
         let internal_declare_error =
             internal_declare.execute(&mut state, &StarknetGeneralConfig::default());
-        assert!(internal_declare_error.is_err());
 
-        let expected_error = TransactionError::NotDeployedContract([0u8; 32]);
-        assert_eq!(
-            internal_declare_error.unwrap_err().to_string(),
-            expected_error.to_string()
+        assert!(internal_declare_error.is_err());
+        assert_matches!(
+            internal_declare_error.unwrap_err(),
+            TransactionError::NotDeployedContract(..)
         );
     }
 

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -434,7 +434,7 @@ mod tests {
         let hash = compute_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class.clone());
+        contract_class_cache.insert(class_hash, contract_class);
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -497,7 +497,7 @@ mod tests {
         let hash = compute_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class.clone());
+        contract_class_cache.insert(class_hash, contract_class);
 
         // store sender_address
         let sender_address = Address(1.into());

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -693,4 +693,89 @@ mod tests {
             expected_error_message
         );
     }
+
+    #[test]
+    fn execute_transaction_invalid_nonce_should_fail() {
+        // accounts contract class must be stored before running declaration of fibonacci
+        let path = PathBuf::from("starknet_programs/account_without_validation.json");
+        let contract_class = ContractClass::try_from(path).unwrap();
+
+        // Instantiate CachedState
+        let mut contract_class_cache = HashMap::new();
+
+        //  ------------ contract data --------------------
+        let hash = compute_class_hash(&contract_class).unwrap();
+        let class_hash = felt_to_hash(&hash);
+
+        contract_class_cache.insert(class_hash, contract_class);
+
+        // store sender_address
+        let sender_address = Address(1.into());
+        // this is not conceptually correct as the sender address would be an
+        // Account contract (not the contract that we are currently declaring)
+        // but for testing reasons its ok
+
+        let mut state_reader = InMemoryStateReader::default();
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(sender_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce_mut()
+            .insert(sender_address, Felt252::zero());
+
+        let mut state = CachedState::new(state_reader, Some(contract_class_cache));
+
+        //* ---------------------------------------
+        //*    Test declare with previous data
+        //* ---------------------------------------
+
+        let fib_path = PathBuf::from("starknet_programs/fibonacci.json");
+        let fib_contract_class = ContractClass::try_from(fib_path).unwrap();
+
+        let chain_id = StarknetChainId::TestNet.to_felt();
+
+        // Declare same class twice
+        let internal_declare = InternalDeclare::new(
+            fib_contract_class.clone(),
+            chain_id.clone(),
+            Address(Felt252::one()),
+            0,
+            1,
+            Vec::new(),
+            Felt252::zero(),
+        )
+        .expect("REASON");
+
+        let internal_declare_error = InternalDeclare::new(
+            fib_contract_class.clone(),
+            chain_id,
+            Address(Felt252::one()),
+            0,
+            1,
+            Vec::new(),
+            Felt252::zero(),
+        )
+        .expect("REASON");
+
+        internal_declare
+            .execute(&mut state, &StarknetGeneralConfig::default())
+            .unwrap();
+
+        let expected_error =
+            internal_declare_error.execute(&mut state, &StarknetGeneralConfig::default());
+
+        // ---------------------
+        //      Comparison
+        // ---------------------
+
+        // Check its an error
+        assert!(expected_error.is_err());
+
+        let expected_error_message = "Invalid transaction nonce. Expected: 1 got 0".to_string();
+        // Check error message
+        assert_eq!(
+            expected_error.unwrap_err().to_string(),
+            expected_error_message
+        );
+    }
 }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -815,4 +815,62 @@ mod tests {
             expected_error.to_string()
         );
     }
+
+    #[test]
+    fn execute_transaction_charge_fee_should_fail() {
+        // accounts contract class must be stored before running declaration of fibonacci
+        let path = PathBuf::from("starknet_programs/account_without_validation.json");
+        let contract_class = ContractClass::try_from(path).unwrap();
+
+        // Instantiate CachedState
+        let mut contract_class_cache = HashMap::new();
+
+        //  ------------ contract data --------------------
+        let hash = compute_class_hash(&contract_class).unwrap();
+        let class_hash = felt_to_hash(&hash);
+
+        contract_class_cache.insert(class_hash, contract_class);
+
+        // store sender_address
+        let sender_address = Address(1.into());
+        // this is not conceptually correct as the sender address would be an
+        // Account contract (not the contract that we are currently declaring)
+        // but for testing reasons its ok
+
+        let mut state_reader = InMemoryStateReader::default();
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(sender_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce_mut()
+            .insert(sender_address, Felt252::zero());
+
+        let mut state = CachedState::new(state_reader, Some(contract_class_cache));
+
+        //* ---------------------------------------
+        //*    Test declare with previous data
+        //* ---------------------------------------
+
+        let fib_path = PathBuf::from("starknet_programs/fibonacci.json");
+        let fib_contract_class = ContractClass::try_from(fib_path).unwrap();
+
+        let chain_id = StarknetChainId::TestNet.to_felt();
+
+        // Use max_fee with certain value to make sure that the transaction fails due to weight resources
+        let internal_declare = InternalDeclare::new(
+            fib_contract_class.clone(),
+            chain_id.clone(),
+            Address(Felt252::one()),
+            1000,
+            1,
+            Vec::new(),
+            Felt252::zero(),
+        )
+        .expect("REASON");
+
+        assert_matches!(
+            internal_declare.execute(&mut state, &StarknetGeneralConfig::default()),
+            Err(TransactionError::ResourcesError { .. })
+        );
+    }
 }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -662,7 +662,7 @@ mod tests {
         .expect("REASON");
 
         let internal_declare_error = InternalDeclare::new(
-            fib_contract_class.clone(),
+            fib_contract_class,
             chain_id,
             Address(Felt252::one()),
             0,
@@ -747,7 +747,7 @@ mod tests {
         .expect("REASON");
 
         let internal_declare_error = InternalDeclare::new(
-            fib_contract_class.clone(),
+            fib_contract_class,
             chain_id,
             Address(Felt252::one()),
             0,

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -33,6 +33,7 @@ use std::collections::HashMap;
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ///  Represents an internal transaction in the StarkNet network that is a declaration of a Cairo
 ///  contract class.
+#[derive(Debug)]
 pub struct InternalDeclare {
     pub class_hash: ClassHash,
     pub sender_address: Address,
@@ -477,6 +478,10 @@ mod tests {
         //      Comparison
         // ---------------------
         assert!(internal_declare.is_err());
+        assert_eq!(
+            internal_declare.unwrap_err().to_string(),
+            "The max_fee field in Declare transactions of version 0 must be 0.".to_string()
+        );
     }
 
     #[test]
@@ -536,5 +541,9 @@ mod tests {
         //      Comparison
         // ---------------------
         assert!(internal_declare.is_err());
+        assert_eq!(
+            internal_declare.unwrap_err().to_string(),
+            "The nonce field in Declare transactions of version 0 must be 0.".to_string()
+        );
     }
 }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -795,8 +795,8 @@ mod tests {
         let chain_id = StarknetChainId::TestNet.to_felt();
 
         let internal_declare = InternalDeclare::new(
-            fib_contract_class.clone(),
-            chain_id.clone(),
+            fib_contract_class,
+            chain_id,
             Address(Felt252::one()),
             0,
             1,

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -25,6 +25,7 @@ use crate::{
 use felt::Felt252;
 use num_traits::Zero;
 
+#[derive(Debug)]
 pub struct InternalDeploy {
     pub(crate) hash_value: Felt252,
     pub(crate) version: u64,
@@ -219,20 +220,6 @@ mod tests {
         utils::calculate_sn_keccak,
     };
 
-    //make Debug trait available for InternalDeploy
-    impl std::fmt::Debug for InternalDeploy {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("InternalDeploy")
-                .field("hash_value", &self.hash_value)
-                .field("version", &self.version)
-                .field("contract_address", &self.contract_address)
-                .field("_contract_address_salt", &self._contract_address_salt)
-                .field("contract_hash", &self.contract_hash)
-                .field("constructor_calldata", &self.constructor_calldata)
-                .field("tx_type", &self.tx_type)
-                .finish()
-        }
-    }
     #[test]
     fn invoke_constructor_test() {
         // Instantiate CachedState

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -293,4 +293,38 @@ mod tests {
         let result = internal_deploy.execute(&mut state, &config);
         assert_matches!(result.unwrap_err(), TransactionError::CairoRunner(..))
     }
+
+    #[test]
+    fn deploy_contract_without_constructor_should_fail() {
+        // Instantiate CachedState
+        let state_reader = InMemoryStateReader::default();
+        let mut state = CachedState::new(state_reader, Some(Default::default()));
+
+        // Set contract_class
+        let class_hash: ClassHash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/amm.json")).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        let internal_deploy = InternalDeploy {
+            hash_value: 0.into(),
+            version: 0,
+            contract_address: Address(1.into()),
+            _contract_address_salt: Address(0.into()),
+            contract_hash: class_hash,
+            constructor_calldata: vec![10.into()],
+            tx_type: TransactionType::Deploy,
+        };
+
+        let config = Default::default();
+
+        let result = internal_deploy.execute(&mut state, &config);
+        assert_matches!(
+            result.unwrap_err(),
+            TransactionError::Starkware(StarkwareError::TransactionFailed)
+        )
+    }
 }

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -227,38 +227,42 @@ mod tests {
         let mut state = CachedState::new(state_reader, Some(Default::default()));
 
         // Set contract_class
-        let class_hash: ClassHash = [1; 32];
         let contract_class =
             ContractClass::try_from(PathBuf::from("starknet_programs/constructor.json")).unwrap();
+        let class_hash: Felt252 = compute_class_hash(&contract_class).unwrap();
+        //transform class_hash to [u8; 32]
+        let mut class_hash_bytes = [0u8; 32];
+        class_hash_bytes.copy_from_slice(&class_hash.to_bytes_be());
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(&class_hash_bytes, &contract_class)
             .unwrap();
 
-        let internal_deploy = InternalDeploy {
-            hash_value: 0.into(),
-            version: 0,
-            contract_address: Address(1.into()),
-            _contract_address_salt: Address(0.into()),
-            contract_hash: class_hash,
-            constructor_calldata: vec![10.into()],
-            tx_type: TransactionType::Deploy,
-        };
+        let internal_deploy = InternalDeploy::new(
+            Address(0.into()),
+            contract_class,
+            vec![10.into()],
+            0.into(),
+            0,
+        )
+        .unwrap();
 
         let config = Default::default();
 
         let _result = internal_deploy.apply(&mut state, &config).unwrap();
 
         assert_eq!(
-            state.get_class_hash_at(&Address(1.into())).unwrap(),
-            &class_hash
+            state
+                .get_class_hash_at(&internal_deploy.contract_address)
+                .unwrap(),
+            &class_hash_bytes
         );
 
         let storage_key = calculate_sn_keccak("owner".as_bytes());
 
         assert_eq!(
             state
-                .get_storage_at(&(Address(1.into()), storage_key))
+                .get_storage_at(&(internal_deploy.contract_address, storage_key))
                 .unwrap(),
             &Felt252::from(10)
         );
@@ -271,23 +275,21 @@ mod tests {
         let mut state = CachedState::new(state_reader, Some(Default::default()));
 
         // Set contract_class
-        let class_hash: ClassHash = [1; 32];
         let contract_class =
             ContractClass::try_from(PathBuf::from("starknet_programs/constructor.json")).unwrap();
 
+        let class_hash: Felt252 = compute_class_hash(&contract_class).unwrap();
+        //transform class_hash to [u8; 32]
+        let mut class_hash_bytes = [0u8; 32];
+        class_hash_bytes.copy_from_slice(&class_hash.to_bytes_be());
+
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(&class_hash_bytes, &contract_class)
             .unwrap();
 
-        let internal_deploy = InternalDeploy {
-            hash_value: 0.into(),
-            version: 0,
-            contract_address: Address(1.into()),
-            _contract_address_salt: Address(0.into()),
-            contract_hash: class_hash,
-            constructor_calldata: Vec::new(),
-            tx_type: TransactionType::Deploy,
-        };
+        let internal_deploy =
+            InternalDeploy::new(Address(0.into()), contract_class, Vec::new(), 0.into(), 0)
+                .unwrap();
 
         let config = Default::default();
 
@@ -302,23 +304,26 @@ mod tests {
         let mut state = CachedState::new(state_reader, Some(Default::default()));
 
         // Set contract_class
-        let class_hash: ClassHash = [1; 32];
         let contract_class =
             ContractClass::try_from(PathBuf::from("starknet_programs/amm.json")).unwrap();
 
+        let class_hash: Felt252 = compute_class_hash(&contract_class).unwrap();
+        //transform class_hash to [u8; 32]
+        let mut class_hash_bytes = [0u8; 32];
+        class_hash_bytes.copy_from_slice(&class_hash.to_bytes_be());
+
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(&class_hash_bytes, &contract_class)
             .unwrap();
 
-        let internal_deploy = InternalDeploy {
-            hash_value: 0.into(),
-            version: 0,
-            contract_address: Address(1.into()),
-            _contract_address_salt: Address(0.into()),
-            contract_hash: class_hash,
-            constructor_calldata: vec![10.into()],
-            tx_type: TransactionType::Deploy,
-        };
+        let internal_deploy = InternalDeploy::new(
+            Address(0.into()),
+            contract_class,
+            vec![10.into()],
+            0.into(),
+            0,
+        )
+        .unwrap();
 
         let config = Default::default();
 

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -430,4 +430,36 @@ mod tests {
             TransactionError::State(StateError::ContractAddressUnavailable(..))
         )
     }
+
+    #[test]
+    #[should_panic]
+    // Should panic at no calldata for constructor. Error managment not implemented yet.
+    fn deploy_account_constructor_should_fail() {
+        let path = PathBuf::from("starknet_programs/constructor.json");
+        let contract = ContractClass::try_from(path).unwrap();
+
+        let hash = compute_class_hash(&contract).unwrap();
+        let class_hash = felt_to_hash(&hash);
+
+        let general_config = StarknetGeneralConfig::default();
+        let mut state = CachedState::new(InMemoryStateReader::default(), Some(Default::default()));
+
+        let internal_deploy = InternalDeployAccount::new(
+            class_hash,
+            0,
+            0,
+            0.into(),
+            Vec::new(),
+            Vec::new(),
+            Address(0.into()),
+            StarknetChainId::TestNet2,
+        )
+        .unwrap();
+
+        let class_hash = internal_deploy.class_hash();
+        state.set_contract_class(class_hash, &contract).unwrap();
+        internal_deploy
+            .execute(&mut state, &general_config)
+            .unwrap();
+    }
 }

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -486,6 +486,110 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_invoke_entrypoint_not_found_should_fail() {
+        let internal_invoke_function = InternalInvokeFunction {
+            contract_address: Address(0.into()),
+            entry_point_selector: (*EXECUTE_ENTRY_POINT_SELECTOR).clone(),
+            entry_point_type: EntryPointType::External,
+            calldata: Vec::new(),
+            tx_type: TransactionType::InvokeFunction,
+            version: 0,
+            validate_entry_point_selector: 0.into(),
+            hash_value: 0.into(),
+            signature: Vec::new(),
+            max_fee: 0,
+            nonce: Some(0.into()),
+        };
+
+        // Instantiate CachedState
+        let mut state_reader = InMemoryStateReader::default();
+        // Set contract_class
+        let class_hash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/amm.json")).unwrap();
+        // Set contact_state
+        let contract_address = Address(0.into());
+        let nonce = Felt252::zero();
+
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(contract_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce
+            .insert(contract_address, nonce);
+
+        let mut state = CachedState::new(state_reader.clone(), None);
+
+        // Initialize state.contract_classes
+        state.set_contract_classes(HashMap::new()).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        let expected_error =
+            internal_invoke_function.apply(&mut state, &StarknetGeneralConfig::default());
+
+        assert!(expected_error.is_err());
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::EntryPointNotFound
+        );
+    }
+
+    #[test]
+    fn test_run_validate_entrypoint_nonce_is_none_should_fail() {
+        let internal_invoke_function = InternalInvokeFunction {
+            contract_address: Address(0.into()),
+            entry_point_selector: (*EXECUTE_ENTRY_POINT_SELECTOR).clone(),
+            entry_point_type: EntryPointType::External,
+            calldata: Vec::new(),
+            tx_type: TransactionType::InvokeFunction,
+            version: 1,
+            validate_entry_point_selector: 0.into(),
+            hash_value: 0.into(),
+            signature: Vec::new(),
+            max_fee: 0,
+            nonce: None,
+        };
+
+        // Instantiate CachedState
+        let mut state_reader = InMemoryStateReader::default();
+        // Set contract_class
+        let class_hash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/amm.json")).unwrap();
+        // Set contact_state
+        let contract_address = Address(0.into());
+        let nonce = Felt252::zero();
+
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(contract_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce
+            .insert(contract_address, nonce);
+
+        let mut state = CachedState::new(state_reader.clone(), None);
+
+        // Initialize state.contract_classes
+        state.set_contract_classes(HashMap::new()).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        let expected_error =
+            internal_invoke_function.apply(&mut state, &StarknetGeneralConfig::default());
+
+        assert!(expected_error.is_err());
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::InvalidTxContext
+        );
+    }
+
+    #[test]
     // Test fee calculation is done correctly but payment to sequencer fails due to been WIP.
     fn test_execute_invoke_fee_payment_to_sequencer_should_fail() {
         let internal_invoke_function = InternalInvokeFunction {
@@ -540,9 +644,69 @@ mod tests {
         ]);
 
         let expected_error = internal_invoke_function.execute(&mut state, &config);
-
+        let error_msg = "Fee transfer failure".to_string();
         assert!(expected_error.is_err());
-        assert_matches!(expected_error.unwrap_err(), TransactionError::FeeError(_));
+        assert_matches!(expected_error.unwrap_err(), TransactionError::FeeError(msg) if msg == error_msg);
+    }
+
+    #[test]
+    fn test_execute_invoke_actual_fee_exceeded_max_fee_should_fail() {
+        let internal_invoke_function = InternalInvokeFunction {
+            contract_address: Address(0.into()),
+            entry_point_selector: Felt252::from_str_radix(
+                "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+                16,
+            )
+            .unwrap(),
+            entry_point_type: EntryPointType::External,
+            calldata: vec![1.into(), 1.into(), 10.into()],
+            tx_type: TransactionType::InvokeFunction,
+            version: 1,
+            validate_entry_point_selector: 0.into(),
+            hash_value: 0.into(),
+            signature: Vec::new(),
+            max_fee: 1000,
+            nonce: Some(0.into()),
+        };
+
+        // Instantiate CachedState
+        let mut state_reader = InMemoryStateReader::default();
+        // Set contract_class
+        let class_hash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/fibonacci.json")).unwrap();
+        // Set contact_state
+        let contract_address = Address(0.into());
+        let nonce = Felt252::zero();
+
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(contract_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce
+            .insert(contract_address, nonce);
+
+        let mut state = CachedState::new(state_reader.clone(), None);
+
+        // Initialize state.contract_classes
+        state.set_contract_classes(HashMap::new()).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        let mut config = StarknetGeneralConfig::default();
+        config.cairo_resource_fee_weights = HashMap::from([
+            (String::from("l1_gas_usage"), 0.into()),
+            (String::from("pedersen_builtin"), 16.into()),
+            (String::from("range_check_builtin"), 70.into()),
+        ]);
+        config.starknet_os_config.gas_price = 1;
+
+        let expected_error = internal_invoke_function.execute(&mut state, &config);
+        let error_msg = "Actual fee exceeded max fee.".to_string();
+        assert!(expected_error.is_err());
+        assert_matches!(expected_error.unwrap_err(), TransactionError::FeeError(actual_error_msg) if actual_error_msg == error_msg);
     }
 
     #[test]

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -416,4 +416,257 @@ mod tests {
         );
         assert_eq!(result.call_info.unwrap().retdata, vec![Felt252::new(144)]);
     }
+
+    #[test]
+    fn test_execute_specific_concurrent_changes() {
+        let internal_invoke_function = InternalInvokeFunction {
+            contract_address: Address(0.into()),
+            entry_point_selector: Felt252::from_str_radix(
+                "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+                16,
+            )
+            .unwrap(),
+            entry_point_type: EntryPointType::External,
+            calldata: vec![1.into(), 1.into(), 10.into()],
+            tx_type: TransactionType::InvokeFunction,
+            version: 0,
+            validate_entry_point_selector: 0.into(),
+            hash_value: 0.into(),
+            signature: Vec::new(),
+            max_fee: 0,
+            nonce: Some(0.into()),
+        };
+
+        // Instantiate CachedState
+        let mut state_reader = InMemoryStateReader::default();
+        // Set contract_class
+        let class_hash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/fibonacci.json")).unwrap();
+        // Set contact_state
+        let contract_address = Address(0.into());
+        let nonce = Felt252::zero();
+
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(contract_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce
+            .insert(contract_address, nonce);
+
+        let mut state = CachedState::new(state_reader.clone(), None);
+
+        // Initialize state.contract_classes
+        state.set_contract_classes(HashMap::new()).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        let result = internal_invoke_function
+            .execute(&mut state, &StarknetGeneralConfig::default())
+            .unwrap();
+
+        assert_eq!(result.tx_type, Some(TransactionType::InvokeFunction));
+        assert_eq!(
+            result.call_info.as_ref().unwrap().class_hash,
+            Some(class_hash)
+        );
+        assert_eq!(
+            result.call_info.as_ref().unwrap().entry_point_selector,
+            Some(internal_invoke_function.entry_point_selector)
+        );
+        assert_eq!(
+            result.call_info.as_ref().unwrap().calldata,
+            internal_invoke_function.calldata
+        );
+        assert_eq!(result.call_info.unwrap().retdata, vec![Felt252::new(144)]);
+    }
+
+    #[test]
+    fn test_execute_invoke_max_fee_non_zero_should_fail() {
+        let internal_invoke_function = InternalInvokeFunction {
+            contract_address: Address(0.into()),
+            entry_point_selector: Felt252::from_str_radix(
+                "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+                16,
+            )
+            .unwrap(),
+            entry_point_type: EntryPointType::External,
+            calldata: vec![1.into(), 1.into(), 10.into()],
+            tx_type: TransactionType::InvokeFunction,
+            version: 1,
+            validate_entry_point_selector: 0.into(),
+            hash_value: 0.into(),
+            signature: Vec::new(),
+            max_fee: 1000,
+            nonce: Some(0.into()),
+        };
+
+        // Instantiate CachedState
+        let mut state_reader = InMemoryStateReader::default();
+        // Set contract_class
+        let class_hash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/fibonacci.json")).unwrap();
+        // Set contact_state
+        let contract_address = Address(0.into());
+        let nonce = Felt252::zero();
+
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(contract_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce
+            .insert(contract_address, nonce);
+
+        let mut state = CachedState::new(state_reader.clone(), None);
+
+        // Initialize state.contract_classes
+        state.set_contract_classes(HashMap::new()).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        let expected_error =
+            internal_invoke_function.execute(&mut state, &StarknetGeneralConfig::default());
+
+        assert!(expected_error.is_err());
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::ResourcesError
+        );
+    }
+
+    #[test]
+    fn test_execute_invoke_twice_should_fail() {
+        let internal_invoke_function = InternalInvokeFunction {
+            contract_address: Address(0.into()),
+            entry_point_selector: Felt252::from_str_radix(
+                "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+                16,
+            )
+            .unwrap(),
+            entry_point_type: EntryPointType::External,
+            calldata: vec![1.into(), 1.into(), 10.into()],
+            tx_type: TransactionType::InvokeFunction,
+            version: 1,
+            validate_entry_point_selector: 0.into(),
+            hash_value: 0.into(),
+            signature: Vec::new(),
+            max_fee: 0,
+            nonce: Some(0.into()),
+        };
+
+        // Instantiate CachedState
+        let mut state_reader = InMemoryStateReader::default();
+        // Set contract_class
+        let class_hash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/fibonacci.json")).unwrap();
+        // Set contact_state
+        let contract_address = Address(0.into());
+        let nonce = Felt252::zero();
+
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(contract_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce
+            .insert(contract_address, nonce);
+
+        let mut state = CachedState::new(state_reader.clone(), None);
+
+        // Initialize state.contract_classes
+        state.set_contract_classes(HashMap::new()).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        internal_invoke_function
+            .execute(&mut state, &StarknetGeneralConfig::default())
+            .unwrap();
+
+        let expected_error =
+            internal_invoke_function.execute(&mut state, &StarknetGeneralConfig::default());
+
+        assert!(expected_error.is_err());
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::InvalidTransactionNonce(..)
+        )
+    }
+
+    #[test]
+    fn test_execute_inovoke_nonce_missing_should_fail() {
+        let internal_invoke_function = InternalInvokeFunction {
+            contract_address: Address(0.into()),
+            entry_point_selector: Felt252::from_str_radix(
+                "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+                16,
+            )
+            .unwrap(),
+            entry_point_type: EntryPointType::External,
+            calldata: vec![1.into(), 1.into(), 10.into()],
+            tx_type: TransactionType::InvokeFunction,
+            version: 1,
+            validate_entry_point_selector: 0.into(),
+            hash_value: 0.into(),
+            signature: Vec::new(),
+            max_fee: 0,
+            nonce: None,
+        };
+
+        // Instantiate CachedState
+        let mut state_reader = InMemoryStateReader::default();
+        // Set contract_class
+        let class_hash = [1; 32];
+        let contract_class =
+            ContractClass::try_from(PathBuf::from("starknet_programs/fibonacci.json")).unwrap();
+        // Set contact_state
+        let contract_address = Address(0.into());
+        let nonce = Felt252::zero();
+
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(contract_address.clone(), class_hash);
+        state_reader
+            .address_to_nonce
+            .insert(contract_address, nonce);
+
+        let mut state = CachedState::new(state_reader.clone(), None);
+
+        // Initialize state.contract_classes
+        state.set_contract_classes(HashMap::new()).unwrap();
+
+        state
+            .set_contract_class(&class_hash, &contract_class)
+            .unwrap();
+
+        let expected_error =
+            internal_invoke_function.execute(&mut state, &StarknetGeneralConfig::default());
+
+        assert!(expected_error.is_err());
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::InvalidTxContext
+        )
+    }
+
+    #[test]
+    fn invoke_version_zero_with_non_zero_nonce_should_fail() {
+        let expected_error = preprocess_invoke_function_fields(
+            Felt252::from_str_radix(
+                "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+                16,
+            )
+            .unwrap(),
+            Some(1.into()),
+            0,
+        )
+        .unwrap_err();
+        assert_matches!(expected_error, TransactionError::InvokeFunctionZeroHasNonce)
+    }
 }


### PR DESCRIPTION
This PR adds tests for the transaction objects module:
* internal_declare.rs
* internal_deploy_account.rs
* internal_deploy.rs
* internal_invoke_function.rs