### PR TITLE
Fix Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 OS := $(shell uname)
 ifeq ($(OS), Darwin)
-	CFLAGS  += -I/opt/homebrew/opt/gmp/include
-	LDFLAGS += -L/opt/homebrew/opt/gmp/lib
+	export CFLAGS  += -I/opt/homebrew/opt/gmp/include
+	export LDFLAGS += -L/opt/homebrew/opt/gmp/lib
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ It makes use of [cairo-rs](https://github.com/lambdaclass/cairo-rs), the Rust im
 Run the following make targets to have a working environment (if in Mac or if you encounter an error, see the subsection below):
 ```bash
 $ make deps
-$ make compile-cairo
 $ make build
 ```
 Check the [Makefile](/Makefile) for additional targets.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ It makes use of [cairo-rs](https://github.com/lambdaclass/cairo-rs), the Rust im
 Run the following make targets to have a working environment (if in Mac or if you encounter an error, see the subsection below):
 ```bash
 $ make deps
-$ source starknet-venv/bin/activate
 $ make compile-cairo
-$ deactivate
 $ make build
 ```
 Check the [Makefile](/Makefile) for additional targets.


### PR DESCRIPTION
I had a couple of issues with my onboarding experience. In this PR I remove an unnecessary step from the README and fix the makefile to make `LDFLAGS` and `CFLAGS` available as environment variables to the make sub-processes.