### PR TITLE
Refactor SyscallResponse for crate visibility and optionality in ResponseBody

### DIFF
--- a/src/core/syscalls/syscall_response.rs
+++ b/src/core/syscalls/syscall_response.rs
@@ -1,7 +1,7 @@
-pub enum ResponseBody {}
+pub(crate) enum ResponseBody {}
 
 #[allow(unused)]
-pub struct SyscallResponse {
+pub(crate) struct SyscallResponse {
     /// The amount of gas left after the syscall execution.
     gas: u64,
     /// Syscall specific response fields.

--- a/src/core/syscalls/syscall_response.rs
+++ b/src/core/syscalls/syscall_response.rs
@@ -5,5 +5,5 @@ pub struct SyscallResponse {
     /// The amount of gas left after the syscall execution.
     gas: u64,
     /// Syscall specific response fields.
-    body: ResponseBody,
+    body: Option<ResponseBody>,
 }


### PR DESCRIPTION
This PR makes:
* SyscallResponse and ResponseBody visible at crate level
* ResponseBody an optional field in SyscallResponse. This is useful for syscalls like send_message_to_L1 , storage_write and emit_event