### PR TITLE
[pyo3] Reexport some cairo-lang classes and fix patch

### DIFF
--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -256,7 +256,7 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("DEFAULT_MAX_STEPS", DEFAULT_VALIDATE_MAX_N_STEPS)?;
     m.add("DEFAULT_VALIDATE_MAX_STEPS", DEFAULT_VALIDATE_MAX_N_STEPS)?;
 
-    m.add("DEFAULT_CHAIN_ID", PyStarknetChainId::testnet())?;
+    m.add("DEFAULT_CHAIN_ID", PyStarknetChainId::TestNet)?;
     m.add(
         "DEFAULT_SEQUENCER_ADDRESS",
         DEFAULT_SEQUENCER_ADDRESS.0.to_biguint(),

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -91,6 +91,17 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
         ],
     )?;
 
+    reexport(
+        py,
+        m,
+        "starkware.starknet.services.api.feeder_gateway.response_objects",
+        vec![
+            "DeployedContract",
+            "FeeEstimationInfo",
+            "StorageEntry", // alias Tuple[int, int]
+        ],
+    )?;
+
     //  starkware.starknet.public.abi
     // m.add_class::<PyAbiEntryType>()?;
 
@@ -111,10 +122,7 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     // m.add_class::<PyTransactionTrace>()?;
     // m.add_class::<PyTransactionExecution>()?;
     // m.add_class::<PyTransactionSpecificInfo>()?;
-    // m.add_class::<PyFeeEstimationInfo>()?;
-    // m.add_class::<PyDeployedContract>()?;
     // m.add_class::<PyStateDiff>()?;
-    // m.add_class::<PyStorageEntry>()?;
     // m.add_class::<PyEvent>()?;
     // m.add_class::<PyFunctionInvocation>()?;
     // m.add_class::<PyL2ToL1Message>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -75,6 +75,18 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
         "starkware.starknet.definitions.error_codes",
         vec!["StarknetErrorCode"],
     )?;
+    reexport(
+        py,
+        m,
+        "starkware.starknet.services.api.gateway.transaction",
+        vec![
+            "AccountTransaction",
+            "Declare",
+            "DeployAccount",
+            "InvokeFunction",
+            "Deploy",
+        ],
+    )?;
 
     //  starkware.starknet.public.abi
     // m.add_class::<PyAbiEntryType>()?;
@@ -118,13 +130,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
 
     //  starkware.starknet.services.api.feeder_gateway.feeder_gateway_client
     // m.add_class::<PyFeederGatewayClient>()?;
-
-    //  starkware.starknet.services.api.gateway.transaction
-    // m.add_class::<PyAccountTransaction>()?;
-    // m.add_class::<PyDeclare>()?;
-    // m.add_class::<PyDeployAccount>()?;
-    // m.add_class::<PyInvokeFunction>()?;
-    // m.add_class::<PyDeploy>()?;
 
     //  starkware.starknet.business_logic.transaction.objects
     // m.add_class::<PyInternalL1Handler>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -5,8 +5,6 @@ mod starknet_state;
 mod types;
 mod utils;
 
-use std::ops::Shl;
-
 use self::{
     cached_state::PyCachedState,
     types::{
@@ -15,14 +13,17 @@ use self::{
         ordered_event::PyOrderedEvent, ordered_l2_to_l1_message::PyOrderedL2ToL1Message,
     },
 };
-use crate::utils::transaction_hash::{
-    py_calculate_declare_transaction_hash, py_calculate_deploy_transaction_hash,
-    py_calculate_transaction_hash_common, PyTransactionHashPrefix,
-};
 use crate::utils::{
     py_calculate_contract_address, py_calculate_contract_address_from_hash,
     py_calculate_event_hash, py_calculate_tx_fee, py_compute_class_hash,
     py_validate_contract_deployed,
+};
+use crate::{
+    types::transaction::{PyTransaction, PyTransactionType},
+    utils::transaction_hash::{
+        py_calculate_declare_transaction_hash, py_calculate_deploy_transaction_hash,
+        py_calculate_transaction_hash_common, PyTransactionHashPrefix,
+    },
 };
 use cairo_felt::{felt_str, Felt252};
 use pyo3::prelude::*;
@@ -34,6 +35,7 @@ use starknet_rs::{
     },
     services::api::contract_class::ContractClass,
 };
