### PR TITLE
Implement syscall `replace_class`

### DIFF
--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -209,7 +209,7 @@ impl<T: StateReader + Clone> State for CachedState<T> {
             .insert(storage_entry.clone(), value);
     }
 
-    fn replace_contract(
+    fn set_class_hash_at(
         &mut self,
         deploy_contract_address: Address,
         class_hash: ClassHash,
@@ -468,7 +468,7 @@ mod tests {
             .unwrap();
 
         assert!(cached_state
-            .replace_contract(contract_address.clone(), [12; 32])
+            .set_class_hash_at(contract_address.clone(), [12; 32])
             .is_ok());
 
         assert_matches!(

--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -208,6 +208,23 @@ impl<T: StateReader + Clone> State for CachedState<T> {
             .storage_writes
             .insert(storage_entry.clone(), value);
     }
+
+    fn replace_contract(
+        &mut self,
+        deploy_contract_address: Address,
+        class_hash: ClassHash,
+    ) -> Result<(), StateError> {
+        if deploy_contract_address == Address(0.into()) {
+            return Err(StateError::ContractAddressOutOfRangeAddress(
+                deploy_contract_address,
+            ));
+        }
+
+        self.cache
+            .class_hash_writes
+            .insert(deploy_contract_address, class_hash);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -430,6 +447,33 @@ mod tests {
         assert_eq!(
             result,
             StateError::ContractAddressUnavailable(contract_address)
+        );
+    }
+
+    #[test]
+    fn cached_state_replace_contract_test() {
+        let state_reader = InMemoryStateReader::new(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let contract_address = Address(32123.into());
+
+        let mut cached_state = CachedState::new(state_reader, None);
+
+        cached_state
+            .deploy_contract(contract_address.clone(), [10; 32])
+            .unwrap();
+
+        assert!(cached_state
+            .replace_contract(contract_address.clone(), [12; 32])
+            .is_ok());
+
+        assert_matches!(
+            cached_state.get_class_hash_at(&contract_address),
+            Ok(class_hash) if class_hash == &[12u8; 32]
         );
     }
 }

--- a/src/business_logic/state/state_api.rs
+++ b/src/business_logic/state/state_api.rs
@@ -32,7 +32,7 @@ pub trait State {
     ) -> Result<(), StateError>;
     fn increment_nonce(&mut self, contract_address: &Address) -> Result<(), StateError>;
     fn set_storage_at(&mut self, storage_entry: &StorageEntry, value: Felt252);
-    fn replace_contract(
+    fn set_class_hash_at(
         &mut self,
         contract_address: Address,
         class_hash: ClassHash,

--- a/src/business_logic/state/state_api.rs
+++ b/src/business_logic/state/state_api.rs
@@ -32,4 +32,9 @@ pub trait State {
     ) -> Result<(), StateError>;
     fn increment_nonce(&mut self, contract_address: &Address) -> Result<(), StateError>;
     fn set_storage_at(&mut self, storage_entry: &StorageEntry, value: Felt252);
+    fn replace_contract(
+        &mut self,
+        contract_address: Address,
+        class_hash: ClassHash,
+    ) -> Result<(), StateError>;
 }

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -565,6 +565,26 @@ where
         self.expected_syscall_ptr.offset += get_syscall_size_from_name(syscall_name);
         Ok(syscall_request)
     }
+
+    fn replace_class(
+        &mut self,
+        vm: &mut VirtualMachine,
+        syscall_ptr: Relocatable,
+    ) -> Result<(), SyscallHandlerError> {
+        let request = match self.read_and_validate_syscall_request("replace_class", vm, syscall_ptr)
+        {
+            Ok(SyscallRequest::ReplaceClass(replace_class_request)) => replace_class_request,
+            _ => return Err(SyscallHandlerError::InvalidSyscallReadRequest),
+        };
+
+        let address = self.contract_address.clone();
+        self.starknet_storage_state
+            .state
+            .deploy_contract(address, felt_to_hash(&request.class_hash))
+            .unwrap();
+
+        Ok(())
+    }
 }
 
 impl<'a, T> SyscallHandlerPostRun for BusinessLogicSyscallHandler<'a, T>

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -580,7 +580,7 @@ where
         let address = self.contract_address.clone();
         self.starknet_storage_state
             .state
-            .deploy_contract(address, felt_to_hash(&request.class_hash))
+            .set_class_hash_at(address, felt_to_hash(&request.class_hash))
             .unwrap();
 
         Ok(())

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -204,6 +204,12 @@ pub(crate) trait SyscallHandler {
             .write_syscall_response(vm, syscall_ptr)
     }
 
+    fn replace_class(
+        &mut self,
+        vm: &mut VirtualMachine,
+        syscall_ptr: Relocatable,
+    ) -> Result<(), SyscallHandlerError>;
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // ***********************************
     //  Implementation of Default methods
@@ -344,6 +350,7 @@ pub(crate) trait SyscallHandler {
             "get_block_timestamp" => GetBlockTimestampRequest::from_ptr(vm, syscall_ptr),
             "storage_read" => StorageReadRequest::from_ptr(vm, syscall_ptr),
             "storage_write" => StorageWriteRequest::from_ptr(vm, syscall_ptr),
+            "replace_class" => ReplaceClassRequest::from_ptr(vm, syscall_ptr),
             _ => Err(SyscallHandlerError::UnknownSyscall(
                 syscall_name.to_string(),
             )),

--- a/src/core/syscalls/syscall_info.rs
+++ b/src/core/syscalls/syscall_info.rs
@@ -15,6 +15,7 @@ pub fn get_syscall_size_from_name(syscall_name: &str) -> usize {
         "send_message_to_l1" => 4,
         "storage_read" => 3,
         "storage_write" => 3,
+        "replace_class" => 2,
         _ => unreachable!(),
     }
 }

--- a/src/core/syscalls/syscall_request.rs
+++ b/src/core/syscalls/syscall_request.rs
@@ -21,6 +21,7 @@ pub(crate) enum SyscallRequest {
     GetTxSignature(GetTxSignatureRequest),
     StorageRead(StorageReadRequest),
     StorageWrite(StorageWriteRequest),
+    ReplaceClass(ReplaceClassRequest),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -123,6 +124,11 @@ pub(crate) struct StorageWriteRequest {
     pub(crate) value: Felt252,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ReplaceClassRequest {
+    pub(crate) class_hash: Felt252,
+}
+
 impl From<EmitEventStruct> for SyscallRequest {
     fn from(emit_event_struct: EmitEventStruct) -> SyscallRequest {
         SyscallRequest::EmitEvent(emit_event_struct)
@@ -192,6 +198,12 @@ impl From<StorageReadRequest> for SyscallRequest {
 impl From<StorageWriteRequest> for SyscallRequest {
     fn from(storage_write: StorageWriteRequest) -> SyscallRequest {
         SyscallRequest::StorageWrite(storage_write)
+    }
+}
+
+impl From<ReplaceClassRequest> for SyscallRequest {
+    fn from(replace_class: ReplaceClassRequest) -> SyscallRequest {
+        SyscallRequest::ReplaceClass(replace_class)
     }
 }
 
@@ -426,6 +438,19 @@ impl FromPtr for StorageWriteRequest {
             selector,
             address,
             value,
+        }))
+    }
+}
+
+impl FromPtr for ReplaceClassRequest {
+    fn from_ptr(
+        vm: &VirtualMachine,
+        syscall_ptr: Relocatable,
+    ) -> Result<SyscallRequest, SyscallHandlerError> {
+        let class_hash = get_big_int(vm, syscall_ptr)?;
+
+        Ok(SyscallRequest::ReplaceClass(ReplaceClassRequest {
+            class_hash,
         }))
     }
 }


### PR DESCRIPTION
- Add `replace_class` to `State` trait to enable replacing a contract because `deploy_contract` has a check that the address is free
- Add implementation for syscall `replace_class`

I'm missing adding integration tests for this in `syscalls.rs` and `syscalls.cairo`, but not sure how to go about it, so any tips are welcomed