### PR TITLE
Fix circular dependency in devnet patch (and more)

### DIFF
--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -52,7 +52,6 @@ use types::general_config::{PyStarknetChainId, PyStarknetGeneralConfig, PyStarkn
 compile_error!("\"extension-module\" is incompatible with \"embedded-python\" as it inhibits linking with cpython");
 
 #[pymodule]
-#[pyo3(name = "starknet_rs_py")]
 pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     eprintln!("WARN: using starknet_rs_py");
 
@@ -375,15 +374,15 @@ mod test {
 
             starknet_rs_py(py, &m).unwrap();
 
-            let res = m.get_item("StarknetErrorCode");
+            let res = m.getattr("StarknetErrorCode");
 
             assert!(res.is_err(), "{res:?}");
 
             add_reexports(py, Some(m)).unwrap();
 
-            let res = m.get_item("StarknetErrorCode");
+            let res = m.getattr("StarknetErrorCode");
 
-            assert!(res.is_err(), "{res:?}");
+            assert!(res.is_ok(), "{res:?}");
         });
     }
 }

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -372,7 +372,7 @@ mod test {
             // try loading our module
             let m = PyModule::new(py, "starknet_rs_py").unwrap();
 
-            starknet_rs_py(py, &m).unwrap();
+            starknet_rs_py(py, m).unwrap();
 
             let res = m.getattr("StarknetErrorCode");
 

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -176,8 +176,6 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
 // NOTE: this is needed to avoid circular dependencies because of the monkeypatch.
 #[pyfunction(name = "init")]
 pub fn add_reexports(py: Python, opt_m: Option<&PyModule>) -> PyResult<()> {
-    eprintln!("DEBUG: initializing exports");
-
     // It's Option<_> to avoid having to pass the module in Python
     let m = match opt_m {
         Some(module) => module,

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -177,6 +177,8 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
 // NOTE: this is needed to avoid circular dependencies because of the monkeypatch.
 #[pyfunction(name = "init")]
 pub fn add_reexports(py: Python, opt_m: Option<&PyModule>) -> PyResult<()> {
+    eprintln!("DEBUG: initializing exports");
+
     // It's Option<_> to avoid having to pass the module in Python
     let m = match opt_m {
         Some(module) => module,

--- a/crates/starknet-rs-py/src/starknet_state.rs
+++ b/crates/starknet-rs-py/src/starknet_state.rs
@@ -182,6 +182,11 @@ impl PyStarknetState {
             .cloned()
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
+
+    pub fn clone(&self) -> Self {
+        let inner = self.inner.clone();
+        Self { inner }
+    }
 }
 
 #[cfg(test)]

--- a/crates/starknet-rs-py/src/starknet_state.rs
+++ b/crates/starknet-rs-py/src/starknet_state.rs
@@ -1,4 +1,5 @@
 use crate::cached_state::PyCachedState;
+use crate::types::block_info::PyBlockInfo;
 use crate::types::{
     call_info::PyCallInfo, contract_class::PyContractClass,
     general_config::PyStarknetGeneralConfig, transaction::PyTransaction,
@@ -186,6 +187,16 @@ impl PyStarknetState {
     pub fn clone(&self) -> Self {
         let inner = self.inner.clone();
         Self { inner }
+    }
+
+    #[getter("block_info")]
+    pub fn get_block_info(&self) -> PyBlockInfo {
+        self.inner.general_config.block_info().clone().into()
+    }
+
+    #[setter("block_info")]
+    pub fn set_block_info(&mut self, block_info: PyBlockInfo) {
+        *self.inner.general_config.block_info_mut() = block_info.into();
     }
 }
 

--- a/crates/starknet-rs-py/src/starknet_state.rs
+++ b/crates/starknet-rs-py/src/starknet_state.rs
@@ -7,7 +7,7 @@ use crate::types::{
 use cairo_felt::Felt252;
 use num_bigint::BigUint;
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
-use starknet_rs::business_logic::state::state_api::State;
+use starknet_rs::business_logic::state::state_api::{State, StateReader};
 use starknet_rs::testing::starknet_state::StarknetState as InnerStarknetState;
 use starknet_rs::utils::{felt_to_hash, Address, ClassHash};
 
@@ -173,6 +173,14 @@ impl PyStarknetState {
     #[getter]
     pub fn general_config(&self) -> PyStarknetGeneralConfig {
         self.inner.general_config.clone().into()
+    }
+
+    pub fn get_class_hash_at(&mut self, address: BigUint) -> PyResult<ClassHash> {
+        self.inner
+            .state
+            .get_class_hash_at(&Address(Felt252::from(address)))
+            .cloned()
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }
 

--- a/crates/starknet-rs-py/src/types/block_info.rs
+++ b/crates/starknet-rs-py/src/types/block_info.rs
@@ -91,6 +91,18 @@ impl PyBlockInfo {
     }
 }
 
+impl From<BlockInfo> for PyBlockInfo {
+    fn from(inner: BlockInfo) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<PyBlockInfo> for BlockInfo {
+    fn from(py_value: PyBlockInfo) -> Self {
+        py_value.inner
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/starknet-rs-py/src/types/call_info.rs
+++ b/crates/starknet-rs-py/src/types/call_info.rs
@@ -11,7 +11,7 @@ use starknet_rs::{
 };
 
 #[pyclass(name = "CallInfo")]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PyCallInfo {
     inner: CallInfo,
 }
@@ -121,5 +121,11 @@ impl PyCallInfo {
 impl From<CallInfo> for PyCallInfo {
     fn from(inner: CallInfo) -> Self {
         Self { inner }
+    }
+}
+
+impl From<PyCallInfo> for CallInfo {
+    fn from(py_value: PyCallInfo) -> Self {
+        py_value.inner
     }
 }

--- a/crates/starknet-rs-py/src/types/transaction.rs
+++ b/crates/starknet-rs-py/src/types/transaction.rs
@@ -1,6 +1,9 @@
 use num_bigint::BigUint;
 use pyo3::prelude::*;
-use starknet_rs::{business_logic::transaction::transactions::Transaction, utils::ClassHash};
+use starknet_rs::{
+    business_logic::transaction::transactions::Transaction,
+    definitions::transaction_type::TransactionType, utils::ClassHash,
+};
 
 #[pyclass(name = "Transaction")]
 pub struct PyTransaction {
@@ -56,6 +59,19 @@ impl PyTransactionType {
             Self::InitializeBlockInfo => "INITIALIZE_BLOCK_INFO",
             Self::InvokeFunction => "INVOKE_FUNCTION",
             Self::L1Handler => "L1_HANDLER",
+        }
+    }
+}
+
+impl From<PyTransactionType> for TransactionType {
+    fn from(py_tx_type: PyTransactionType) -> Self {
+        match py_tx_type {
+            PyTransactionType::Declare => Self::Declare,
+            PyTransactionType::Deploy => Self::Deploy,
+            PyTransactionType::DeployAccount => Self::DeployAccount,
+            PyTransactionType::InitializeBlockInfo => Self::InitializeBlockInfo,
+            PyTransactionType::InvokeFunction => Self::InvokeFunction,
+            PyTransactionType::L1Handler => Self::L1Handler,
         }
     }
 }

--- a/crates/starknet-rs-py/src/types/transaction_execution_info.rs
+++ b/crates/starknet-rs-py/src/types/transaction_execution_info.rs
@@ -1,5 +1,5 @@
 use super::{call_info::PyCallInfo, transaction::PyTransactionType};
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyValueError, prelude::*};
 use starknet_rs::business_logic::execution::objects::TransactionExecutionInfo;
 use std::collections::HashMap;
 
@@ -59,6 +59,14 @@ impl PyTransactionExecutionInfo {
     #[getter]
     fn transaction_type(&self) -> Option<u64> {
         Some(self.inner.tx_type?.into())
+    }
+
+    fn get_sorted_events(&self) -> PyResult<Vec<u64>> {
+        match self.inner.get_sorted_events() {
+            // TODO: we should return Vec<PyEvent>, but we didn't implement PyEvent
+            Ok(_res) => Ok(vec![]),
+            Err(err) => Err(PyValueError::new_err(err.to_string())),
+        }
     }
 }
 

--- a/crates/starknet-rs-py/src/types/transaction_execution_info.rs
+++ b/crates/starknet-rs-py/src/types/transaction_execution_info.rs
@@ -1,16 +1,36 @@
-use super::call_info::PyCallInfo;
+use super::{call_info::PyCallInfo, transaction::PyTransactionType};
 use pyo3::prelude::*;
 use starknet_rs::business_logic::execution::objects::TransactionExecutionInfo;
 use std::collections::HashMap;
 
 #[pyclass(name = "TransactionExecutionInfo")]
-#[derive(Debug)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct PyTransactionExecutionInfo {
     inner: TransactionExecutionInfo,
 }
 
 #[pymethods]
 impl PyTransactionExecutionInfo {
+    #[new]
+    fn new(
+        actual_fee: u64,
+        actual_resources: HashMap<String, usize>,
+        validate_info: Option<PyCallInfo>,
+        call_info: Option<PyCallInfo>,
+        fee_transfer_info: Option<PyCallInfo>,
+        tx_type: Option<PyTransactionType>,
+    ) -> Self {
+        let inner = TransactionExecutionInfo::new(
+            validate_info.map(Into::into),
+            call_info.map(Into::into),
+            fee_transfer_info.map(Into::into),
+            actual_fee,
+            actual_resources,
+            tx_type.map(Into::into),
+        );
+        Self { inner }
+    }
+
     #[getter]
     fn validate_info(&self) -> Option<PyCallInfo> {
         self.inner.validate_info.clone().map(Into::into)

--- a/scripts/move-devnet-sir.patch
+++ b/scripts/move-devnet-sir.patch
@@ -1,32 +1,33 @@
 diff --git a/starknet_devnet/__init__.py b/starknet_devnet/__init__.py
-index 51ffd51..48b2dca 100644
+index 51ffd51..1c8bcb0 100644
 --- a/starknet_devnet/__init__.py
 +++ b/starknet_devnet/__init__.py
-@@ -77,16 +77,12 @@ def _patch_cairo_vm():
- 
+@@ -78,15 +78,14 @@ def _patch_cairo_vm():
      warn("Using Cairo VM: Rust")
  
-+def _patch_starknet_rs():
-+    from starknet_devnet.starknet_rs_patch import starknet_rs_py_monkeypatch
-+    starknet_rs_py_monkeypatch()
  
 -_VM_VAR = "STARKNET_DEVNET_CAIRO_VM"
 -_cairo_vm = os.environ.get(_VM_VAR)
--
++def _patch_starknet_rs():
++    from starknet_devnet.starknet_rs_patch import starknet_rs_py_monkeypatch
+ 
 -if _cairo_vm == "rust":
 -    _patch_cairo_vm()
++    starknet_rs_py_monkeypatch()
++
 +    from .util import warn
++
++    warn("Patching...")
  
 -elif not _cairo_vm or _cairo_vm == "python":
 -    # python VM set by default
 -    pass
-+    warn("Patching...")
  
 -else:
 -    sys.exit(f"Error: Invalid value of environment variable {_VM_VAR}: '{_cairo_vm}'")
 +_patch_starknet_rs()
 diff --git a/starknet_devnet/account.py b/starknet_devnet/account.py
-index 36c7cb5..95b25e7 100644
+index 36c7cb5..253cb62 100644
 --- a/starknet_devnet/account.py
 +++ b/starknet_devnet/account.py
 @@ -2,12 +2,12 @@
@@ -46,15 +47,15 @@ index 36c7cb5..95b25e7 100644
  
  from starknet_devnet.account_util import set_balance
  from starknet_devnet.contract_class_wrapper import ContractClassWrapper
-@@ -54,12 +54,12 @@ class Account:
+@@ -54,12 +54,10 @@ class Account:
          """Deploy this account and set its balance."""
          starknet: Starknet = self.starknet_wrapper.starknet
          contract_class = self.contract_class
 -        await starknet.state.state.set_contract_class(
-+        starknet.state.set_contract_class(
-             self.class_hash_bytes, contract_class
-         )
+-            self.class_hash_bytes, contract_class
+-        )
 -        await starknet.state.state.deploy_contract(self.address, self.class_hash_bytes)
++        starknet.state.set_contract_class(self.class_hash_bytes, contract_class)
 +        starknet.state.deploy_contract(self.address, self.class_hash_bytes)
  
 -        await starknet.state.state.set_storage_at(
@@ -63,7 +64,7 @@ index 36c7cb5..95b25e7 100644
          )
  
 diff --git a/starknet_devnet/account_util.py b/starknet_devnet/account_util.py
-index df809df..a58f863 100644
+index df809df..4ec19a2 100644
 --- a/starknet_devnet/account_util.py
 +++ b/starknet_devnet/account_util.py
 @@ -7,13 +7,13 @@ from typing import List, NamedTuple, Sequence, Tuple
@@ -84,18 +85,18 @@ index df809df..a58f863 100644
  
  from .util import Uint256
  
-@@ -123,9 +123,9 @@ async def set_balance(state: StarknetState, address: int, balance: int):
+@@ -123,9 +123,5 @@ async def set_balance(state: StarknetState, address: int, balance: int):
      balance_address = pedersen_hash(get_selector_from_name("ERC20_balances"), address)
      balance_uint256 = Uint256.from_felt(balance)
  
 -    await state.state.set_storage_at(
-+    state.set_storage_at(
-         fee_token_address, balance_address, balance_uint256.low
-     )
+-        fee_token_address, balance_address, balance_uint256.low
+-    )
 -    await state.state.set_storage_at(
-+    state.set_storage_at(
-         fee_token_address, balance_address + 1, balance_uint256.high
-     )
+-        fee_token_address, balance_address + 1, balance_uint256.high
+-    )
++    state.set_storage_at(fee_token_address, balance_address, balance_uint256.low)
++    state.set_storage_at(fee_token_address, balance_address + 1, balance_uint256.high)
 diff --git a/starknet_devnet/block_info_generator.py b/starknet_devnet/block_info_generator.py
 index 3812ffa..def6a9f 100644
 --- a/starknet_devnet/block_info_generator.py
@@ -337,7 +338,7 @@ index 7727eae..c4c87f1 100644
  
  from starknet_devnet.constants import CAIRO_LANG_VERSION
 diff --git a/starknet_devnet/cairo_rs_py_patch.py b/starknet_devnet/cairo_rs_py_patch.py
-index 8a00a5b..6a7bffa 100644
+index 8a00a5b..28dde19 100644
 --- a/starknet_devnet/cairo_rs_py_patch.py
 +++ b/starknet_devnet/cairo_rs_py_patch.py
 @@ -30,25 +30,24 @@ from starkware.cairo.lang.vm.vm_exceptions import (
@@ -375,15 +376,17 @@ index 8a00a5b..6a7bffa 100644
  from starkware.starknet.services.api.contract_class import ContractClass
  from starkware.starkware_utils.error_handling import (
      ErrorCode,
-@@ -105,7 +104,7 @@ def cairo_rs_py_run(
+@@ -104,9 +103,7 @@ def cairo_rs_py_run(
+ 
      validate_contract_deployed(state=state, contract_address=self.contract_address)
  
-     initial_syscall_ptr = cast(
+-    initial_syscall_ptr = cast(
 -        RelocatableValue, os_context[starknet_abi.SYSCALL_PTR_OFFSET]
-+        RelocatableValue, os_context[SYSCALL_PTR_OFFSET]
-     )
+-    )
++    initial_syscall_ptr = cast(RelocatableValue, os_context[SYSCALL_PTR_OFFSET])
      syscall_handler = syscall_utils.BusinessLogicSysCallHandler(
          execute_entry_point_cls=ExecuteEntryPoint,
+         tx_execution_context=tx_execution_context,
 diff --git a/starknet_devnet/devnet_config.py b/starknet_devnet/devnet_config.py
 index 08f7daa..4dce439 100644
 --- a/starknet_devnet/devnet_config.py
@@ -421,7 +424,7 @@ index 08f7daa..4dce439 100644
          sys.exit(
              f"Error: The value of --chain-id must be in {{{CHAIN_IDS}}}, got: {chain_id}"
 diff --git a/starknet_devnet/fee_token.py b/starknet_devnet/fee_token.py
-index 0e646b4..87f3ced 100644
+index 0e646b4..7b0c881 100644
 --- a/starknet_devnet/fee_token.py
 +++ b/starknet_devnet/fee_token.py
 @@ -4,11 +4,12 @@ Fee token and its predefined constants.
@@ -441,23 +444,21 @@ index 0e646b4..87f3ced 100644
  
  from starknet_devnet.account_util import get_execute_args
  from starknet_devnet.chargeable_account import ChargeableAccount
-@@ -52,33 +53,31 @@ class FeeToken:
+@@ -52,33 +53,27 @@ class FeeToken:
          starknet: Starknet = self.starknet_wrapper.starknet
          contract_class = FeeToken.get_contract_class()
  
 -        await starknet.state.state.set_contract_class(
-+        starknet.state.set_contract_class(
-             FeeToken.HASH_BYTES, contract_class
-         )
+-            FeeToken.HASH_BYTES, contract_class
+-        )
++        starknet.state.set_contract_class(FeeToken.HASH_BYTES, contract_class)
  
 -        # pylint: disable=protected-access
 -        starknet.state.state.cache._class_hash_writes[
 -            FeeToken.ADDRESS
 -        ] = FeeToken.HASH_BYTES
 -        # replace with await starknet.state.state.deploy_contract
-+        starknet.state.deploy_contract(
-+            FeeToken.ADDRESS, FeeToken.HASH_BYTES
-+        )
++        starknet.state.deploy_contract(FeeToken.ADDRESS, FeeToken.HASH_BYTES)
  
          # mimic constructor
 -        await starknet.state.state.set_storage_at(
@@ -483,7 +484,7 @@ index 0e646b4..87f3ced 100644
              FeeToken.ADDRESS,
              get_selector_from_name("Ownable_owner"),
              ChargeableAccount.ADDRESS,
-@@ -115,7 +114,7 @@ class FeeToken:
+@@ -115,7 +110,7 @@ class FeeToken:
  
          # we need a funded account for this since the tx has to be signed and a fee will be charged
          # a user-intedded predeployed account cannot be used for this
@@ -492,7 +493,7 @@ index 0e646b4..87f3ced 100644
          chargeable_address = hex(ChargeableAccount.ADDRESS)
          signature, execute_calldata = get_execute_args(
              calls=[(hex(FeeToken.ADDRESS), "mint", calldata)],
-@@ -151,7 +150,7 @@ class FeeToken:
+@@ -151,7 +146,7 @@ class FeeToken:
              internal_tx = InternalInvokeFunction.from_external(
                  transaction, starknet.state.general_config
              )
@@ -530,7 +531,7 @@ index 419e4ab..6b1a2e2 100644
  
  from .block_info_generator import now
 diff --git a/starknet_devnet/general_config.py b/starknet_devnet/general_config.py
-index 2a3d036..4ab9189 100644
+index 2a3d036..bc6bcba 100644
 --- a/starknet_devnet/general_config.py
 +++ b/starknet_devnet/general_config.py
 @@ -1,8 +1,14 @@
@@ -544,7 +545,7 @@ index 2a3d036..4ab9189 100644
 +    CONTRACT_STATES_COMMITMENT_TREE_HEIGHT,
 +    EVENT_COMMITMENT_TREE_HEIGHT,
 +    CONTRACT_ADDRESS_BITS,
-+    TRANSACTION_COMMITMENT_TREE_HEIGHT
++    TRANSACTION_COMMITMENT_TREE_HEIGHT,
 +)
 +from starknet_rs_py import (
      DEFAULT_GAS_PRICE,
@@ -651,17 +652,35 @@ index 8ed2ee8..e2ccbab 100644
      DeployAccount,
 diff --git a/starknet_devnet/starknet_rs_patch.py b/starknet_devnet/starknet_rs_patch.py
 new file mode 100644
-index 0000000..c902bc8
+index 0000000..1765daf
 --- /dev/null
 +++ b/starknet_devnet/starknet_rs_patch.py
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,23 @@
 +import sys
 +import starknet_rs_py
 +
++
 +def starknet_rs_py_monkeypatch():
-+    setattr(sys.modules["starkware.starknet.services.api.contract_class"], "ContractClass", starknet_rs_py.ContractClass)
++    setattr(
++        sys.modules["starkware.starknet.services.api.contract_class"],
++        "ContractClass",
++        starknet_rs_py.ContractClass,
++    )
++    for obj in (
++        "InternalDeclare",
++        "InternalDeploy",
++        "InternalDeployAccount",
++        "InternalInvokeFunction",
++        "InternalL1Handler",
++        "InternalTransaction",
++    ):
++        setattr(
++            sys.modules["starkware.starknet.business_logic.transaction.objects"],
++            obj,
++            getattr(starknet_rs_py, obj),
++        )
 diff --git a/starknet_devnet/starknet_wrapper.py b/starknet_devnet/starknet_wrapper.py
-index ff38d1c..41e08d1 100644
+index ff38d1c..26555cd 100644
 --- a/starknet_devnet/starknet_wrapper.py
 +++ b/starknet_devnet/starknet_wrapper.py
 @@ -7,9 +7,9 @@ from types import TracebackType
@@ -873,16 +892,18 @@ index ff38d1c..41e08d1 100644
              tx_handler.internal_calls = (
                  tx_handler.execution_info.call_info.internal_calls
              )
-@@ -693,7 +696,7 @@ class StarknetWrapper:
+@@ -693,9 +696,7 @@ class StarknetWrapper:
          for transaction in transactions_to_execute:
              async with self.__get_transaction_handler() as tx_handler:
                  tx_handler.internal_tx = transaction
 -                tx_handler.execution_info = await state.execute_tx(
-+                tx_handler.execution_info = state.execute_tx(
-                     tx_handler.internal_tx
-                 )
+-                    tx_handler.internal_tx
+-                )
++                tx_handler.execution_info = state.execute_tx(tx_handler.internal_tx)
                  tx_handler.internal_calls = (
-@@ -752,7 +755,7 @@ class StarknetWrapper:
+                     tx_handler.execution_info.call_info.internal_calls
+                 )
+@@ -752,7 +753,7 @@ class StarknetWrapper:
          """Calculates traces and fees by simulating tx on state copy.
          Uses the resulting state for each consecutive estimation"""
          state = await self.__get_query_state(block_id)
@@ -891,7 +912,7 @@ index ff38d1c..41e08d1 100644
  
          traces = []
          fee_estimation_infos = []
-@@ -791,7 +794,7 @@ class StarknetWrapper:
+@@ -791,7 +792,7 @@ class StarknetWrapper:
              traces.append(trace)
  
              fee_estimation_info = get_fee_estimation_info(
@@ -900,7 +921,7 @@ index ff38d1c..41e08d1 100644
              )
              fee_estimation_infos.append(fee_estimation_info)
  
-@@ -809,7 +812,7 @@ class StarknetWrapper:
+@@ -809,7 +810,7 @@ class StarknetWrapper:
  
          execution_info = await internal_call.apply_state_updates(
              # pylint: disable=protected-access
@@ -909,7 +930,7 @@ index ff38d1c..41e08d1 100644
              state.general_config,
          )
  
-@@ -820,7 +823,7 @@ class StarknetWrapper:
+@@ -820,7 +821,7 @@ class StarknetWrapper:
          )
  
          fee_estimation_info = get_fee_estimation_info(
@@ -918,7 +939,7 @@ index ff38d1c..41e08d1 100644
          )
          return fee_estimation_info
  
-@@ -841,11 +844,11 @@ class StarknetWrapper:
+@@ -841,11 +842,11 @@ class StarknetWrapper:
      ):
          """Returns nonce of contract with `contract_address`"""
          state = await self.__get_query_state(block_id)
@@ -932,7 +953,7 @@ index ff38d1c..41e08d1 100644
              to_bytes(STARKNET_CLI_ACCOUNT_CLASS_HASH), oz_account_class
          )
  
-@@ -860,7 +863,7 @@ class StarknetWrapper:
+@@ -860,7 +861,7 @@ class StarknetWrapper:
          Check if the contract is deployed.
          """
          assert isinstance(address, int)
@@ -988,7 +1009,7 @@ index d7aa7b7..03fea29 100644
      TransactionExecutionInfo,
  )
 diff --git a/starknet_devnet/udc.py b/starknet_devnet/udc.py
-index 5799dba..6732600 100644
+index 5799dba..c9027bf 100644
 --- a/starknet_devnet/udc.py
 +++ b/starknet_devnet/udc.py
 @@ -2,8 +2,9 @@
@@ -1002,20 +1023,17 @@ index 5799dba..6732600 100644
  
  
  class UDC:
-@@ -38,8 +39,8 @@ class UDC:
+@@ -38,8 +39,6 @@ class UDC:
          starknet: Starknet = self.starknet_wrapper.starknet
          contract_class = UDC.get_contract_class()
  
 -        await starknet.state.state.set_contract_class(UDC.HASH_BYTES, contract_class)
--
++        starknet.state.set_contract_class(UDC.HASH_BYTES, contract_class)
+ 
 -        # pylint: disable=protected-access
 -        starknet.state.state.cache._class_hash_writes[UDC.ADDRESS] = UDC.HASH_BYTES
 -        # replace with await starknet.state.state.deploy_contract
-+        starknet.state.set_contract_class(UDC.HASH_BYTES, contract_class)
-+ 
-+        starknet.state.deploy_contract(
-+            UDC.ADDRESS, UDC.HASH_BYTES
-+        )
++        starknet.state.deploy_contract(UDC.ADDRESS, UDC.HASH_BYTES)
 diff --git a/starknet_devnet/util.py b/starknet_devnet/util.py
 index ea98aa9..f3749a5 100644
 --- a/starknet_devnet/util.py

--- a/scripts/move-devnet-sir.patch
+++ b/scripts/move-devnet-sir.patch
@@ -661,7 +661,7 @@ index 0000000..c902bc8
 +def starknet_rs_py_monkeypatch():
 +    setattr(sys.modules["starkware.starknet.services.api.contract_class"], "ContractClass", starknet_rs_py.ContractClass)
 diff --git a/starknet_devnet/starknet_wrapper.py b/starknet_devnet/starknet_wrapper.py
-index ff38d1c..c961c4c 100644
+index ff38d1c..4dc7629 100644
 --- a/starknet_devnet/starknet_wrapper.py
 +++ b/starknet_devnet/starknet_wrapper.py
 @@ -7,9 +7,9 @@ from types import TracebackType
@@ -736,6 +736,15 @@ index ff38d1c..c961c4c 100644
              await self.__create_genesis_block()
              self.__initialized = True
  
+@@ -211,7 +212,7 @@ class StarknetWrapper:
+         return await self.blocks.generate_empty_block(self.get_state(), state_update)
+ 
+     async def __preserve_current_state(self, state: CachedState):
+-        self.__current_cached_state = deepcopy(state)
++        self.__current_cached_state = state.clone()
+ 
+     async def __init_starknet(self):
+         """
 @@ -230,8 +231,10 @@ class StarknetWrapper:
                      chain_id=self.config.chain_id,
                  )
@@ -749,15 +758,67 @@ index ff38d1c..c961c4c 100644
                  )
  
          return self.starknet
-@@ -322,7 +325,7 @@ class StarknetWrapper:
+@@ -243,7 +246,7 @@ class StarknetWrapper:
+         """
+         Returns the StarknetState of the underlying Starknet instance.
+         """
+-        return self.starknet.state
++        return self.starknet
+ 
+     async def _update_pending_state(
+         self,
+@@ -316,13 +319,13 @@ class StarknetWrapper:
+             # calculate class hash here if execution fails
+             class_hash_int = int.from_bytes(tx_handler.internal_tx.class_hash, "big")
+ 
+-            tx_handler.execution_info = await state.execute_tx(tx_handler.internal_tx)
++            tx_handler.execution_info = state.execute_tx(tx_handler.internal_tx)
+ 
+             tx_handler.explicitly_declared.append(class_hash_int)
  
              # alpha-goerli allows multiple declarations of the same class.
              # Even though execute_tx is performed, class needs to be set explicitly
 -            await state.state.set_contract_class(
-+            await state.set_contract_class(
++            state.set_contract_class(
                  class_hash=tx_handler.internal_tx.class_hash,
                  contract_class=external_tx.contract_class,
              )
+@@ -475,7 +478,7 @@ class StarknetWrapper:
+ 
+         async with self.__get_transaction_handler() as tx_handler:
+             tx_handler.internal_tx = internal_tx
+-            await self.get_state().state.set_contract_class(
++            self.get_state().state.set_contract_class(
+                 class_hash=internal_tx.class_hash, contract_class=contract_class
+             )
+             tx_handler.execution_info = await self.__deploy(internal_tx)
+@@ -500,7 +503,7 @@ class StarknetWrapper:
+             tx_handler.internal_tx = InternalInvokeFunction.from_external(
+                 external_tx, state.general_config
+             )
+-            tx_handler.execution_info = await state.execute_tx(tx_handler.internal_tx)
++            tx_handler.execution_info = state.execute_tx(tx_handler.internal_tx)
+             tx_handler.internal_calls = (
+                 tx_handler.execution_info.call_info.internal_calls
+             )
+@@ -540,7 +543,7 @@ class StarknetWrapper:
+         """Perform call according to specifications in `transaction`."""
+         state = await self.__get_query_state(block_id)
+ 
+-        call_info = await state.copy().execute_entry_point_raw(
++        call_info = state.copy().execute_entry_point_raw(
+             contract_address=transaction.contract_address,
+             selector=transaction.entry_point_selector,
+             calldata=transaction.calldata,
+@@ -556,7 +559,7 @@ class StarknetWrapper:
+         This way InternalDeploy doesn't have to be created twice, calculating hash every time.
+         """
+         state = self.get_state()
+-        tx_execution_info = await state.execute_tx(tx=deploy_tx)
++        tx_execution_info = state.execute_tx(tx=deploy_tx)
+         return tx_execution_info
+ 
+     async def _register_new_contracts(
 @@ -591,7 +594,7 @@ class StarknetWrapper:
      ) -> int:
          """Return class hash give the contract address"""
@@ -781,10 +842,28 @@ index ff38d1c..c961c4c 100644
          """
          state = await self.__get_query_state(block_id)
 -        return hex(await state.state.get_storage_at(contract_address, key))
-+        return hex(await state.get_storage_at(contract_address, key))
++        return hex(state.get_storage_at(contract_address, key))
  
      async def load_messaging_contract_in_l1(
          self, network_url: str, contract_address: str, network_id: str
+@@ -675,7 +678,7 @@ class StarknetWrapper:
+         # Execute transactions inside StarknetWrapper
+         async with self.__get_transaction_handler() as tx_handler:
+             tx_handler.internal_tx = transaction
+-            tx_handler.execution_info = await state.execute_tx(tx_handler.internal_tx)
++            tx_handler.execution_info = state.execute_tx(tx_handler.internal_tx)
+             tx_handler.internal_calls = (
+                 tx_handler.execution_info.call_info.internal_calls
+             )
+@@ -693,7 +696,7 @@ class StarknetWrapper:
+         for transaction in transactions_to_execute:
+             async with self.__get_transaction_handler() as tx_handler:
+                 tx_handler.internal_tx = transaction
+-                tx_handler.execution_info = await state.execute_tx(
++                tx_handler.execution_info = state.execute_tx(
+                     tx_handler.internal_tx
+                 )
+                 tx_handler.internal_calls = (
 @@ -752,7 +755,7 @@ class StarknetWrapper:
          """Calculates traces and fees by simulating tx on state copy.
          Uses the resulting state for each consecutive estimation"""
@@ -821,15 +900,28 @@ index ff38d1c..c961c4c 100644
          )
          return fee_estimation_info
  
-@@ -841,7 +844,7 @@ class StarknetWrapper:
+@@ -841,11 +844,11 @@ class StarknetWrapper:
      ):
          """Returns nonce of contract with `contract_address`"""
          state = await self.__get_query_state(block_id)
 -        return await state.state.get_nonce_at(contract_address)
-+        return await state.get_nonce_at(contract_address)
++        return state.get_nonce_at(contract_address)
  
      async def __predeclare_starknet_cli_account(self):
          """Predeclares the account class used by Starknet CLI"""
+-        await self.get_state().state.set_contract_class(
++        self.get_state().state.set_contract_class(
+             to_bytes(STARKNET_CLI_ACCOUNT_CLASS_HASH), oz_account_class
+         )
+ 
+@@ -861,6 +864,6 @@ class StarknetWrapper:
+         """
+         assert isinstance(address, int)
+         cached_state = self.get_state().state
+-        class_hash_bytes = await cached_state.get_class_hash_at(address)
++        class_hash_bytes = cached_state.get_class_hash_at(address)
+         class_hash_int = int.from_bytes(class_hash_bytes, "big")
+         return bool(class_hash_int)
 diff --git a/starknet_devnet/state_archive.py b/starknet_devnet/state_archive.py
 index 95e3ab2..57df788 100644
 --- a/starknet_devnet/state_archive.py

--- a/scripts/move-devnet-sir.patch
+++ b/scripts/move-devnet-sir.patch
@@ -661,7 +661,7 @@ index 0000000..c902bc8
 +def starknet_rs_py_monkeypatch():
 +    setattr(sys.modules["starkware.starknet.services.api.contract_class"], "ContractClass", starknet_rs_py.ContractClass)
 diff --git a/starknet_devnet/starknet_wrapper.py b/starknet_devnet/starknet_wrapper.py
-index ff38d1c..4dc7629 100644
+index ff38d1c..41e08d1 100644
 --- a/starknet_devnet/starknet_wrapper.py
 +++ b/starknet_devnet/starknet_wrapper.py
 @@ -7,9 +7,9 @@ from types import TracebackType
@@ -758,15 +758,15 @@ index ff38d1c..4dc7629 100644
                  )
  
          return self.starknet
-@@ -243,7 +246,7 @@ class StarknetWrapper:
-         """
-         Returns the StarknetState of the underlying Starknet instance.
-         """
--        return self.starknet.state
-+        return self.starknet
- 
-     async def _update_pending_state(
-         self,
+@@ -260,7 +263,7 @@ class StarknetWrapper:
+         # state update and preservation
+         previous_state = self.__current_cached_state
+         assert previous_state is not None
+-        current_state = self.get_state().state
++        current_state = self.get_state()
+         current_state.block_info = self.block_info_generator.next_block(
+             block_info=current_state.block_info,
+             general_config=self.get_state().general_config,
 @@ -316,13 +319,13 @@ class StarknetWrapper:
              # calculate class hash here if execution fails
              class_hash_int = int.from_bytes(tx_handler.internal_tx.class_hash, "big")
@@ -783,12 +783,21 @@ index ff38d1c..4dc7629 100644
                  class_hash=tx_handler.internal_tx.class_hash,
                  contract_class=external_tx.contract_class,
              )
+@@ -331,7 +334,7 @@ class StarknetWrapper:
+ 
+     def _update_block_number(self):
+         """Updates just the block number. Returns the old block info to allow reverting"""
+-        current_cached_state = self.get_state().state
++        current_cached_state = self.get_state()
+         block_info = current_cached_state.block_info
+         current_cached_state.block_info = BlockInfo(
+             gas_price=block_info.gas_price,
 @@ -475,7 +478,7 @@ class StarknetWrapper:
  
          async with self.__get_transaction_handler() as tx_handler:
              tx_handler.internal_tx = internal_tx
 -            await self.get_state().state.set_contract_class(
-+            self.get_state().state.set_contract_class(
++            self.get_state().set_contract_class(
                  class_hash=internal_tx.class_hash, contract_class=contract_class
              )
              tx_handler.execution_info = await self.__deploy(internal_tx)
@@ -819,6 +828,15 @@ index ff38d1c..4dc7629 100644
          return tx_execution_info
  
      async def _register_new_contracts(
+@@ -582,7 +585,7 @@ class StarknetWrapper:
+ 
+     async def get_class_by_hash(self, class_hash: int) -> ContractClass:
+         """Return contract class given class hash"""
+-        cached_state = self.get_state().state
++        cached_state = self.get_state()
+         class_hash_bytes = to_bytes(class_hash)
+         return await cached_state.get_contract_class(class_hash_bytes)
+ 
 @@ -591,7 +594,7 @@ class StarknetWrapper:
      ) -> int:
          """Return class hash give the contract address"""
@@ -910,15 +928,17 @@ index ff38d1c..4dc7629 100644
      async def __predeclare_starknet_cli_account(self):
          """Predeclares the account class used by Starknet CLI"""
 -        await self.get_state().state.set_contract_class(
-+        self.get_state().state.set_contract_class(
++        self.get_state().set_contract_class(
              to_bytes(STARKNET_CLI_ACCOUNT_CLASS_HASH), oz_account_class
          )
  
-@@ -861,6 +864,6 @@ class StarknetWrapper:
+@@ -860,7 +863,7 @@ class StarknetWrapper:
+         Check if the contract is deployed.
          """
          assert isinstance(address, int)
-         cached_state = self.get_state().state
+-        cached_state = self.get_state().state
 -        class_hash_bytes = await cached_state.get_class_hash_at(address)
++        cached_state = self.get_state()
 +        class_hash_bytes = cached_state.get_class_hash_at(address)
          class_hash_int = int.from_bytes(class_hash_bytes, "big")
          return bool(class_hash_int)

--- a/scripts/move-devnet-sir.patch
+++ b/scripts/move-devnet-sir.patch
@@ -227,7 +227,7 @@ index 3d4e0d6..7eb82ed 100644
      PENDING_BLOCK_ID,
      BlockStatus,
 diff --git a/starknet_devnet/blueprints/rpc/structures/payloads.py b/starknet_devnet/blueprints/rpc/structures/payloads.py
-index 28f24df..a7c5a24 100644
+index 28f24df..638360a 100644
 --- a/starknet_devnet/blueprints/rpc/structures/payloads.py
 +++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
 @@ -7,11 +7,11 @@ from __future__ import annotations
@@ -236,11 +236,12 @@ index 28f24df..a7c5a24 100644
  from marshmallow.exceptions import MarshmallowError
 -from starkware.starknet.definitions.general_config import StarknetGeneralConfig
 -from starkware.starknet.public.abi import AbiEntryType
-+from starknet_rs_py import StarknetGeneralConfig
-+from starknet_rs_py import AbiEntryType
- from starkware.starknet.services.api.contract_class import ContractClass
+-from starkware.starknet.services.api.contract_class import ContractClass
 -from starkware.starknet.services.api.feeder_gateway.request_objects import CallFunction
 -from starkware.starknet.services.api.feeder_gateway.response_objects import (
++from starknet_rs_py import StarknetGeneralConfig
++from starknet_rs_py import AbiEntryType
++from starknet_rs_py import ContractClass
 +from starknet_rs_py import CallFunction
 +from starknet_rs_py import (
      BlockStateUpdate,
@@ -387,8 +388,21 @@ index 8a00a5b..28dde19 100644
      syscall_handler = syscall_utils.BusinessLogicSysCallHandler(
          execute_entry_point_cls=ExecuteEntryPoint,
          tx_execution_context=tx_execution_context,
+diff --git a/starknet_devnet/contract_class_wrapper.py b/starknet_devnet/contract_class_wrapper.py
+index 7eb1fae..be5a72c 100644
+--- a/starknet_devnet/contract_class_wrapper.py
++++ b/starknet_devnet/contract_class_wrapper.py
+@@ -4,7 +4,7 @@ import os
+ from dataclasses import dataclass
+ 
+ from starkware.python.utils import to_bytes
+-from starkware.starknet.services.api.contract_class import ContractClass
++from starknet_rs_py import ContractClass
+ 
+ 
+ @dataclass
 diff --git a/starknet_devnet/devnet_config.py b/starknet_devnet/devnet_config.py
-index 08f7daa..4dce439 100644
+index 08f7daa..fb32787 100644
 --- a/starknet_devnet/devnet_config.py
 +++ b/starknet_devnet/devnet_config.py
 @@ -13,10 +13,10 @@ from aiohttp.client_exceptions import ClientConnectorError, InvalidURL
@@ -397,10 +411,11 @@ index 08f7daa..4dce439 100644
  from starkware.python.utils import to_bytes
 -from starkware.starknet.core.os.class_hash import compute_class_hash
 -from starkware.starknet.definitions.general_config import StarknetChainId
+-from starkware.starknet.services.api.contract_class import ContractClass
+-from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
 +from starknet_rs_py import compute_class_hash
 +from starknet_rs_py import StarknetChainId
- from starkware.starknet.services.api.contract_class import ContractClass
--from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
++from starknet_rs_py import ContractClass
 +from starknet_rs_py import (
      FeederGatewayClient,
  )
@@ -424,7 +439,7 @@ index 08f7daa..4dce439 100644
          sys.exit(
              f"Error: The value of --chain-id must be in {{{CHAIN_IDS}}}, got: {chain_id}"
 diff --git a/starknet_devnet/fee_token.py b/starknet_devnet/fee_token.py
-index 0e646b4..7b0c881 100644
+index 0e646b4..b20ddef 100644
 --- a/starknet_devnet/fee_token.py
 +++ b/starknet_devnet/fee_token.py
 @@ -4,11 +4,12 @@ Fee token and its predefined constants.
@@ -432,12 +447,13 @@ index 0e646b4..7b0c881 100644
  from starkware.python.utils import to_bytes
  from starkware.solidity.utils import load_nearby_contract
 -from starkware.starknet.compiler.compile import get_selector_from_name
-+
-+from starknet_rs_py import get_selector_from_name
- from starkware.starknet.services.api.contract_class import ContractClass
+-from starkware.starknet.services.api.contract_class import ContractClass
 -from starkware.starknet.services.api.gateway.transaction import InvokeFunction
 -from starkware.starknet.testing.contract import StarknetContract
 -from starkware.starknet.testing.starknet import Starknet
++
++from starknet_rs_py import get_selector_from_name
++from starknet_rs_py import ContractClass
 +from starknet_rs_py import InvokeFunction
 +from starknet_rs_py import StarknetContract
 +from starknet_rs_py import Starknet
@@ -503,7 +519,7 @@ index 0e646b4..7b0c881 100644
              _, tx_hash_int = await self.starknet_wrapper.invoke(transaction)
              tx_hash = hex(tx_hash_int)
 diff --git a/starknet_devnet/forked_state.py b/starknet_devnet/forked_state.py
-index 419e4ab..6b1a2e2 100644
+index 419e4ab..69735fc 100644
 --- a/starknet_devnet/forked_state.py
 +++ b/starknet_devnet/forked_state.py
 @@ -5,16 +5,16 @@ import json
@@ -514,12 +530,13 @@ index 419e4ab..6b1a2e2 100644
 -from starkware.starknet.business_logic.state.state_api import StateReader
 -from starkware.starknet.definitions.constants import UNINITIALIZED_CLASS_HASH
 -from starkware.starknet.definitions.general_config import StarknetChainId
+-from starkware.starknet.services.api.contract_class import ContractClass
+-from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
 +from starknet_rs_py import BlockInfo, CachedState
 +from starknet_rs_py import StateReader
 +from starknet_rs_py import UNINITIALIZED_CLASS_HASH
 +from starknet_rs_py import StarknetChainId
- from starkware.starknet.services.api.contract_class import ContractClass
--from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
++from starknet_rs_py import ContractClass
 +from starknet_rs_py import (
      FeederGatewayClient,
  )
@@ -652,35 +669,44 @@ index 8ed2ee8..e2ccbab 100644
      DeployAccount,
 diff --git a/starknet_devnet/starknet_rs_patch.py b/starknet_devnet/starknet_rs_patch.py
 new file mode 100644
-index 0000000..1765daf
+index 0000000..35413c0
 --- /dev/null
 +++ b/starknet_devnet/starknet_rs_patch.py
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,32 @@
 +import sys
++
 +import starknet_rs_py
 +
 +
 +def starknet_rs_py_monkeypatch():
++    # used internally
 +    setattr(
 +        sys.modules["starkware.starknet.services.api.contract_class"],
 +        "ContractClass",
 +        starknet_rs_py.ContractClass,
 +    )
++
 +    for obj in (
 +        "InternalDeclare",
 +        "InternalDeploy",
 +        "InternalDeployAccount",
 +        "InternalInvokeFunction",
-+        "InternalL1Handler",
-+        "InternalTransaction",
++        # "InternalL1Handler",
++        # "InternalTransaction",
 +    ):
++        import starkware.starknet.business_logic.transaction.objects
++
 +        setattr(
 +            sys.modules["starkware.starknet.business_logic.transaction.objects"],
 +            obj,
 +            getattr(starknet_rs_py, obj),
 +        )
++
++    # finish initializing module
++    # needed because of circular dependencies between starknet_rs_py and cairo-lang
++    starknet_rs_py.init()
 diff --git a/starknet_devnet/starknet_wrapper.py b/starknet_devnet/starknet_wrapper.py
-index ff38d1c..26555cd 100644
+index ff38d1c..a937b4d 100644
 --- a/starknet_devnet/starknet_wrapper.py
 +++ b/starknet_devnet/starknet_wrapper.py
 @@ -7,9 +7,9 @@ from types import TracebackType
@@ -710,10 +736,11 @@ index ff38d1c..26555cd 100644
  )
 -from starkware.starknet.definitions.error_codes import StarknetErrorCode
 -from starkware.starknet.definitions.transaction_type import TransactionType
+-from starkware.starknet.services.api.contract_class import ContractClass, EntryPointType
+-from starkware.starknet.services.api.feeder_gateway.request_objects import (
 +from starknet_rs_py import StarknetErrorCode
 +from starknet_rs_py import TransactionType
- from starkware.starknet.services.api.contract_class import ContractClass, EntryPointType
--from starkware.starknet.services.api.feeder_gateway.request_objects import (
++from starknet_rs_py import ContractClass, EntryPointType
 +from starknet_rs_py import StarknetState
 +from starknet_rs_py import (
      CallFunction,
@@ -1009,16 +1036,17 @@ index d7aa7b7..03fea29 100644
      TransactionExecutionInfo,
  )
 diff --git a/starknet_devnet/udc.py b/starknet_devnet/udc.py
-index 5799dba..c9027bf 100644
+index 5799dba..8aab778 100644
 --- a/starknet_devnet/udc.py
 +++ b/starknet_devnet/udc.py
 @@ -2,8 +2,9 @@
  
  from starkware.python.utils import to_bytes
  from starkware.solidity.utils import load_nearby_contract
-+
- from starkware.starknet.services.api.contract_class import ContractClass
+-from starkware.starknet.services.api.contract_class import ContractClass
 -from starkware.starknet.testing.starknet import Starknet
++
++from starknet_rs_py import ContractClass
 +from starknet_rs_py import Starknet
  
  
@@ -1057,6 +1085,15 @@ index ea98aa9..f3749a5 100644
  from starkware.starkware_utils.error_handling import StarkException
  
  
+diff --git a/test/__init__.py b/test/__init__.py
+index e69de29..848ca1c 100644
+--- a/test/__init__.py
++++ b/test/__init__.py
+@@ -0,0 +1,4 @@
++import starknet_rs_py
++
++# needed for initializing reexports
++starknet_rs_py.init()
 diff --git a/test/account.py b/test/account.py
 index 181d822..49c2fb2 100644
 --- a/test/account.py
@@ -1244,18 +1281,20 @@ index 20127a6..0d51f65 100644
  )
  
 diff --git a/test/test_account_custom.py b/test/test_account_custom.py
-index 8cc6292..345b23f 100644
+index 8cc6292..a84e536 100644
 --- a/test/test_account_custom.py
 +++ b/test/test_account_custom.py
-@@ -4,7 +4,7 @@ import os
+@@ -4,8 +4,8 @@ import os
  import subprocess
  
  import pytest
 -from starkware.starknet.core.os.class_hash import compute_class_hash
+-from starkware.starknet.services.api.contract_class import ContractClass
 +from starknet_rs_py import compute_class_hash
- from starkware.starknet.services.api.contract_class import ContractClass
++from starknet_rs_py import ContractClass
  
  from .account import invoke
+ from .shared import (
 diff --git a/test/test_account_predeployed.py b/test/test_account_predeployed.py
 index a85fd78..3e6dff6 100644
 --- a/test/test_account_predeployed.py
@@ -1339,7 +1378,7 @@ index f32162c..7401e79 100644
  from .account import declare
  from .settings import APP_URL
 diff --git a/test/test_deploy.py b/test/test_deploy.py
-index 0b621a9..c943d50 100644
+index 0b621a9..a6dc10e 100644
 --- a/test/test_deploy.py
 +++ b/test/test_deploy.py
 @@ -3,22 +3,22 @@
@@ -1354,11 +1393,12 @@ index 0b621a9..c943d50 100644
 -from starkware.starknet.definitions.general_config import DEFAULT_CHAIN_ID
 -from starkware.starknet.definitions.transaction_type import TransactionType
 -from starkware.starknet.public.abi import get_selector_from_name
+-from starkware.starknet.services.api.contract_class import ContractClass
+-from starkware.starknet.services.api.feeder_gateway.response_objects import (
 +from starknet_rs_py import DEFAULT_CHAIN_ID
 +from starknet_rs_py import TransactionType
 +from starknet_rs_py import get_selector_from_name
- from starkware.starknet.services.api.contract_class import ContractClass
--from starkware.starknet.services.api.feeder_gateway.response_objects import (
++from starknet_rs_py import ContractClass
 +from starknet_rs_py import (
      TransactionStatus,
  )
@@ -1512,7 +1552,7 @@ index 00f084b..713946f 100644
  from .account import invoke
  from .shared import (
 diff --git a/test/util.py b/test/util.py
-index 5873dc2..2132719 100644
+index 5873dc2..14eae04 100644
 --- a/test/util.py
 +++ b/test/util.py
 @@ -12,11 +12,11 @@ from typing import IO, List
@@ -1522,11 +1562,12 @@ index 5873dc2..2132719 100644
 -from starkware.starknet.cli.starknet_cli import get_salt
 -from starkware.starknet.definitions.error_codes import StarknetErrorCode
 -from starkware.starknet.definitions.transaction_type import TransactionType
+-from starkware.starknet.services.api.contract_class import ContractClass
+-from starkware.starknet.services.api.gateway.transaction import Deploy
 +from starknet_rs_py import get_salt
 +from starknet_rs_py import StarknetErrorCode
 +from starknet_rs_py import TransactionType
- from starkware.starknet.services.api.contract_class import ContractClass
--from starkware.starknet.services.api.gateway.transaction import Deploy
++from starknet_rs_py import ContractClass
 +from starknet_rs_py import Deploy
  
  from starknet_devnet.general_config import DEFAULT_GENERAL_CONFIG

--- a/src/testing/starknet_state.rs
+++ b/src/testing/starknet_state.rs
@@ -34,6 +34,7 @@ use std::collections::HashMap;
 
 // ---------------------------------------------------------------------
 /// StarkNet testing object. Represents a state of a StarkNet network.
+#[derive(Clone)]
 pub struct StarknetState {
     pub state: CachedState<InMemoryStateReader>,
     pub general_config: StarknetGeneralConfig,


### PR DESCRIPTION
~Blocked by: #249~

List of changes:
- Dodge `isinstance` checks in _cairo-lang_ with a _"monkeypatch"_ similar to the one used in _cairo-rs_, that replaces classes in the _cairo-lang_ side.
- Split exporting of _starknet-rs-py_ objects and reexporting of _cairo-lang_ ones. The reexports inside the module were loading some of the modules that needed patched dependencies before those dependencies were patched.
- Add a test for this.
- Add some missing methods, constructors, and `#[getters]`
- Among those, a trivial `get_sorted_events` with a TODO.