### PR TITLE
Add missing bits of transaction fee calculation

### DIFF
--- a/src/business_logic/transaction/fee.rs
+++ b/src/business_logic/transaction/fee.rs
@@ -89,8 +89,6 @@ pub(crate) fn calculate_l1_gas_by_cairo_usage(
     general_config: &StarknetGeneralConfig,
     cairo_resource_usage: &HashMap<String, usize>,
 ) -> Result<f64, TransactionError> {
-    // Ensure that every key in `general_config.cairo_resource_fee_weights` is present in
-    // `cairo_resource_usage`.
     if !cairo_resource_usage
         .keys()
         .all(|k| k == "l1_gas_usage" || general_config.cairo_resource_fee_weights.contains_key(k))

--- a/src/business_logic/transaction/fee.rs
+++ b/src/business_logic/transaction/fee.rs
@@ -91,10 +91,9 @@ pub(crate) fn calculate_l1_gas_by_cairo_usage(
 ) -> Result<f64, TransactionError> {
     // Ensure that every key in `general_config.cairo_resource_fee_weights` is present in
     // `cairo_resource_usage`.
-    if !general_config
-        .cairo_resource_fee_weights
+    if !cairo_resource_usage
         .keys()
-        .all(|k| cairo_resource_usage.contains_key(k))
+        .all(|k| k == "l1_gas_usage" || general_config.cairo_resource_fee_weights.contains_key(k))
     {
         return Err(TransactionError::ResourcesError);
     }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -832,7 +832,7 @@ mod tests {
 
         let chain_id = StarknetChainId::TestNet.to_felt();
 
-        // Use max_fee with certain value to make sure that the transaction fails due to weight resources
+        // Use non-zero value so that the actual fee calculation is done
         let internal_declare = InternalDeclare::new(
             fib_contract_class,
             chain_id,
@@ -844,9 +844,10 @@ mod tests {
         )
         .unwrap();
 
+        // We expect a fee transfer failure because the fee token contract is not set up
         assert_matches!(
             internal_declare.execute(&mut state, &StarknetGeneralConfig::default()),
-            Err(TransactionError::FeeError(_))
+            Err(TransactionError::FeeError(e)) if e == "Fee transfer failure"
         );
     }
 }

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -837,7 +837,7 @@ mod tests {
             fib_contract_class,
             chain_id,
             Address(Felt252::one()),
-            1000,
+            10,
             1,
             Vec::new(),
             Felt252::zero(),
@@ -846,7 +846,7 @@ mod tests {
 
         assert_matches!(
             internal_declare.execute(&mut state, &StarknetGeneralConfig::default()),
-            Err(TransactionError::ResourcesError { .. })
+            Err(TransactionError::FeeError(_))
         );
     }
 }

--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -17,10 +17,23 @@ pub(crate) const CONSUMED_MSG_TO_L2_ENCODED_DATA_SIZE: usize =
 pub(crate) const LOG_MSG_TO_L1_ENCODED_DATA_SIZE: usize =
     (L2_TO_L1_MSG_HEADER_SIZE + 1) - LOG_MSG_TO_L1_N_TOPICS;
 
+/// The (empirical) L1 gas cost of each Cairo step.
+pub(crate) const N_STEPS_FEE_WEIGHT: f64 = 0.01;
+
 lazy_static! {
-    // TODO: should have an additional (builtin, 0.0) for each builtin (except for keccak)
+    // Ratios are taken from the `starknet_instance` CairoLayout object in cairo-lang.
     pub static ref DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS: HashMap<String, f64> =
-        HashMap::from([("n_steps".to_string(), 1.0)]);
+        HashMap::from([
+            ("n_steps".to_string(), N_STEPS_FEE_WEIGHT),
+            ("output_builtin".to_string(), 0.0),
+            ("pedersen_builtin".to_string(), N_STEPS_FEE_WEIGHT * 32.0),
+            ("range_check_builtin".to_string(), N_STEPS_FEE_WEIGHT * 16.0),
+            ("ecdsa_builtin".to_string(), N_STEPS_FEE_WEIGHT * 2048.0),
+            ("bitwise_builtin".to_string(), N_STEPS_FEE_WEIGHT * 64.0),
+            ("ec_op_builtin".to_string(), N_STEPS_FEE_WEIGHT * 1024.0),
+            ("poseidon_builtin".to_string(), N_STEPS_FEE_WEIGHT * 32.0),
+            ("segment_arena_builtin".to_string(), N_STEPS_FEE_WEIGHT * 10.0),
+    ]);
     pub static ref DEFAULT_SEQUENCER_ADDRESS: Address = Address(felt_str!(
         "3711666a3506c99c9d78c4d4013409a87a962b7a0880a1c24af9fe193dafc01",
         16

--- a/src/starknet_runner/runner.rs
+++ b/src/starknet_runner/runner.rs
@@ -77,7 +77,16 @@ where
     }
 
     pub fn get_execution_resources(&self) -> Result<ExecutionResources, TransactionError> {
-        Ok(self.cairo_runner.get_execution_resources(&self.vm)?)
+        let execution_resources = self.cairo_runner.get_execution_resources(&self.vm)?;
+
+        Ok(ExecutionResources {
+            builtin_instance_counter: execution_resources
+                .builtin_instance_counter
+                .into_iter()
+                .map(|(name, counter)| (format!("{name}_builtin"), counter))
+                .collect(),
+            ..execution_resources
+        })
     }
 
     pub fn get_return_values(&self) -> Result<Vec<Felt252>, StarknetRunnerError> {

--- a/tests/complex_contracts/amm_contracts/amm_proxy.rs
+++ b/tests/complex_contracts/amm_contracts/amm_proxy.rs
@@ -91,8 +91,8 @@ fn amm_proxy_init_pool_test() {
         execution_resources: ExecutionResources {
             n_memory_holes: 20,
             builtin_instance_counter: HashMap::from([
-                ("pedersen".to_string(), 2),
-                ("range_check".to_string(), 14),
+                ("pedersen_builtin".to_string(), 2),
+                ("range_check_builtin".to_string(), 14),
             ]),
             ..Default::default()
         },
@@ -186,8 +186,8 @@ fn amm_proxy_get_pool_token_balance_test() {
         execution_resources: ExecutionResources {
             n_memory_holes: 10,
             builtin_instance_counter: HashMap::from([
-                ("pedersen".to_string(), 1),
-                ("range_check".to_string(), 3),
+                ("pedersen_builtin".to_string(), 1),
+                ("range_check_builtin".to_string(), 3),
             ]),
             ..Default::default()
         },
@@ -287,8 +287,8 @@ fn amm_proxy_add_demo_token_test() {
         execution_resources: ExecutionResources {
             n_memory_holes: 42,
             builtin_instance_counter: HashMap::from([
-                ("pedersen".to_string(), 8),
-                ("range_check".to_string(), 20),
+                ("pedersen_builtin".to_string(), 8),
+                ("range_check_builtin".to_string(), 20),
             ]),
             ..Default::default()
         },
@@ -401,8 +401,8 @@ fn amm_proxy_get_account_token_balance() {
         execution_resources: ExecutionResources {
             n_memory_holes: 10,
             builtin_instance_counter: HashMap::from([
-                ("pedersen".to_string(), 2),
-                ("range_check".to_string(), 3),
+                ("pedersen_builtin".to_string(), 2),
+                ("range_check_builtin".to_string(), 3),
             ]),
             ..Default::default()
         },
@@ -522,8 +522,8 @@ fn amm_proxy_swap() {
         execution_resources: ExecutionResources {
             n_memory_holes: 93,
             builtin_instance_counter: HashMap::from([
-                ("pedersen".to_string(), 14),
-                ("range_check".to_string(), 41),
+                ("pedersen_builtin".to_string(), 14),
+                ("range_check_builtin".to_string(), 41),
             ]),
             ..Default::default()
         },

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -9,7 +9,6 @@ use cairo_rs::vm::{
 use felt::{felt_str, Felt252};
 use lazy_static::lazy_static;
 use num_traits::{Num, One, ToPrimitive, Zero};
-use starknet_rs::core::errors::state_errors::StateError;
 use starknet_rs::{
     business_logic::{
         execution::objects::{CallInfo, CallType, OrderedEvent, TransactionExecutionInfo},
@@ -44,6 +43,10 @@ use starknet_rs::{
     public::abi::VALIDATE_ENTRY_POINT_SELECTOR,
     services::api::contract_class::{ContractClass, EntryPointType},
     utils::{calculate_sn_keccak, Address, ClassHash},
+};
+use starknet_rs::{
+    core::errors::state_errors::StateError,
+    definitions::constants::DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -105,7 +108,7 @@ pub fn new_starknet_general_config_for_testing() -> StarknetGeneralConfig {
         ),
         0,
         0,
-        Default::default(),
+        DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS.clone(),
         1_000_000,
         0,
         BlockInfo::empty(TEST_SEQUENCER_ADDRESS.clone()),

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -756,9 +756,8 @@ fn expected_transaction_execution_info() -> TransactionExecutionInfo {
         0,
         HashMap::from([
             ("pedersen_builtin".to_string(), 16),
-            ("range_check".to_string(), 2),
+            ("range_check_builtin".to_string(), 72),
             ("l1_gas_usage".to_string(), 0),
-            ("range_check_builtin".to_string(), 70),
         ]),
         Some(TransactionType::InvokeFunction),
     )


### PR DESCRIPTION
This PR adds missing resource weights to the default Starknet OS configuration and fixes a few bugs so that transaction fee calculation is working.

The resource fee weights are taken to be equivalent to the `cairo-lang` 0.11.0.2 values.

The logic for calculating transaction fees had two problems:

- The validation logic in `calculate_l1_gas_by_cairo_usage()` should check that all keys in `cairo_resource_usage` except `l1_gas_usage` are present in the OS config weights hash -- it was checking the reverse and not handling `l1_gas_usage` as an exception.
- Builtin names were inconsistent: mixing names from the Cairo VM (without the `_builtin` suffix) and internal ones (with the `_builtin` suffix). This PR changes the code to fix up the ones received from the Cairo VM to have a `_builtin` suffix, too. (This is behaviour equivalent to the `cairo-lang` Python code.)