### PR TITLE
Execution should not require `Default` implementation for state

### DIFF
--- a/src/business_logic/transaction/fee.rs
+++ b/src/business_logic/transaction/fee.rs
@@ -22,7 +22,7 @@ pub type FeeInfo = (Option<CallInfo>, u64);
 
 /// Transfers the amount actual_fee from the caller account to the sequencer.
 /// Returns the resulting CallInfo of the transfer call.
-pub(crate) fn execute_fee_transfer<S: Default + State + StateReader + Clone>(
+pub(crate) fn execute_fee_transfer<S: State + StateReader + Clone>(
     state: &mut S,
     general_config: &StarknetGeneralConfig,
     tx_context: &TransactionExecutionContext,

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -119,7 +119,7 @@ impl InternalDeclare {
 
     /// Executes a call to the cairo-vm using the accounts_validation.cairo contract to validate
     /// the contract that is being declared. Then it returns the transaction execution info of the run.
-    pub fn apply<S: Default + State + StateReader + Clone>(
+    pub fn apply<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -166,7 +166,7 @@ impl InternalDeclare {
         )
     }
 
-    pub fn run_validate_entrypoint<S: Default + State + StateReader>(
+    pub fn run_validate_entrypoint<S: State + StateReader>(
         &self,
         state: &mut S,
         resources_manager: &mut ExecutionResourcesManager,
@@ -202,7 +202,7 @@ impl InternalDeclare {
     }
 
     /// Calculates and charges the actual fee.
-    pub fn charge_fee<S: Default + State + StateReader + Clone>(
+    pub fn charge_fee<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
         resources: &HashMap<String, usize>,
@@ -225,7 +225,7 @@ impl InternalDeclare {
         Ok((Some(fee_transfer_info), actual_fee))
     }
 
-    fn handle_nonce<S: Default + State + StateReader + Clone>(
+    fn handle_nonce<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
     ) -> Result<(), TransactionError> {
@@ -249,7 +249,7 @@ impl InternalDeclare {
 
     /// Calculates actual fee used by the transaction using the execution
     /// info returned by apply(), then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -77,7 +77,7 @@ impl InternalDeploy {
         self.contract_hash
     }
 
-    pub fn apply<S: Default + State + StateReader + Clone>(
+    pub fn apply<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -98,7 +98,7 @@ impl InternalDeploy {
         }
     }
 
-    pub fn handle_empty_constructor<T: Default + State + StateReader + Clone>(
+    pub fn handle_empty_constructor<T: State + StateReader + Clone>(
         &self,
         state: &mut T,
     ) -> Result<TransactionExecutionInfo, StarkwareError> {
@@ -135,7 +135,7 @@ impl InternalDeploy {
         )
     }
 
-    pub fn invoke_constructor<S: Default + State + StateReader + Clone>(
+    pub fn invoke_constructor<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -189,7 +189,7 @@ impl InternalDeploy {
 
     /// Calculates actual fee used by the transaction using the execution
     /// info returned by apply(), then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -114,7 +114,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        S: Clone + Default + State + StateReader,
+        S: Clone + State + StateReader,
     {
         let tx_info = self.apply(state, general_config)?;
 
@@ -139,7 +139,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        S: Default + State + StateReader,
+        S: State + StateReader,
     {
         let contract_class = state.get_contract_class(&self.class_hash)?;
 
@@ -183,7 +183,7 @@ impl InternalDeployAccount {
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError>
     where
-        S: Default + State + StateReader,
+        S: State + StateReader,
     {
         let num_constructors = contract_class
             .entry_points_by_type()
@@ -209,7 +209,7 @@ impl InternalDeployAccount {
         }
     }
 
-    fn handle_nonce<S: Default + State + StateReader + Clone>(
+    fn handle_nonce<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
     ) -> Result<(), TransactionError> {
@@ -237,7 +237,7 @@ impl InternalDeployAccount {
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError>
     where
-        S: Default + State + StateReader,
+        S: State + StateReader,
     {
         let entry_point = ExecutionEntryPoint::new(
             self.contract_address.clone(),
@@ -290,7 +290,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<Option<CallInfo>, TransactionError>
     where
-        S: Default + State + StateReader,
+        S: State + StateReader,
     {
         if self.version == 0 {
             return Ok(None);
@@ -332,7 +332,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<FeeInfo, TransactionError>
     where
-        S: Clone + Default + State + StateReader,
+        S: Clone + State + StateReader,
     {
         if self.max_fee.is_zero() {
             return Ok((None, 0));

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -113,7 +113,7 @@ impl InternalInvokeFunction {
         general_config: &StarknetGeneralConfig,
     ) -> Result<Option<CallInfo>, TransactionError>
     where
-        T: Default + State + StateReader,
+        T: State + StateReader,
     {
         if self.entry_point_selector != *EXECUTE_ENTRY_POINT_SELECTOR {
             return Ok(None);
@@ -156,7 +156,7 @@ impl InternalInvokeFunction {
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError>
     where
-        T: Default + State + StateReader,
+        T: State + StateReader,
     {
         let call = ExecutionEntryPoint::new(
             self.contract_address.clone(),
@@ -186,7 +186,7 @@ impl InternalInvokeFunction {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        T: Default + State + StateReader + Clone,
+        T: State + StateReader + Clone,
     {
         let mut resources_manager = ExecutionResourcesManager::default();
 
@@ -221,7 +221,7 @@ impl InternalInvokeFunction {
         general_config: &StarknetGeneralConfig,
     ) -> Result<FeeInfo, TransactionError>
     where
-        S: Clone + Default + State + StateReader,
+        S: Clone + State + StateReader,
     {
         if self.max_fee.is_zero() {
             return Ok((None, 0));
@@ -242,7 +242,7 @@ impl InternalInvokeFunction {
 
     /// Calculates actual fee used by the transaction using the execution info returned by apply(),
     /// then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -265,7 +265,7 @@ impl InternalInvokeFunction {
         )
     }
 
-    fn handle_nonce<S: Default + State + StateReader + Clone>(
+    fn handle_nonce<S: State + StateReader + Clone>(
         &self,
         state: &mut S,
     ) -> Result<(), TransactionError> {

--- a/src/business_logic/transaction/transactions.rs
+++ b/src/business_logic/transaction/transactions.rs
@@ -32,7 +32,7 @@ impl Transaction {
         }
     }
 
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: Clone + State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -51,7 +51,7 @@ pub struct BusinessLogicSyscallHandler<'a, T: State + StateReader> {
     pub(crate) expected_syscall_ptr: Relocatable,
 }
 
-impl<'a, T: Default + State + StateReader> BusinessLogicSyscallHandler<'a, T> {
+impl<'a, T: State + StateReader> BusinessLogicSyscallHandler<'a, T> {
     pub fn new(
         tx_execution_context: TransactionExecutionContext,
         state: &'a mut T,
@@ -241,7 +241,7 @@ where
 
 impl<'a, T> SyscallHandler for BusinessLogicSyscallHandler<'a, T>
 where
-    T: Default + State + StateReader,
+    T: State + StateReader,
 {
     fn emit_event(
         &mut self,
@@ -562,7 +562,7 @@ where
 
 impl<'a, T> SyscallHandlerPostRun for BusinessLogicSyscallHandler<'a, T>
 where
-    T: Default + State + StateReader,
+    T: State + StateReader,
 {
     fn post_run(
         &self,

--- a/src/starknet_runner/runner.rs
+++ b/src/starknet_runner/runner.rs
@@ -32,20 +32,6 @@ impl<H> StarknetRunner<H>
 where
     H: SyscallHandler,
 {
-    pub fn map_hint_processor<H2>(
-        self,
-        hint_processor: SyscallHintProcessor<H2>,
-    ) -> StarknetRunner<H2>
-    where
-        H2: SyscallHandler,
-    {
-        StarknetRunner {
-            cairo_runner: self.cairo_runner,
-            vm: self.vm,
-            hint_processor,
-        }
-    }
-
     pub fn new(
         cairo_runner: CairoRunner,
         vm: VirtualMachine,
@@ -100,29 +86,6 @@ where
             )
             .map_err(|_| StarknetRunnerError::NotAFelt)?;
         Ok(ret_data.into_iter().map(Cow::into_owned).collect())
-    }
-
-    pub(crate) fn prepare_os_context(&mut self) -> Vec<MaybeRelocatable> {
-        let syscall_segment = self.vm.add_memory_segment();
-        let mut os_context = [syscall_segment.into()].to_vec();
-        let builtin_runners = self
-            .vm
-            .get_builtin_runners()
-            .clone()
-            .into_iter()
-            .map(|runner| (runner.name(), runner))
-            .collect::<HashMap<&str, BuiltinRunner>>();
-        self.cairo_runner
-            .get_program_builtins()
-            .iter()
-            .for_each(|builtin| {
-                if builtin_runners.contains_key(builtin.name()) {
-                    let b_runner = builtin_runners.get(builtin.name()).unwrap();
-                    let stack = b_runner.initial_stack();
-                    os_context.extend(stack);
-                }
-            });
-        os_context
     }
 
     /// Returns the base and stop ptr of the OS-designated segment that starts at ptr_offset.
@@ -223,9 +186,33 @@ where
     }
 }
 
+pub(crate) fn prepare_os_context(
+    vm: &mut VirtualMachine,
+    cairo_runner: &mut CairoRunner,
+) -> Vec<MaybeRelocatable> {
+    let syscall_segment = vm.add_memory_segment();
+    let mut os_context = [syscall_segment.into()].to_vec();
+    let builtin_runners = vm
+        .get_builtin_runners()
+        .clone()
+        .into_iter()
+        .map(|runner| (runner.name(), runner))
+        .collect::<HashMap<&str, BuiltinRunner>>();
+    cairo_runner
+        .get_program_builtins()
+        .iter()
+        .for_each(|builtin| {
+            if let Some(b_runner) = builtin_runners.get(builtin.name()) {
+                let stack = b_runner.initial_stack();
+                os_context.extend(stack);
+            }
+        });
+    os_context
+}
+
 #[cfg(test)]
 mod test {
-    use super::StarknetRunner;
+    use super::{prepare_os_context, StarknetRunner};
     use crate::{
         business_logic::{
             fact_state::in_memory_state_reader::InMemoryStateReader,
@@ -246,16 +233,10 @@ mod test {
     #[test]
     fn prepare_os_context_test() {
         let program = cairo_rs::types::program::Program::default();
-        let cairo_runner = CairoRunner::new(&program, "all", false).unwrap();
-        let vm = VirtualMachine::new(true);
+        let mut cairo_runner = CairoRunner::new(&program, "all", false).unwrap();
+        let mut vm = VirtualMachine::new(true);
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
-        let hint_processor =
-            SyscallHintProcessor::new(BusinessLogicSyscallHandler::default_with(&mut state));
-
-        let mut runner = StarknetRunner::new(cairo_runner, vm, hint_processor);
-
-        let os_context = runner.prepare_os_context();
+        let os_context = prepare_os_context(&mut vm, &mut cairo_runner);
 
         // is expected to return a pointer to the first segment as there is nothing more in the vm
         let expected = Vec::from([MaybeRelocatable::from((0, 0))]);


### PR DESCRIPTION
Implementing `Default` for state implementations backed by an actual database is not really straightforward, like: what's a reasonable default for a database connection pool, or the storage commitment used by a particular state reader?

It turns out the only place this is used is in `ExecutionEntryPoint::run`, where a temporary state object is constructed to fetch the initial syscall_ptr. Instead of relying on `Default` this change modifies the code to construct a temporary state with a CachedState wrapping an InMemoryStateReader instead.