### PR TITLE
Execution should not require `Clone` implementation for state

### DIFF
--- a/src/business_logic/transaction/fee.rs
+++ b/src/business_logic/transaction/fee.rs
@@ -22,7 +22,7 @@ pub type FeeInfo = (Option<CallInfo>, u64);
 
 /// Transfers the amount actual_fee from the caller account to the sequencer.
 /// Returns the resulting CallInfo of the transfer call.
-pub(crate) fn execute_fee_transfer<S: State + StateReader + Clone>(
+pub(crate) fn execute_fee_transfer<S: State + StateReader>(
     state: &mut S,
     general_config: &StarknetGeneralConfig,
     tx_context: &TransactionExecutionContext,

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -119,7 +119,7 @@ impl InternalDeclare {
 
     /// Executes a call to the cairo-vm using the accounts_validation.cairo contract to validate
     /// the contract that is being declared. Then it returns the transaction execution info of the run.
-    pub fn apply<S: State + StateReader + Clone>(
+    pub fn apply<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -202,7 +202,7 @@ impl InternalDeclare {
     }
 
     /// Calculates and charges the actual fee.
-    pub fn charge_fee<S: State + StateReader + Clone>(
+    pub fn charge_fee<S: State + StateReader>(
         &self,
         state: &mut S,
         resources: &HashMap<String, usize>,
@@ -225,10 +225,7 @@ impl InternalDeclare {
         Ok((Some(fee_transfer_info), actual_fee))
     }
 
-    fn handle_nonce<S: State + StateReader + Clone>(
-        &self,
-        state: &mut S,
-    ) -> Result<(), TransactionError> {
+    fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
         if self.version == 0 {
             return Ok(());
         }
@@ -249,7 +246,7 @@ impl InternalDeclare {
 
     /// Calculates actual fee used by the transaction using the execution
     /// info returned by apply(), then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -77,7 +77,7 @@ impl InternalDeploy {
         self.contract_hash
     }
 
-    pub fn apply<S: State + StateReader + Clone>(
+    pub fn apply<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -98,7 +98,7 @@ impl InternalDeploy {
         }
     }
 
-    pub fn handle_empty_constructor<T: State + StateReader + Clone>(
+    pub fn handle_empty_constructor<T: State + StateReader>(
         &self,
         state: &mut T,
     ) -> Result<TransactionExecutionInfo, StarkwareError> {
@@ -135,7 +135,7 @@ impl InternalDeploy {
         )
     }
 
-    pub fn invoke_constructor<S: State + StateReader + Clone>(
+    pub fn invoke_constructor<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -189,7 +189,7 @@ impl InternalDeploy {
 
     /// Calculates actual fee used by the transaction using the execution
     /// info returned by apply(), then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -114,7 +114,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        S: Clone + State + StateReader,
+        S: State + StateReader,
     {
         let tx_info = self.apply(state, general_config)?;
 
@@ -209,10 +209,7 @@ impl InternalDeployAccount {
         }
     }
 
-    fn handle_nonce<S: State + StateReader + Clone>(
-        &self,
-        state: &mut S,
-    ) -> Result<(), TransactionError> {
+    fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
         if self.version == 0 {
             return Ok(());
         }
@@ -332,7 +329,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<FeeInfo, TransactionError>
     where
-        S: Clone + State + StateReader,
+        S: State + StateReader,
     {
         if self.max_fee.is_zero() {
             return Ok((None, 0));

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -186,7 +186,7 @@ impl InternalInvokeFunction {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        T: State + StateReader + Clone,
+        T: State + StateReader,
     {
         let mut resources_manager = ExecutionResourcesManager::default();
 
@@ -221,7 +221,7 @@ impl InternalInvokeFunction {
         general_config: &StarknetGeneralConfig,
     ) -> Result<FeeInfo, TransactionError>
     where
-        S: Clone + State + StateReader,
+        S: State + StateReader,
     {
         if self.max_fee.is_zero() {
             return Ok((None, 0));
@@ -242,7 +242,7 @@ impl InternalInvokeFunction {
 
     /// Calculates actual fee used by the transaction using the execution info returned by apply(),
     /// then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -265,10 +265,7 @@ impl InternalInvokeFunction {
         )
     }
 
-    fn handle_nonce<S: State + StateReader + Clone>(
-        &self,
-        state: &mut S,
-    ) -> Result<(), TransactionError> {
+    fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
         if self.version == 0 {
             return Ok(());
         }


### PR DESCRIPTION
It turns out `Clone` wasn't actually used so there's no reason to require it.