+use std::ops::Shl;
 
 use starknet_state::PyStarknetState;
 use types::general_config::{PyStarknetChainId, PyStarknetGeneralConfig, PyStarknetOsConfig};
@@ -64,8 +66,15 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyCallInfo>()?;
 
     m.add_class::<PyTransactionHashPrefix>()?;
+    m.add_class::<PyTransaction>()?;
+    m.add_class::<PyTransactionType>()?;
 
-    // m.add_function(build_general_config)?;
+    reexport(
+        py,
+        m,
+        "starkware.starknet.definitions.error_codes",
+        vec!["StarknetErrorCode"],
+    )?;
 
     //  starkware.starknet.public.abi
     // m.add_class::<PyAbiEntryType>()?;
@@ -73,9 +82,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     //  starkware.starknet.testing.starknet
     // m.add_class::<PyStarknet>()?;
     // m.add_class::<PyStarknetCallInfo>()?; // doesn't seem necessary
-
-    //  starkware.starknet.definitions.error_codes
-    // m.add_class::<PyStarknetErrorCode>()?;
 
     //  starkware.starknet.services.api.feeder_gateway.response_objects
     // m.add_class::<PyBlockIdentifier>()?; this one is a Python Union
@@ -119,7 +125,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     // m.add_class::<PyDeployAccount>()?;
     // m.add_class::<PyInvokeFunction>()?;
     // m.add_class::<PyDeploy>()?;
-    // m.add_class::<PyTransaction>()?;
 
     //  starkware.starknet.business_logic.transaction.objects
     // m.add_class::<PyInternalL1Handler>()?;
@@ -133,9 +138,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
 
     //  starkware.starknet.testing.contract
     // m.add_class::<PyStarknetContract>()?;
-
-    //  starkware.starknet.definitions.transaction_type
-    // m.add_class::<PyTransactionType>()?;
 
     //  starkware.starknet.services.api.feeder_gateway.request_objects
     // m.add_class::<PyCallFunction>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -98,49 +98,67 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
         vec![
             "DeployedContract",
             "FeeEstimationInfo",
-            "StorageEntry", // alias Tuple[int, int]
+            "StorageEntry",    // alias Tuple[int, int]
+            "BlockIdentifier", // Union[int, Literal["latest"], Literal["pending"]]
+            "StateDiff",
+            "BlockStateUpdate",
+            "BlockStatus",
+            "BlockTransactionTraces",
+            "TransactionSimulationInfo",
+            "StarknetBlock",
+            "TransactionInfo",
+            "TransactionReceipt",
+            "TransactionStatus",
+            "TransactionTrace",
+            "TransactionExecution",
+            "TransactionSpecificInfo",
+            "Event",
+            "FunctionInvocation",
+            "L2ToL1Message",
+            "DeclareSpecificInfo",
+            "DeployAccountSpecificInfo",
+            "DeploySpecificInfo",
+            "InvokeSpecificInfo",
+            "L1HandlerSpecificInfo",
         ],
     )?;
 
-    //  starkware.starknet.public.abi
-    // m.add_class::<PyAbiEntryType>()?;
+    reexport(
+        py,
+        m,
+        "starkware.starknet.public.abi",
+        vec![
+            "AbiEntryType", // alias Dict[str, Any]
+        ],
+    )?;
 
-    //  starkware.starknet.testing.starknet
-    // m.add_class::<PyStarknet>()?;
-    // m.add_class::<PyStarknetCallInfo>()?; // doesn't seem necessary
+    reexport(
+        py,
+        m,
+        "starkware.starknet.testing.starknet",
+        vec!["Starknet", "StarknetCallInfo"],
+    )?;
 
