### PR TITLE
Test transactions internal invoke function

### DIFF
--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -860,4 +860,24 @@ mod tests {
             TransactionError::UnauthorizedActionOnValidate
         );
     }
+
+    #[test]
+    fn preprocess_invoke_function_fields_nonce_is_none() {
+        let entry_point_selector = Felt252::from_str_radix(
+            "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+            16,
+        )
+        .unwrap();
+        let result = preprocess_invoke_function_fields(entry_point_selector.clone(), None, 0);
+
+        let expected_additional_data: Vec<Felt252> = Vec::new();
+        let expected_entry_point_selector_field = entry_point_selector;
+        assert_eq!(
+            result.unwrap(),
+            (
+                expected_entry_point_selector_field,
+                expected_additional_data
+            )
+        )
+    }
 }

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -839,4 +839,25 @@ mod tests {
         .unwrap_err();
         assert_matches!(expected_error, TransactionError::InvokeFunctionZeroHasNonce)
     }
+
+    #[test]
+    // the test should try to make verify_no_calls_to_other_contracts fail
+    fn verify_no_calls_to_other_contracts_should_fail() {
+        let mut call_info = CallInfo::default();
+        let mut internal_calls = Vec::new();
+        let internal_call = CallInfo {
+            contract_address: Address(1.into()),
+            ..Default::default()
+        };
+        internal_calls.push(internal_call);
+        call_info.internal_calls = internal_calls;
+
+        let expected_error = verify_no_calls_to_other_contracts(&call_info);
+
+        assert!(expected_error.is_err());
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::UnauthorizedActionOnValidate
+        );
+    }
 }

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -880,4 +880,22 @@ mod tests {
             )
         )
     }
+
+    #[test]
+    fn invoke_version_one_with_no_nonce_should_fail() {
+        let expected_error = preprocess_invoke_function_fields(
+            Felt252::from_str_radix(
+                "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
+                16,
+            )
+            .unwrap(),
+            None,
+            1,
+        );
+        assert!(expected_error.is_err());
+        assert_matches!(
+            expected_error.unwrap_err(),
+            TransactionError::InvokeFunctionNonZeroMissingNonce
+        )
+    }
 }


### PR DESCRIPTION
This PR adds a 3 new tests to cover special cases in different functions. The new tests are:
* verify_no_calls_to_other_contracts_should_fail
* preprocess_invoke_function_fields_nonce_is_none
* invoke_version_one_with_no_nonce_should_fail
The only line that has not been tested yet is a special case in [handle_nonce](https://github.com/lambdaclass/starknet_in_rust/blob/main/src/business_logic/transaction/objects/internal_invoke_function.rs#L281) that's going to be refactor in the future.