### PR TITLE
Update Makefile so that it uses python3.9 

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -25,6 +25,9 @@ jobs:
         cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Deps
       run: make deps
     - name: Build
@@ -65,6 +68,9 @@ jobs:
         cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Deps
       run: make deps
     - name: Run tests
@@ -103,6 +109,9 @@ jobs:
         cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Deps
       run: make deps
     - name: Coverage

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -47,6 +47,9 @@ jobs:
         cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Deps
       run: make deps
     - name: Format
@@ -90,6 +93,9 @@ jobs:
         cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
     - name: Deps
       run: make deps
     - name: Run rs-py tests

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ check: compile-cairo compile-starknet
 deps: check-python-version 
 	cargo install cargo-tarpaulin --version 0.23.1
 	cargo install flamegraph --version 0.6.2
-	python3 -m venv starknet-venv
+	python3.9 -m venv starknet-venv
 	. starknet-venv/bin/activate && $(MAKE) deps-venv
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 OS := $(shell uname)
 ifeq ($(OS), Darwin)
-	CFLAGS  += -I/opt/homebrew/opt/gmp/include
-	LDFLAGS += -L/opt/homebrew/opt/gmp/lib
+	export CFLAGS  += -I/opt/homebrew/opt/gmp/include
+	export LDFLAGS += -L/opt/homebrew/opt/gmp/lib
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ It makes use of [cairo-rs](https://github.com/lambdaclass/cairo-rs), the Rust im
 Run the following make targets to have a working environment (if in Mac or if you encounter an error, see the subsection below):
 ```bash
 $ make deps
-$ source starknet-venv/bin/activate
-$ make compile-cairo
-$ deactivate
 $ make build
 ```
 Check the [Makefile](/Makefile) for additional targets.


### PR DESCRIPTION
This PR introduces a change to force Python 3.9 to install the venv, and avoiding a problem where `python3` had to be a correct version which is not the default in many cases. 