-    //  starkware.starknet.services.api.feeder_gateway.response_objects
-    // m.add_class::<PyBlockIdentifier>()?; this one is a Python Union
-    // m.add_class::<PyBlockStateUpdate>()?;
-    // m.add_class::<PyBlockStatus>()?;
-    // m.add_class::<PyBlockTransactionTraces>()?;
-    // m.add_class::<PyTransactionSimulationInfo>()?;
-    // m.add_class::<PyStarknetBlock>()?;
-    // m.add_class::<PyTransactionInfo>()?;
-    // m.add_class::<PyTransactionReceipt>()?;
-    // m.add_class::<PyTransactionStatus>()?;
-    // m.add_class::<PyTransactionTrace>()?;
-    // m.add_class::<PyTransactionExecution>()?;
-    // m.add_class::<PyTransactionSpecificInfo>()?;
-    // m.add_class::<PyStateDiff>()?;
-    // m.add_class::<PyEvent>()?;
-    // m.add_class::<PyFunctionInvocation>()?;
-    // m.add_class::<PyL2ToL1Message>()?;
-    // m.add_class::<PyDeclareSpecificInfo>()?;
-    // m.add_class::<PyDeployAccountSpecificInfo>()?;
-    // m.add_class::<PyDeploySpecificInfo>()?;
-    // m.add_class::<PyInvokeSpecificInfo>()?;
-    // m.add_class::<PyL1HandlerSpecificInfo>()?;
+    reexport(
+        py,
+        m,
+        "starkware.starknet.business_logic.execution.objects",
+        vec!["ResourcesMapping"],
+    )?;
 
-    //  starkware.starknet.business_logic.execution.objects
-    // m.add_class::<PyResourcesMapping>()?;
+    reexport(
+        py,
+        m,
+        "starkware.starknet.business_logic.state.state_api",
+        vec!["SyncState", "StateReader"],
+    )?;
 
-    //  starkware.starknet.business_logic.state.state_api
-    // m.add_class::<PySyncState>()?;
-    // m.add_class::<PyStateReader>()?;
-
-    //  starkware.starknet.services.api.feeder_gateway.feeder_gateway_client
-    // m.add_class::<PyFeederGatewayClient>()?;
+    reexport(
+        py,
+        m,
+        "starkware.starknet.services.api.feeder_gateway.feeder_gateway_client",
+        vec!["FeederGatewayClient"],
+    )?;
 
     //  starkware.starknet.business_logic.transaction.objects
     // m.add_class::<PyInternalL1Handler>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -126,6 +126,20 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     reexport(
         py,
         m,
+        "starkware.starknet.services.api.feeder_gateway.request_objects",
+        vec!["CallL1Handler", "CallFunction"],
+    )?;
+
+    reexport(
+        py,
+        m,
+        "starkware.starknet.services.api.feeder_gateway.feeder_gateway_client",
+        vec!["FeederGatewayClient"],
+    )?;
+
+    reexport(
+        py,
+        m,
         "starkware.starknet.public.abi",
         vec![
             "AbiEntryType", // alias Dict[str, Any]
@@ -153,13 +167,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
         vec!["SyncState", "StateReader"],
     )?;
 
-    reexport(
-        py,
-        m,
-        "starkware.starknet.services.api.feeder_gateway.feeder_gateway_client",
-        vec!["FeederGatewayClient"],
-    )?;
-
     // TODO: check
     reexport(
         py,
@@ -184,10 +191,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     // m.add_class::<PyInternalInvokeFunction>()?;
     // m.add_class::<PyInternalTransaction>()?;
     // m.add_class::<PyTransactionExecutionInfo>()?;
-
-    //  starkware.starknet.services.api.feeder_gateway.request_objects
-    // m.add_class::<PyCallFunction>()?;
-    // m.add_class::<PyCallL1Handler>()?;
 
     //  starkware.starknet.services.api.messages
     // m.add_class::<PyStarknetMessageToL1>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -14,18 +14,18 @@ use self::{
     },
 };
 use crate::{
-    types::general_config::build_general_config,
-    utils::{
-        py_calculate_contract_address, py_calculate_contract_address_from_hash,
-        py_calculate_event_hash, py_calculate_tx_fee, py_compute_class_hash,
-        py_validate_contract_deployed,
-    },
-};
-use crate::{
     types::transaction::{PyTransaction, PyTransactionType},
     utils::transaction_hash::{
         py_calculate_declare_transaction_hash, py_calculate_deploy_transaction_hash,
         py_calculate_transaction_hash_common, PyTransactionHashPrefix,
+    },
+};
+use crate::{
+    types::{general_config::build_general_config, starknet_message_to_l1::PyStarknetMessageToL1},
+    utils::{
+        py_calculate_contract_address, py_calculate_contract_address_from_hash,
+        py_calculate_event_hash, py_calculate_tx_fee, py_compute_class_hash,
+        py_validate_contract_deployed,
     },
 };
 use cairo_felt::{felt_str, Felt252};
