### PR TITLE
Change `StateReader` to return owned values

### DIFF
--- a/crates/starknet-rs-py/src/cached_state.rs
+++ b/crates/starknet-rs-py/src/cached_state.rs
@@ -31,7 +31,8 @@ impl PyCachedState {
 
     fn get_class_hash_at(&mut self, address: BigUint) -> PyResult<BigUint> {
         Ok(BigUint::from_bytes_be(
-            self.state
+            &self
+                .state
                 .get_class_hash_at(&Address(Felt252::from(address)))
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
         ))

--- a/src/business_logic/fact_state/in_memory_state_reader.rs
+++ b/src/business_logic/fact_state/in_memory_state_reader.rs
@@ -47,28 +47,28 @@ impl StateReader for InMemoryStateReader {
         Ok(contract_class)
     }
 
-    fn get_class_hash_at(&mut self, contract_address: &Address) -> Result<&ClassHash, StateError> {
+    fn get_class_hash_at(&mut self, contract_address: &Address) -> Result<ClassHash, StateError> {
         let class_hash = self
             .address_to_class_hash
             .get(contract_address)
             .ok_or_else(|| StateError::NoneContractState(contract_address.clone()));
-        class_hash
+        class_hash.cloned()
     }
 
-    fn get_nonce_at(&mut self, contract_address: &Address) -> Result<&Felt252, StateError> {
+    fn get_nonce_at(&mut self, contract_address: &Address) -> Result<Felt252, StateError> {
         let nonce = self
             .address_to_nonce
             .get(contract_address)
             .ok_or_else(|| StateError::NoneContractState(contract_address.clone()));
-        nonce
+        nonce.cloned()
     }
 
-    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<&Felt252, StateError> {
+    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<Felt252, StateError> {
         let storage = self
             .address_to_storage
             .get(storage_entry)
             .ok_or_else(|| StateError::NoneStorage(storage_entry.clone()));
-        storage
+        storage.cloned()
     }
 
     fn count_actual_storage_changes(&mut self) -> (usize, usize) {
@@ -110,12 +110,12 @@ mod tests {
 
         assert_eq!(
             state_reader.get_class_hash_at(&contract_address),
-            Ok(&class_hash)
+            Ok(class_hash)
         );
-        assert_eq!(state_reader.get_nonce_at(&contract_address), Ok(&nonce));
+        assert_eq!(state_reader.get_nonce_at(&contract_address), Ok(nonce));
         assert_eq!(
             state_reader.get_storage_at(&storage_entry),
-            Ok(&storage_value)
+            Ok(storage_value)
         );
     }
 

--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -115,7 +115,7 @@ impl<T: StateReader + Clone> StateReader for CachedState<T> {
             let nonce = self.state_reader.get_nonce_at(contract_address)?;
             self.cache
                 .nonce_initial_values
-                .insert(contract_address.clone(), nonce.clone());
+                .insert(contract_address.clone(), nonce);
         }
         self.cache
             .get_nonce(contract_address)
@@ -126,7 +126,7 @@ impl<T: StateReader + Clone> StateReader for CachedState<T> {
     fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<Felt252, StateError> {
         if self.cache.get_storage(storage_entry).is_none() {
             let value = match self.state_reader.get_storage_at(storage_entry) {
-                Ok(x) => x.clone(),
+                Ok(x) => x,
                 Err(
                     StateError::Storage(StorageError::ErrorFetchingData)
                     | StateError::EmptyKeyInStorage

--- a/src/business_logic/state/contract_storage_state.rs
+++ b/src/business_logic/state/contract_storage_state.rs
@@ -25,7 +25,7 @@ impl<'a, T: State + StateReader> ContractStorageState<'a, T> {
         }
     }
 
-    pub(crate) fn read(&mut self, address: &ClassHash) -> Result<&Felt252, StateError> {
+    pub(crate) fn read(&mut self, address: &ClassHash) -> Result<Felt252, StateError> {
         self.accessed_keys.insert(*address);
         let value = self
             .state

--- a/src/business_logic/state/state_api.rs
+++ b/src/business_logic/state/state_api.rs
@@ -10,11 +10,11 @@ pub trait StateReader {
     /// Returns the contract class of the given class hash.
     fn get_contract_class(&mut self, class_hash: &ClassHash) -> Result<ContractClass, StateError>;
     /// Returns the class hash of the contract class at the given address.
-    fn get_class_hash_at(&mut self, contract_address: &Address) -> Result<&ClassHash, StateError>;
+    fn get_class_hash_at(&mut self, contract_address: &Address) -> Result<ClassHash, StateError>;
     /// Returns the nonce of the given contract instance.
-    fn get_nonce_at(&mut self, contract_address: &Address) -> Result<&Felt252, StateError>;
+    fn get_nonce_at(&mut self, contract_address: &Address) -> Result<Felt252, StateError>;
     /// Returns the storage value under the given key in the given contract instance.
-    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<&Felt252, StateError>;
+    fn get_storage_at(&mut self, storage_entry: &StorageEntry) -> Result<Felt252, StateError>;
     /// Counts the amount of modified contracts and the updates to the storage
     fn count_actual_storage_changes(&mut self) -> (usize, usize);
 }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -234,7 +234,7 @@ impl InternalDeclare {
         }
 
         let contract_address = &self.sender_address;
-        let current_nonce = state.get_nonce_at(contract_address)?.to_owned();
+        let current_nonce = state.get_nonce_at(contract_address)?;
         if current_nonce != self.nonce {
             return Err(TransactionError::InvalidTransactionNonce(
                 current_nonce.to_string(),

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -256,7 +256,7 @@ mod tests {
             state
                 .get_class_hash_at(&internal_deploy.contract_address)
                 .unwrap(),
-            &class_hash_bytes
+            class_hash_bytes
         );
 
         let storage_key = calculate_sn_keccak("owner".as_bytes());
@@ -265,7 +265,7 @@ mod tests {
             state
                 .get_storage_at(&(internal_deploy.contract_address, storage_key))
                 .unwrap(),
-            &Felt252::from(10)
+            Felt252::from(10)
         );
     }
 

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -217,7 +217,7 @@ impl InternalDeployAccount {
             return Ok(());
         }
 
-        let current_nonce = state.get_nonce_at(&self.contract_address)?.to_owned();
+        let current_nonce = state.get_nonce_at(&self.contract_address)?;
         if current_nonce != self.nonce {
             return Err(TransactionError::InvalidTransactionNonce(
                 current_nonce.to_string(),

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -283,7 +283,7 @@ impl InternalInvokeFunction {
                 Ok(())
             }
             Some(nonce) => {
-                if nonce != current_nonce {
+                if *nonce != current_nonce {
                     return Err(TransactionError::InvalidTransactionNonce(
                         current_nonce.to_string(),
                         nonce.to_string(),

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -529,10 +529,7 @@ where
     }
 
     fn syscall_storage_read(&mut self, address: Address) -> Result<Felt252, SyscallHandlerError> {
-        Ok(self
-            .starknet_storage_state
-            .read(&address.0.to_be_bytes())
-            .cloned()?)
+        Ok(self.starknet_storage_state.read(&address.0.to_be_bytes())?)
     }
 
     fn syscall_storage_write(

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -1244,7 +1244,7 @@ mod tests {
             .starknet_storage_state
             .read(&address.to_be_bytes());
 
-        assert_eq!(write, Ok(&Felt252::new(45)));
+        assert_eq!(write, Ok(Felt252::new(45)));
     }
 
     #[test]
@@ -1331,7 +1331,7 @@ mod tests {
                 .starknet_storage_state
                 .state
                 .get_class_hash_at(&Address(deployed_address)),
-            Ok(&class_hash)
+            Ok(class_hash)
         );
     }
 
@@ -1428,7 +1428,7 @@ mod tests {
                 .starknet_storage_state
                 .state
                 .get_class_hash_at(&Address(deployed_address.clone())),
-            Ok(&class_hash)
+            Ok(class_hash)
         );
 
         /*

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn invoke_parser(
         Felt252::from_str_radix(&args.address[2..], 16)
             .map_err(|_| ParserError::ParseFelt(args.address.clone()))?,
     );
-    let class_hash = *cached_state.get_class_hash_at(&contract_address)?;
+    let class_hash = cached_state.get_class_hash_at(&contract_address)?;
     let contract_class = cached_state.get_contract_class(&class_hash)?;
     let function_entrypoint_indexes = read_abi(&args.abi);
 
@@ -215,7 +215,7 @@ fn call_parser(
         Felt252::from_str_radix(&args.address[2..], 16)
             .map_err(|_| ParserError::ParseFelt(args.address.clone()))?,
     );
-    let class_hash = *cached_state.get_class_hash_at(&contract_address)?;
+    let class_hash = cached_state.get_class_hash_at(&contract_address)?;
     let contract_class = cached_state.get_contract_class(&class_hash)?;
     let function_entrypoint_indexes = read_abi(&args.abi);
     let entry_points_by_type = contract_class.entry_points_by_type();

--- a/src/testing/starknet_state.rs
+++ b/src/testing/starknet_state.rs
@@ -250,7 +250,7 @@ impl StarknetState {
 
         let nonce = match nonce {
             Some(n) => n,
-            None => self.state.get_nonce_at(&contract_address)?.to_owned(),
+            None => self.state.get_nonce_at(&contract_address)?,
         };
 
         InternalInvokeFunction::new(

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -462,7 +462,7 @@ fn validate_final_balances<S>(
             *erc20_account_balance_storage_key,
         ))
         .unwrap();
-    assert_eq!(account_balance, &Felt252::zero());
+    assert_eq!(account_balance, Felt252::zero());
 
     let sequencer_balance = state
         .get_storage_at(&(
@@ -473,7 +473,7 @@ fn validate_final_balances<S>(
             TEST_ERC20_SEQUENCER_BALANCE_KEY.to_be_bytes(),
         ))
         .unwrap();
-    assert_eq!(sequencer_balance, expected_sequencer_balance);
+    assert_eq!(sequencer_balance, *expected_sequencer_balance);
 }
 
 #[test]
@@ -491,10 +491,10 @@ fn test_create_account_tx_test_state() {
             TEST_ERC20_ACCOUNT_BALANCE_KEY.to_be_bytes(),
         ))
         .unwrap();
-    assert_eq!(value, &*ACTUAL_FEE);
+    assert_eq!(value, *ACTUAL_FEE);
 
     let class_hash = state.get_class_hash_at(&TEST_CONTRACT_ADDRESS).unwrap();
-    assert_eq!(class_hash, &TEST_CLASS_HASH.to_be_bytes());
+    assert_eq!(class_hash, TEST_CLASS_HASH.to_be_bytes());
 
     let contract_class = state
         .get_contract_class(&TEST_ERC20_CONTRACT_CLASS_HASH.to_be_bytes())
@@ -898,7 +898,7 @@ fn test_deploy_account() {
     let nonce_from_state = state
         .get_nonce_at(deploy_account_tx.contract_address())
         .unwrap();
-    assert_eq!(nonce_from_state, &Felt252::one());
+    assert_eq!(nonce_from_state, Felt252::one());
 
     let hash = &TEST_ERC20_DEPLOYED_ACCOUNT_BALANCE_KEY.to_be_bytes();
 
@@ -907,7 +907,7 @@ fn test_deploy_account() {
     let class_hash_from_state = state
         .get_class_hash_at(deploy_account_tx.contract_address())
         .unwrap();
-    assert_eq!(class_hash_from_state, deploy_account_tx.class_hash());
+    assert_eq!(class_hash_from_state, *deploy_account_tx.class_hash());
 }
 
 fn expected_deploy_account_states() -> (
@@ -1088,16 +1088,10 @@ fn test_state_for_declare_tx() {
     let declare_tx = declare_tx();
     // Check ContractClass is not set before the declare_tx
     assert!(state.get_contract_class(&declare_tx.class_hash).is_err());
-    assert_eq!(
-        state.get_nonce_at(&declare_tx.sender_address),
-        Ok(&0.into())
-    );
+    assert_eq!(state.get_nonce_at(&declare_tx.sender_address), Ok(0.into()));
     // Execute declare_tx
     assert!(declare_tx.execute(&mut state, &general_config).is_ok());
-    assert_eq!(
-        state.get_nonce_at(&declare_tx.sender_address),
-        Ok(&1.into())
-    );
+    assert_eq!(state.get_nonce_at(&declare_tx.sender_address), Ok(1.into()));
 
     // Check state.state_reader
     let mut state_reader = state.state_reader().clone();


### PR DESCRIPTION
This PR changes the `StateReader` trait to return owned values instead of shared references.

When implementing `StateReader` with an actual database backend returning shared references is painful. Most of the time these values live in local variables (after conversion from the database representation) and thus we cannot return a shared reference to those.