### PR TITLE
Implement new `library_call` syscall and deprecate older one

### DIFF
--- a/src/business_logic/execution/execution_entry_point.rs
+++ b/src/business_logic/execution/execution_entry_point.rs
@@ -26,7 +26,7 @@ use felt::Felt252;
 #[derive(Debug)]
 pub struct ExecutionEntryPoint {
     call_type: CallType,
-    contract_address: Address,
+    pub(crate) contract_address: Address,
     code_address: Option<Address>,
     class_hash: Option<[u8; 32]>,
     calldata: Vec<Felt252>,

--- a/src/core/errors/syscall_handler_errors.rs
+++ b/src/core/errors/syscall_handler_errors.rs
@@ -57,6 +57,8 @@ pub enum SyscallHandlerError {
     ExpectedGetContractAddressRequest,
     #[error("Expected CallContractRequest")]
     ExpectedCallContractRequest,
+    #[error("Expected a LibraryCallRequest")]
+    ExpectedLibraryCallRequest,
     #[error("Expected GetSequencerAddressRequest")]
     ExpectedGetSequencerAddressRequest,
     #[error("Memory error: {0}")]

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -222,13 +222,12 @@ impl<'a, T: Default + State + StateReader> SyscallHandler for BusinessLogicSysca
         &mut self,
         remaining_gas: u64,
         vm: &mut VirtualMachine,
-        syscall_ptr: Relocatable,
+        library_call_request: SyscallRequest,
     ) -> Result<SyscallResponse, SyscallHandlerError> {
-        let request =
-            match self.read_and_validate_syscall_request("library_call", vm, syscall_ptr)? {
-                SyscallRequest::LibraryCall(request) => request,
-                _ => return Err(SyscallHandlerError::ExpectedLibraryCallRequest),
-            };
+        let request = match library_call_request {
+            SyscallRequest::LibraryCall(request) => request,
+            _ => return Err(SyscallHandlerError::ExpectedLibraryCallRequest),
+        };
 
         let calldata = get_felt_range(vm, request.calldata_start, request.calldata_end)?;
         let execution_entry_point = ExecutionEntryPoint::new(

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -19,7 +19,7 @@ pub(crate) trait SyscallHandler {
         &mut self,
         remaining_gas: u64,
         vm: &mut VirtualMachine,
-        syscall_ptr: Relocatable,
+        library_call_request: SyscallRequest,
     ) -> Result<SyscallResponse, SyscallHandlerError>;
 
     fn read_and_validate_syscall_request(

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -1,6 +1,7 @@
 use super::{
     syscall_request::{
-        CallContractRequest, FromPtr, LibraryCallRequest, SendMessageToL1SysCall, StorageWriteRequest, SyscallRequest,
+        CallContractRequest, FromPtr, LibraryCallRequest, SendMessageToL1SysCall,
+        StorageWriteRequest, SyscallRequest,
     },
     syscall_response::SyscallResponse,
 };


### PR DESCRIPTION
Closes #314 
Implements `library_call` syscall. 

**NOTE:** The cairo-lang implementation uses the same response struct for both `call_contract` and `library_call`, so a new one was not created and the one related to `call_contract` was used instead. If this looks ambiguous, we could rename the struct to make it more general and avoid confusion.