@@ -71,6 +71,11 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyTransactionHashPrefix>()?;
     m.add_class::<PyTransaction>()?;
     m.add_class::<PyTransactionType>()?;
+
+    m.add_class::<PyStarknetMessageToL1>()?;
+
+    //  starkware.starknet.business_logic.transaction.objects
+    // m.add_class::<PyInternalL1Handler>()?;  // isn't implemented
 
     reexport(
         py,
@@ -171,20 +176,8 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
         py,
         m,
         "starkware.starknet.business_logic.transaction.objects",
-        vec!["InternalAccountTransaction"],
+        vec!["InternalAccountTransaction", "InternalTransaction"],
     )?;
-
-    //  starkware.starknet.business_logic.transaction.objects
-    // m.add_class::<PyInternalL1Handler>()?;
-    // m.add_class::<PyInternalDeclare>()?;
-    // m.add_class::<PyInternalDeploy>()?;
-    // m.add_class::<PyInternalDeployAccount>()?;
-    // m.add_class::<PyInternalInvokeFunction>()?;
-    // m.add_class::<PyInternalTransaction>()?;
-    // m.add_class::<PyTransactionExecutionInfo>()?;
-
-    //  starkware.starknet.services.api.messages
-    // m.add_class::<PyStarknetMessageToL1>()?;
 
     // ~~~~~~~~~~~~~~~~~~~~
     //  Exported Functions

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -160,18 +160,30 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
         vec!["FeederGatewayClient"],
     )?;
 
+    // TODO: check
+    reexport(
+        py,
+        m,
+        "starkware.starknet.testing.contract",
+        vec!["StarknetContract"],
+    )?;
+
+    // TODO: check
+    reexport(
+        py,
+        m,
+        "starkware.starknet.business_logic.transaction.objects",
+        vec!["InternalAccountTransaction"],
+    )?;
+
     //  starkware.starknet.business_logic.transaction.objects
     // m.add_class::<PyInternalL1Handler>()?;
-    // m.add_class::<PyInternalAccountTransaction>()?;
     // m.add_class::<PyInternalDeclare>()?;
     // m.add_class::<PyInternalDeploy>()?;
     // m.add_class::<PyInternalDeployAccount>()?;
     // m.add_class::<PyInternalInvokeFunction>()?;
     // m.add_class::<PyInternalTransaction>()?;
     // m.add_class::<PyTransactionExecutionInfo>()?;
-
-    //  starkware.starknet.testing.contract
-    // m.add_class::<PyStarknetContract>()?;
 
     //  starkware.starknet.services.api.feeder_gateway.request_objects
     // m.add_class::<PyCallFunction>()?;

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -198,10 +198,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(build_general_config, m)?)?;
 
-    //  starkware.starknet.wallets.open_zeppelin
-    // m.add_function(sign_deploy_account_tx)?;  blocked by PyDeployAccount
-    // m.add_function(sign_invoke_tx)?;          blocked by PyInvokeFunction
-
     m.add_function(wrap_pyfunction!(py_calculate_transaction_hash_common, m)?)?;
     m.add_function(wrap_pyfunction!(py_calculate_declare_transaction_hash, m)?)?;
     m.add_function(wrap_pyfunction!(py_calculate_deploy_transaction_hash, m)?)?;
@@ -214,6 +210,13 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_validate_contract_deployed, m)?)?;
     m.add_function(wrap_pyfunction!(py_compute_class_hash, m)?)?;
     m.add_function(wrap_pyfunction!(py_calculate_tx_fee, m)?)?;
+
+    reexport(
+        py,
+        m,
+        "starkware.starknet.wallets.open_zeppelin",
+        vec!["sign_deploy_account_tx", "sign_invoke_tx"],
+    )?;
 
     // TODO: export from starknet-rs when implemented
     reexport(

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -140,15 +140,6 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     reexport(
         py,
         m,
-        "starkware.starknet.public.abi",
-        vec![
-            "AbiEntryType", // alias Dict[str, Any]
-        ],
-    )?;
-
-    reexport(
-        py,
-        m,
         "starkware.starknet.testing.starknet",
         vec!["Starknet", "StarknetCallInfo"],
     )?;
@@ -221,12 +212,16 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
         vec!["sign_deploy_account_tx", "sign_invoke_tx"],
     )?;
 
-    // TODO: export from starknet-rs when implemented
     reexport(
         py,
         m,
         "starkware.starknet.public.abi",
-        vec!["get_selector_from_name", "get_storage_var_address"],
+        vec![
+            "AbiEntryType", // alias Dict[str, Any]
+            // TODO: export from starknet-rs when implemented
+            "get_selector_from_name",
+            "get_storage_var_address",
+        ],
     )?;
 
     // TODO: export from starknet-rs when implemented

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -13,10 +13,13 @@ use self::{
         ordered_event::PyOrderedEvent, ordered_l2_to_l1_message::PyOrderedL2ToL1Message,
     },
 };
-use crate::utils::{
-    py_calculate_contract_address, py_calculate_contract_address_from_hash,
-    py_calculate_event_hash, py_calculate_tx_fee, py_compute_class_hash,
-    py_validate_contract_deployed,
+use crate::{
+    types::general_config::build_general_config,
+    utils::{
+        py_calculate_contract_address, py_calculate_contract_address_from_hash,
+        py_calculate_event_hash, py_calculate_tx_fee, py_compute_class_hash,
+        py_validate_contract_deployed,
+    },
 };
 use crate::{
     types::transaction::{PyTransaction, PyTransactionType},
@@ -155,7 +158,7 @@ pub fn starknet_rs_py(py: Python, m: &PyModule) -> PyResult<()> {
     //  Exported Functions
     // ~~~~~~~~~~~~~~~~~~~~
 
-    // m.add_function(build_general_config)?;    needs to be manually implemented
+    m.add_function(wrap_pyfunction!(build_general_config, m)?)?;
 
     //  starkware.starknet.wallets.open_zeppelin
     // m.add_function(sign_deploy_account_tx)?;  blocked by PyDeployAccount

--- a/crates/starknet-rs-py/src/types.rs
+++ b/crates/starknet-rs-py/src/types.rs
@@ -6,5 +6,6 @@ pub mod execution_resources;
 pub mod general_config;
 pub mod ordered_event;
 pub mod ordered_l2_to_l1_message;
+pub mod starknet_message_to_l1;
 pub mod transaction;
 pub mod transaction_execution_info;

--- a/crates/starknet-rs-py/src/types/general_config.rs
+++ b/crates/starknet-rs-py/src/types/general_config.rs
@@ -132,7 +132,7 @@ impl From<StarknetOsConfig> for PyStarknetOsConfig {
 impl PyStarknetOsConfig {
     #[new]
     #[pyo3(signature = (
-        chain_id = PyStarknetChainId::testnet(),
+        chain_id = PyStarknetChainId::TestNet,
         fee_token_address = DEFAULT_STARKNET_OS_CONFIG.fee_token_address().0.to_biguint(),
     ))]
     fn new(chain_id: PyStarknetChainId, fee_token_address: BigUint) -> Self {
@@ -148,59 +148,49 @@ impl From<PyStarknetGeneralConfig> for StarknetGeneralConfig {
     }
 }
 
-#[pyclass]
-#[pyo3(name = "StarknetChainId")]
+#[pyclass(name = "StarknetChainId")]
 #[derive(Debug, Clone, Copy)]
-pub struct PyStarknetChainId {
-    inner: StarknetChainId,
+pub enum PyStarknetChainId {
+    #[pyo3(name = "MAINNET")]
+    MainNet,
+    #[pyo3(name = "TESTNET")]
+    TestNet,
+    #[pyo3(name = "TESTNET2")]
+    TestNet2,
 }
 
 impl From<StarknetChainId> for PyStarknetChainId {
-    fn from(inner: StarknetChainId) -> Self {
-        Self { inner }
+    fn from(chain_id: StarknetChainId) -> Self {
+        match chain_id {
+            StarknetChainId::MainNet => Self::MainNet,
+            StarknetChainId::TestNet => Self::TestNet,
+            StarknetChainId::TestNet2 => Self::TestNet2,
+        }
     }
 }
 
 impl From<PyStarknetChainId> for StarknetChainId {
     fn from(chain_id: PyStarknetChainId) -> Self {
-        chain_id.inner
+        match chain_id {
+            PyStarknetChainId::MainNet => Self::MainNet,
+            PyStarknetChainId::TestNet => Self::TestNet,
+            PyStarknetChainId::TestNet2 => Self::TestNet2,
+        }
     }
 }
 
 #[pymethods]
 impl PyStarknetChainId {
-    #[classattr]
-    #[pyo3(name = "MAINNET")]
-    fn mainnet() -> Self {
-        Self {
-            inner: StarknetChainId::MainNet,
-        }
-    }
-
-    #[classattr]
-    #[pyo3(name = "TESTNET")]
-    pub fn testnet() -> Self {
-        Self {
-            inner: StarknetChainId::TestNet,
-        }
-    }
-
-    #[classattr]
-    #[pyo3(name = "TESTNET2")]
-    fn testnet2() -> Self {
-        Self {
-            inner: StarknetChainId::TestNet2,
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
-        self.inner.to_string()
+        let chain_id: StarknetChainId = (*self).into();
+        chain_id.to_string()
     }
 
     #[getter]
     fn value(&self) -> BigUint {
-        self.inner.to_felt().to_biguint()
+        let chain_id: StarknetChainId = (*self).into();
+        chain_id.to_felt().to_biguint()
     }
 }
 

--- a/crates/starknet-rs-py/src/types/general_config.rs
+++ b/crates/starknet-rs-py/src/types/general_config.rs
@@ -1,6 +1,9 @@
 use cairo_felt::Felt252;
 use num_bigint::BigUint;
-use pyo3::{prelude::*, types::PyDict};
+use pyo3::{
+    prelude::*,
+    types::{PyDict, PyType},
+};
 use starknet_rs::{
     business_logic::state::state_api_objects::BlockInfo,
     definitions::{
@@ -191,6 +194,13 @@ impl PyStarknetChainId {
     fn value(&self) -> BigUint {
         let chain_id: StarknetChainId = (*self).into();
         chain_id.to_felt().to_biguint()
+    }
+
+    // TODO: remove when pyo3 auto-implements this
+    // https://github.com/PyO3/pyo3/issues/2887
+    #[classmethod]
+    fn __iter__(_cls: &PyType) -> Vec<Self> {
+        vec![Self::MainNet, Self::TestNet, Self::TestNet2]
     }
 }
 

--- a/crates/starknet-rs-py/src/types/general_config.rs
+++ b/crates/starknet-rs-py/src/types/general_config.rs
@@ -204,6 +204,12 @@ impl PyStarknetChainId {
     }
 }
 
+#[pyfunction]
+pub fn build_general_config(_raw_general_config: &PyDict) -> PyResult<PyStarknetGeneralConfig> {
+    // TODO: this function should parse the _raw_general_config
+    Ok(PyStarknetGeneralConfig::default())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/starknet-rs-py/src/types/general_config.rs
+++ b/crates/starknet-rs-py/src/types/general_config.rs
@@ -198,6 +198,8 @@ impl PyStarknetChainId {
 
     // TODO: remove when pyo3 auto-implements this
     // https://github.com/PyO3/pyo3/issues/2887
+    // NOTE: doesn't work. __iter__ seems to be included in the instance impl
+    //  instead of the class impl
     #[classmethod]
     fn __iter__(_cls: &PyType) -> Vec<Self> {
         vec![Self::MainNet, Self::TestNet, Self::TestNet2]

--- a/crates/starknet-rs-py/src/types/starknet_message_to_l1.rs
+++ b/crates/starknet-rs-py/src/types/starknet_message_to_l1.rs
@@ -1,0 +1,34 @@
+use cairo_felt::Felt252;
+use num_bigint::BigUint;
+use pyo3::prelude::*;
+use starknet_rs::{services::api::messages::StarknetMessageToL1, utils::Address};
+
+#[pyclass]
+pub struct PyStarknetMessageToL1 {
+    inner: StarknetMessageToL1,
+}
+
+#[pymethods]
+impl PyStarknetMessageToL1 {
+    #[new]
+    fn new(from_address: BigUint, to_address: BigUint, payload: Vec<BigUint>) -> Self {
+        let from_address = Address(Felt252::from(from_address));
+        let to_address = Address(Felt252::from(to_address));
+        let payload: Vec<_> = payload.into_iter().map(Felt252::from).collect();
+
+        let inner = StarknetMessageToL1::new(from_address, to_address, payload);
+        Self { inner }
+    }
+
+    fn encode(&self) -> Vec<BigUint> {
+        self.inner
+            .encode()
+            .iter()
+            .map(Felt252::to_biguint)
+            .collect()
+    }
+
+    fn get_hash(&self) -> Vec<u8> {
+        self.inner.get_hash()
+    }
+}

--- a/crates/starknet-rs-py/src/types/transaction.rs
+++ b/crates/starknet-rs-py/src/types/transaction.rs
@@ -2,8 +2,7 @@ use num_bigint::BigUint;
 use pyo3::prelude::*;
 use starknet_rs::{business_logic::transaction::transactions::Transaction, utils::ClassHash};
 
-#[pyclass]
-#[pyo3(name = "TransactionExecutionInfo")]
+#[pyclass(name = "TransactionExecutionInfo")]
 pub struct PyTransaction {
     pub(crate) inner: Transaction,
 }
@@ -14,6 +13,7 @@ impl PyTransaction {
     fn contract_hash(&self) -> ClassHash {
         self.inner.contract_hash()
     }
+
     #[getter]
     fn contract_address(&self) -> BigUint {
         self.inner.contract_address().0.to_biguint()
@@ -24,4 +24,21 @@ impl From<Transaction> for PyTransaction {
     fn from(value: Transaction) -> Self {
         Self { inner: value }
     }
+}
+
+#[pyclass(name = "TransactionType")]
+#[derive(Debug, PartialEq, Copy, Clone, Eq, Hash)]
+pub enum PyTransactionType {
+    #[pyo3(name = "DECLARE")]
+    Declare,
+    #[pyo3(name = "DEPLOY")]
+    Deploy,
+    #[pyo3(name = "DEPLOY_ACCOUNT")]
+    DeployAccount,
+    #[pyo3(name = "INITIALIZE_BLOCK_INFO")]
+    InitializeBlockInfo,
+    #[pyo3(name = "INVOKE_FUNCTION")]
+    InvokeFunction,
+    #[pyo3(name = "L1_HANDLER")]
+    L1Handler,
 }

--- a/crates/starknet-rs-py/src/types/transaction.rs
+++ b/crates/starknet-rs-py/src/types/transaction.rs
@@ -2,7 +2,7 @@ use num_bigint::BigUint;
 use pyo3::prelude::*;
 use starknet_rs::{business_logic::transaction::transactions::Transaction, utils::ClassHash};
 
-#[pyclass(name = "TransactionExecutionInfo")]
+#[pyclass(name = "Transaction")]
 pub struct PyTransaction {
     pub(crate) inner: Transaction,
 }

--- a/scripts/move-devnet-sir.patch
+++ b/scripts/move-devnet-sir.patch
@@ -341,7 +341,7 @@ index 7eb1fae..be5a72c 100644
  
  @dataclass
 diff --git a/starknet_devnet/devnet_config.py b/starknet_devnet/devnet_config.py
-index 08f7daa..24fc6b5 100644
+index 08f7daa..fb32787 100644
 --- a/starknet_devnet/devnet_config.py
 +++ b/starknet_devnet/devnet_config.py
 @@ -13,10 +13,10 @@ from aiohttp.client_exceptions import ClientConnectorError, InvalidURL
@@ -359,6 +359,24 @@ index 08f7daa..24fc6b5 100644
      FeederGatewayClient,
  )
  
+@@ -41,7 +41,7 @@ NETWORK_TO_URL = {
+     "alpha-mainnet": "https://alpha-mainnet.starknet.io",
+ }
+ NETWORK_NAMES = ", ".join(NETWORK_TO_URL.keys())
+-CHAIN_IDS = ", ".join([member.name for member in StarknetChainId])
++CHAIN_IDS = ", ".join([member.name for member in StarknetChainId.variants()])
+ 
+ 
+ def _fork_network(network_id: str):
+@@ -71,7 +71,7 @@ def _fork_block(specifier: str):
+ def _chain_id(chain_id: str):
+     """Parse chain id.'"""
+     try:
+-        chain_id = StarknetChainId[chain_id]
++        chain_id = StarknetChainId.get(chain_id)
+     except KeyError:
+         sys.exit(
+             f"Error: The value of --chain-id must be in {{{CHAIN_IDS}}}, got: {chain_id}"
 diff --git a/starknet_devnet/fee_token.py b/starknet_devnet/fee_token.py
 index 0e646b4..b0d3222 100644
 --- a/starknet_devnet/fee_token.py
@@ -923,7 +941,7 @@ index e573242..3048de0 100644
  from .account import invoke
  from .shared import (
 diff --git a/test/test_chain_id_cli_params.py b/test/test_chain_id_cli_params.py
-index afa7940..3734d07 100644
+index afa7940..19d529b 100644
 --- a/test/test_chain_id_cli_params.py
 +++ b/test/test_chain_id_cli_params.py
 @@ -3,7 +3,7 @@
@@ -935,6 +953,24 @@ index afa7940..3734d07 100644
  
  from starknet_devnet.devnet_config import CHAIN_IDS
  
+@@ -31,7 +31,7 @@ ACTIVE_DEVNET = DevnetBackgroundProc()
+ 
+ @pytest.mark.parametrize(
+     "chain_id",
+-    [member.name for member in StarknetChainId],
++    [member.name for member in StarknetChainId.variants()],
+ )
+ def test_chain_id_valid(chain_id):
+     """Test if chain id works"""
+@@ -67,7 +67,7 @@ def test_chain_id_invalid(chain_id):
+     "run_devnet_in_background, chain_id",
+     [
+         ([*PREDEPLOY_ACCOUNT_CLI_ARGS, "--chain-id", chain_id.name], chain_id)
+-        for chain_id in StarknetChainId
++        for chain_id in StarknetChainId.variants()
+     ],
+     indirect=True,
+ )
 diff --git a/test/test_declare.py b/test/test_declare.py
 index f32162c..7401e79 100644
 --- a/test/test_declare.py

--- a/scripts/move-devnet-sir.patch
+++ b/scripts/move-devnet-sir.patch
@@ -659,10 +659,10 @@ index 5799dba..cae8255 100644
  
  class UDC:
 diff --git a/starknet_devnet/util.py b/starknet_devnet/util.py
-index ea98aa9..4b1f92c 100644
+index ea98aa9..f3749a5 100644
 --- a/starknet_devnet/util.py
 +++ b/starknet_devnet/util.py
-@@ -7,15 +7,17 @@ import sys
+@@ -7,14 +7,14 @@ import sys
  from dataclasses import dataclass
  from typing import Dict, List, Set, Union
  
@@ -677,14 +677,10 @@ index ea98aa9..4b1f92c 100644
      StorageEntry,
  )
 -from starkware.starknet.testing.contract import StarknetContract
--from starkware.starkware_utils.error_handling import StarkException
-+
 +from starknet_rs_py import StarknetContract
-+from starknet_rs_py import StarkErrorCode, StarkException
-+
+ from starkware.starkware_utils.error_handling import StarkException
  
  
- def custom_int(arg: str) -> int:
 diff --git a/test/account.py b/test/account.py
 index 181d822..49c2fb2 100644
 --- a/test/account.py

--- a/src/services/api/messages.rs
+++ b/src/services/api/messages.rs
@@ -6,7 +6,7 @@ use crate::utils::Address;
 
 /// A StarkNet Message from L2 to L1.
 #[derive(Debug, Clone)]
-pub(crate) struct StarknetMessageToL1 {
+pub struct StarknetMessageToL1 {
     from_address: Address,
     to_address: Address,
     payload: Vec<Felt252>,


### PR DESCRIPTION
This PR reexports:
- some classes of _cairo-lang_ that are used for RPC requests/responses
- the `sign_*_tx` functions
- the feeder gateway client
- the `Starknet` class

Also adds:
- a fix to the devnet patch (modification that wasn't needed)
- implementations of `PyTransactionType`
- implementations of `PyMessageToL1`
- dummy `build_general_config` function
- fixed existing `PyStarknetChainId` impl
- added `PyStarknetChainId::variants` and `PyStarknetChainId::get`, along with a patch on the devnet to use them
