### PR TITLE
Transaction version should be represented as a felt

### DIFF
--- a/bench/internals.rs
+++ b/bench/internals.rs
@@ -83,7 +83,7 @@ fn deploy_account() {
             let internal_deploy_account = InternalDeployAccount::new(
                 class_hash,
                 0,
-                0,
+                0.into(),
                 Felt252::zero(),
                 vec![],
                 signature,
@@ -117,7 +117,7 @@ fn declare() {
                 StarknetChainId::TestNet.to_felt(),
                 address,
                 0,
-                0,
+                0.into(),
                 vec![],
                 Felt252::zero(),
             )
@@ -150,9 +150,14 @@ fn deploy() {
         let class = CONTRACT_CLASS.clone();
         scope(|| {
             // new consumes more execution time than raw struct instantiation
-            let internal_deploy =
-                InternalDeploy::new(salt, class, vec![], StarknetChainId::TestNet.to_felt(), 0)
-                    .unwrap();
+            let internal_deploy = InternalDeploy::new(
+                salt,
+                class,
+                vec![],
+                StarknetChainId::TestNet.to_felt(),
+                0.into(),
+            )
+            .unwrap();
             internal_deploy.execute(&mut state_copy, config)
         })
         .unwrap();
@@ -174,8 +179,14 @@ fn invoke() {
         "2669425616857739096022668060305620640217901643963991674344872184515580705509"
     ));
     let class = CONTRACT_CLASS.clone();
-    let internal_deploy =
-        InternalDeploy::new(salt, class, vec![], StarknetChainId::TestNet.to_felt(), 0).unwrap();
+    let internal_deploy = InternalDeploy::new(
+        salt,
+        class,
+        vec![],
+        StarknetChainId::TestNet.to_felt(),
+        0.into(),
+    )
+    .unwrap();
     internal_deploy.execute(&mut state, config).unwrap();
 
     for _ in 0..RUNS {

--- a/crates/starknet-rs-py/src/lib.rs
+++ b/crates/starknet-rs-py/src/lib.rs
@@ -149,10 +149,13 @@ pub fn starknet_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
 
     // Indentation for transactions meant to query and not addressed to the OS.
     let query_version_base = Felt252::from(1).shl(128u32); // == 2 ** 128
-    let query_version = query_version_base + Felt252::from(TRANSACTION_VERSION);
+    let query_version = query_version_base + TRANSACTION_VERSION.clone();
     m.add("QUERY_VERSION", query_version.to_biguint())?;
 
-    m.add("TRANSACTION_VERSION", TRANSACTION_VERSION)?;
+    m.add(
+        "TRANSACTION_VERSION",
+        TRANSACTION_VERSION.clone().to_biguint(),
+    )?;
 
     // The (empirical) L1 gas cost of each Cairo step.
     pub const N_STEPS_FEE_WEIGHT: f64 = 0.05;

--- a/crates/starknet-rs-py/src/types/transactions/declare.rs
+++ b/crates/starknet-rs-py/src/types/transactions/declare.rs
@@ -31,7 +31,7 @@ impl PyInternalDeclare {
     #[new]
     fn new(
         hash_value: BigUint,
-        version: u64,
+        version: BigUint,
         max_fee: u64,
         signature: Vec<BigUint>,
         nonce: BigUint,
@@ -44,6 +44,7 @@ impl PyInternalDeclare {
         let hash_value = Felt252::from(hash_value);
         let contract_class =
             ContractClass::new(Default::default(), Default::default(), None).unwrap();
+        let version = Felt252::from(version);
 
         let inner = InternalDeclare {
             class_hash,

--- a/crates/starknet-rs-py/src/types/transactions/deploy.rs
+++ b/crates/starknet-rs-py/src/types/transactions/deploy.rs
@@ -32,7 +32,7 @@ impl PyInternalDeploy {
         contract_hash: ClassHash,
         contract_address_salt: BigUint,
         hash_value: BigUint,
-        version: u64,
+        version: BigUint,
         constructor_calldata: Vec<BigUint>,
     ) -> Self {
         let contract_address = Address(Felt252::from(contract_address));
@@ -42,6 +42,7 @@ impl PyInternalDeploy {
             .map(Felt252::from)
             .collect();
         let hash_value = Felt252::from(hash_value);
+        let version = Felt252::from(version);
 
         let inner = InternalDeploy {
             hash_value,

--- a/crates/starknet-rs-py/src/utils/transaction_hash.rs
+++ b/crates/starknet-rs-py/src/utils/transaction_hash.rs
@@ -52,7 +52,7 @@ impl From<&PyTransactionHashPrefix> for TransactionHashPrefix {
 
 #[pyfunction(name = "calculate_deploy_transaction_hash")]
 pub(crate) fn py_calculate_deploy_transaction_hash(
-    version: u64,
+    version: BigUint,
     contract_address: BigUint,
     constructor_calldata: Vec<BigUint>,
     chain_id: BigUint,
@@ -60,6 +60,8 @@ pub(crate) fn py_calculate_deploy_transaction_hash(
     let contract_address = Address(Felt252::from(contract_address));
     let constructor_calldata: Vec<_> = constructor_calldata.into_iter().map(Into::into).collect();
     let chain_id = Felt252::from(chain_id);
+    let version = Felt252::from(version);
+
     match calculate_deploy_transaction_hash(
         version,
         &contract_address,
@@ -77,12 +79,14 @@ pub(crate) fn py_calculate_declare_transaction_hash(
     chain_id: BigUint,
     sender_address: BigUint,
     max_fee: u64,
-    version: u64,
+    version: BigUint,
     nonce: BigUint,
 ) -> PyResult<BigUint> {
     let chain_id = Felt252::from(chain_id);
     let sender_address = Address(Felt252::from(sender_address));
     let nonce = Felt252::from(nonce);
+    let version = Felt252::from(version);
+
     match calculate_declare_transaction_hash(
         contract_class.into(),
         chain_id,
@@ -100,7 +104,7 @@ pub(crate) fn py_calculate_declare_transaction_hash(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn py_calculate_transaction_hash_common(
     tx_hash_prefix: &PyTransactionHashPrefix,
-    version: u64,
+    version: BigUint,
     contract_address: BigUint,
     entry_point_selector: BigUint,
     calldata: Vec<BigUint>,
@@ -114,6 +118,7 @@ pub(crate) fn py_calculate_transaction_hash_common(
     let chain_id = Felt252::from(chain_id);
     let calldata: Vec<_> = calldata.into_iter().map(Felt252::from).collect();
     let additional_data: Vec<_> = additional_data.into_iter().map(Felt252::from).collect();
+    let version = Felt252::from(version);
 
     match calculate_transaction_hash_common(
         tx_hash_prefix,

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
                 0,
                 10.into(),
                 general_config.invoke_tx_max_n_steps(),
-                TRANSACTION_VERSION,
+                TRANSACTION_VERSION.clone(),
             );
             let mut resources_manager = ExecutionResourcesManager::default();
 

--- a/src/business_logic/execution/execution_entry_point.rs
+++ b/src/business_logic/execution/execution_entry_point.rs
@@ -324,7 +324,7 @@ mod tests {
             10,
             0.into(),
             general_config.invoke_tx_max_n_steps(),
-            TRANSACTION_VERSION,
+            TRANSACTION_VERSION.clone(),
         );
 
         //* --------------------------------------------

--- a/src/business_logic/execution/objects.rs
+++ b/src/business_logic/execution/objects.rs
@@ -253,7 +253,7 @@ impl Event {
 #[derive(Clone, Debug, Default, Getters)]
 pub struct TransactionExecutionContext {
     pub(crate) n_emitted_events: u64,
-    pub(crate) version: u64,
+    pub(crate) version: Felt252,
     pub(crate) account_contract_address: Address,
     pub(crate) max_fee: u64,
     pub(crate) transaction_hash: Felt252,
@@ -272,7 +272,7 @@ impl TransactionExecutionContext {
         max_fee: u64,
         nonce: Felt252,
         n_steps: u64,
-        version: u64,
+        version: Felt252,
     ) -> Self {
         TransactionExecutionContext {
             n_emitted_events: 0,
@@ -292,7 +292,7 @@ impl TransactionExecutionContext {
         _max_fee: u64,
         nonce: Felt252,
         n_steps: u64,
-        version: u64,
+        version: Felt252,
     ) -> Self {
         TransactionExecutionContext {
             n_emitted_events: 0,
@@ -310,7 +310,7 @@ impl TransactionExecutionContext {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct TxInfoStruct {
-    pub(crate) version: usize,
+    pub(crate) version: Felt252,
     pub(crate) account_contract_address: Address,
     pub(crate) max_fee: u64,
     pub(crate) signature_len: usize,
@@ -327,7 +327,7 @@ impl TxInfoStruct {
         chain_id: StarknetChainId,
     ) -> TxInfoStruct {
         TxInfoStruct {
-            version: tx.version as usize,
+            version: tx.version,
             account_contract_address: tx.account_contract_address,
             max_fee: tx.max_fee,
             signature_len: tx.signature.len(),
@@ -340,7 +340,7 @@ impl TxInfoStruct {
 
     pub(crate) fn to_vec(&self) -> Vec<MaybeRelocatable> {
         vec![
-            MaybeRelocatable::from(Felt252::new(self.version)),
+            MaybeRelocatable::from(&self.version),
             MaybeRelocatable::from(&self.account_contract_address.0),
             MaybeRelocatable::from(Felt252::new(self.max_fee)),
             MaybeRelocatable::from(Felt252::new(self.signature_len)),
@@ -355,7 +355,7 @@ impl TxInfoStruct {
         vm: &VirtualMachine,
         tx_info_ptr: Relocatable,
     ) -> Result<TxInfoStruct, SyscallHandlerError> {
-        let version = get_integer(vm, tx_info_ptr)?;
+        let version = get_big_int(vm, tx_info_ptr)?;
 
         let account_contract_address = Address(get_big_int(vm, &tx_info_ptr + 1)?);
         let max_fee = get_big_int(vm, &tx_info_ptr + 2)?

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -36,7 +36,7 @@ pub struct InternalDeclare {
     pub sender_address: Address,
     pub tx_type: TransactionType,
     pub validate_entry_point_selector: Felt252,
-    pub version: u64,
+    pub version: Felt252,
     pub max_fee: u64,
     pub signature: Vec<Felt252>,
     pub nonce: Felt252,
@@ -53,11 +53,11 @@ impl InternalDeclare {
         chain_id: Felt252,
         sender_address: Address,
         max_fee: u64,
-        version: u64,
+        version: Felt252,
         signature: Vec<Felt252>,
         nonce: Felt252,
     ) -> Result<Self, TransactionError> {
-        let hash = compute_class_hash(&contract_class)?;
+        let hash: Felt252 = compute_class_hash(&contract_class)?;
         let class_hash = hash.to_be_bytes();
 
         let hash_value = calculate_declare_transaction_hash(
@@ -65,7 +65,7 @@ impl InternalDeclare {
             chain_id,
             &sender_address,
             max_fee,
-            version,
+            version.clone(),
             nonce.clone(),
         )?;
 
@@ -162,7 +162,7 @@ impl InternalDeclare {
             self.max_fee,
             self.nonce.clone(),
             n_steps,
-            self.version,
+            self.version.clone(),
         )
     }
 
@@ -172,7 +172,7 @@ impl InternalDeclare {
         resources_manager: &mut ExecutionResourcesManager,
         general_config: &StarknetGeneralConfig,
     ) -> Result<Option<CallInfo>, TransactionError> {
-        if self.version == 0 {
+        if self.version.is_zero() {
             return Ok(None);
         }
 
@@ -226,7 +226,7 @@ impl InternalDeclare {
     }
 
     fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
-        if self.version == 0 {
+        if self.version.is_zero() {
             return Ok(());
         }
 
@@ -357,7 +357,7 @@ mod tests {
             chain_id,
             Address(Felt252::one()),
             0,
-            1,
+            1.into(),
             Vec::new(),
             Felt252::zero(),
         )
@@ -455,7 +455,7 @@ mod tests {
 
         let chain_id = StarknetChainId::TestNet.to_felt();
         let max_fee = 1000;
-        let version = 0;
+        let version = 0.into();
 
         // Declare tx should fail because max_fee > 0 and version == 0
         let internal_declare = InternalDeclare::new(
@@ -518,7 +518,7 @@ mod tests {
 
         let chain_id = StarknetChainId::TestNet.to_felt();
         let nonce = Felt252::from(148);
-        let version = 0;
+        let version = 0.into();
 
         // Declare tx should fail because nonce > 0 and version == 0
         let internal_declare = InternalDeclare::new(
@@ -588,7 +588,7 @@ mod tests {
             chain_id,
             Address(Felt252::one()),
             0,
-            0,
+            0.into(),
             signature,
             Felt252::zero(),
         );
@@ -649,7 +649,7 @@ mod tests {
             chain_id.clone(),
             Address(Felt252::one()),
             0,
-            1,
+            1.into(),
             Vec::new(),
             Felt252::zero(),
         )
@@ -660,7 +660,7 @@ mod tests {
             chain_id,
             Address(Felt252::one()),
             0,
-            1,
+            1.into(),
             Vec::new(),
             Felt252::one(),
         )
@@ -729,7 +729,7 @@ mod tests {
             chain_id,
             Address(Felt252::one()),
             0,
-            1,
+            1.into(),
             Vec::new(),
             Felt252::zero(),
         )
@@ -773,7 +773,7 @@ mod tests {
             chain_id,
             Address(Felt252::one()),
             0,
-            1,
+            1.into(),
             Vec::new(),
             Felt252::zero(),
         )
@@ -835,7 +835,7 @@ mod tests {
             chain_id,
             Address(Felt252::one()),
             10,
-            1,
+            1.into(),
             Vec::new(),
             Felt252::zero(),
         )

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -28,7 +28,7 @@ use num_traits::Zero;
 #[derive(Debug)]
 pub struct InternalDeploy {
     pub hash_value: Felt252,
-    pub version: u64,
+    pub version: Felt252,
     pub contract_address: Address,
     pub contract_address_salt: Address,
     pub contract_hash: ClassHash,
@@ -42,7 +42,7 @@ impl InternalDeploy {
         contract_class: ContractClass,
         constructor_calldata: Vec<Felt252>,
         chain_id: Felt252,
-        version: u64,
+        version: Felt252,
     ) -> Result<Self, SyscallHandlerError> {
         let class_hash = compute_class_hash(&contract_class)
             .map_err(|_| SyscallHandlerError::ErrorComputingHash)?;
@@ -56,7 +56,7 @@ impl InternalDeploy {
         )?);
 
         let hash_value = calculate_deploy_transaction_hash(
-            version,
+            version.clone(),
             &contract_address,
             &constructor_calldata,
             chain_id,
@@ -157,7 +157,7 @@ impl InternalDeploy {
             0,
             Felt252::zero(),
             general_config.invoke_tx_max_n_steps,
-            self.version,
+            self.version.clone(),
         );
 
         let mut resources_manager = ExecutionResourcesManager::default();
@@ -244,7 +244,7 @@ mod tests {
             contract_class,
             vec![10.into()],
             0.into(),
-            0,
+            0.into(),
         )
         .unwrap();
 
@@ -288,9 +288,14 @@ mod tests {
             .set_contract_class(&class_hash_bytes, &contract_class)
             .unwrap();
 
-        let internal_deploy =
-            InternalDeploy::new(Address(0.into()), contract_class, Vec::new(), 0.into(), 0)
-                .unwrap();
+        let internal_deploy = InternalDeploy::new(
+            Address(0.into()),
+            contract_class,
+            Vec::new(),
+            0.into(),
+            0.into(),
+        )
+        .unwrap();
 
         let config = Default::default();
 
@@ -322,7 +327,7 @@ mod tests {
             contract_class,
             vec![10.into()],
             0.into(),
-            0,
+            0.into(),
         )
         .unwrap();
 
@@ -352,7 +357,7 @@ mod tests {
             error_contract_class,
             Vec::new(),
             0.into(),
-            1,
+            1.into(),
         );
         assert_matches!(
             internal_deploy_error.unwrap_err(),

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -47,7 +47,7 @@ pub struct InternalDeployAccount {
     class_hash: ClassHash,
     #[getset(get = "pub")]
     constructor_calldata: Vec<Felt252>,
-    version: u64,
+    version: Felt252,
     nonce: Felt252,
     max_fee: u64,
     #[getset(get = "pub")]
@@ -62,7 +62,7 @@ impl InternalDeployAccount {
     pub fn new(
         class_hash: ClassHash,
         max_fee: u64,
-        version: u64,
+        version: Felt252,
         nonce: Felt252,
         constructor_calldata: Vec<Felt252>,
         signature: Vec<Felt252>,
@@ -77,7 +77,7 @@ impl InternalDeployAccount {
         )?);
 
         let hash_value = calculate_deploy_account_transaction_hash(
-            version,
+            version.clone(),
             &contract_address,
             Felt252::from_bytes_be(&class_hash),
             &constructor_calldata,
@@ -210,7 +210,7 @@ impl InternalDeployAccount {
     }
 
     fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
-        if self.version == 0 {
+        if self.version.is_zero() {
             return Ok(());
         }
 
@@ -262,7 +262,7 @@ impl InternalDeployAccount {
         TransactionExecutionContext::new(
             self.contract_address.clone(),
             calculate_deploy_account_transaction_hash(
-                self.version,
+                self.version.clone(),
                 &self.contract_address,
                 Felt252::from_bytes_be(&self.class_hash),
                 &self.constructor_calldata,
@@ -276,7 +276,7 @@ impl InternalDeployAccount {
             self.max_fee,
             self.nonce.clone(),
             n_steps,
-            self.version,
+            self.version.clone(),
         )
     }
 
@@ -289,7 +289,7 @@ impl InternalDeployAccount {
     where
         S: State + StateReader,
     {
-        if self.version == 0 {
+        if self.version.is_zero() {
             return Ok(None);
         }
 
@@ -378,7 +378,7 @@ mod tests {
         let internal_deploy = InternalDeployAccount::new(
             class_hash,
             0,
-            0,
+            0.into(),
             0.into(),
             vec![10.into()],
             Vec::new(),
@@ -410,7 +410,7 @@ mod tests {
         let internal_deploy = InternalDeployAccount::new(
             class_hash,
             0,
-            0,
+            0.into(),
             0.into(),
             vec![10.into()],
             Vec::new(),
@@ -422,7 +422,7 @@ mod tests {
         let internal_deploy_error = InternalDeployAccount::new(
             class_hash,
             0,
-            0,
+            0.into(),
             0.into(),
             vec![10.into()],
             Vec::new(),
@@ -460,7 +460,7 @@ mod tests {
         let internal_deploy = InternalDeployAccount::new(
             class_hash,
             0,
-            0,
+            0.into(),
             0.into(),
             Vec::new(),
             Vec::new(),

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -38,7 +38,7 @@ pub struct InternalInvokeFunction {
     entry_point_type: EntryPointType,
     calldata: Vec<Felt252>,
     tx_type: TransactionType,
-    version: u64,
+    version: Felt252,
     validate_entry_point_selector: Felt252,
     #[getset(get = "pub")]
     hash_value: Felt252,
@@ -58,15 +58,15 @@ impl InternalInvokeFunction {
         chain_id: Felt252,
         nonce: Option<Felt252>,
     ) -> Result<Self, TransactionError> {
-        let version = TRANSACTION_VERSION;
+        let version = TRANSACTION_VERSION.clone();
         let (entry_point_selector_field, additional_data) = preprocess_invoke_function_fields(
             entry_point_selector.clone(),
             nonce.clone(),
-            version,
+            version.clone(),
         )?;
         let hash_value = calculate_transaction_hash_common(
             TransactionHashPrefix::Invoke,
-            version,
+            version.clone(),
             &contract_address,
             entry_point_selector_field,
             &calldata,
@@ -102,7 +102,7 @@ impl InternalInvokeFunction {
             self.max_fee,
             self.nonce.clone().ok_or(TransactionError::MissingNonce)?,
             n_steps,
-            self.version,
+            self.version.clone(),
         ))
     }
 
@@ -118,7 +118,7 @@ impl InternalInvokeFunction {
         if self.entry_point_selector != *EXECUTE_ENTRY_POINT_SELECTOR {
             return Ok(None);
         }
-        if self.version == 0 {
+        if self.version.is_zero() {
             return Ok(None);
         }
 
@@ -266,7 +266,7 @@ impl InternalInvokeFunction {
     }
 
     fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
-        if self.version == 0 {
+        if self.version.is_zero() {
             return Ok(());
         }
 
@@ -314,9 +314,9 @@ pub fn verify_no_calls_to_other_contracts(call_info: &CallInfo) -> Result<(), Tr
 pub(crate) fn preprocess_invoke_function_fields(
     entry_point_selector: Felt252,
     nonce: Option<Felt252>,
-    version: u64,
+    version: Felt252,
 ) -> Result<(Felt252, Vec<Felt252>), TransactionError> {
-    if version == 0 || version == u64::MAX {
+    if version.is_zero() {
         match nonce {
             Some(_) => Err(TransactionError::InvokeFunctionZeroHasNonce),
             None => {
@@ -363,7 +363,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: vec![1.into(), 1.into(), 10.into()],
             tx_type: TransactionType::InvokeFunction,
-            version: 0,
+            version: 0.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -429,7 +429,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: vec![1.into(), 1.into(), 10.into()],
             tx_type: TransactionType::InvokeFunction,
-            version: 0,
+            version: 0.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -491,7 +491,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: Vec::new(),
             tx_type: TransactionType::InvokeFunction,
-            version: 0,
+            version: 0.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -543,7 +543,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: Vec::new(),
             tx_type: TransactionType::InvokeFunction,
-            version: 1,
+            version: 1.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -600,7 +600,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: vec![1.into(), 1.into(), 10.into()],
             tx_type: TransactionType::InvokeFunction,
-            version: 1,
+            version: 1.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -659,7 +659,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: vec![1.into(), 1.into(), 10.into()],
             tx_type: TransactionType::InvokeFunction,
-            version: 1,
+            version: 1.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -719,7 +719,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: vec![1.into(), 1.into(), 10.into()],
             tx_type: TransactionType::InvokeFunction,
-            version: 1,
+            version: 1.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -779,7 +779,7 @@ mod tests {
             entry_point_type: EntryPointType::External,
             calldata: vec![1.into(), 1.into(), 10.into()],
             tx_type: TransactionType::InvokeFunction,
-            version: 1,
+            version: 1.into(),
             validate_entry_point_selector: 0.into(),
             hash_value: 0.into(),
             signature: Vec::new(),
@@ -832,7 +832,7 @@ mod tests {
             )
             .unwrap(),
             Some(1.into()),
-            0,
+            0.into(),
         )
         .unwrap_err();
         assert_matches!(expected_error, TransactionError::InvokeFunctionZeroHasNonce)
@@ -866,7 +866,8 @@ mod tests {
             16,
         )
         .unwrap();
-        let result = preprocess_invoke_function_fields(entry_point_selector.clone(), None, 0);
+        let result =
+            preprocess_invoke_function_fields(entry_point_selector.clone(), None, 0.into());
 
         let expected_additional_data: Vec<Felt252> = Vec::new();
         let expected_entry_point_selector_field = entry_point_selector;
@@ -888,7 +889,7 @@ mod tests {
             )
             .unwrap(),
             None,
-            1,
+            1.into(),
         );
         assert!(expected_error.is_err());
         assert_matches!(

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -783,7 +783,7 @@ mod tests {
 
         let tx_execution_context = TransactionExecutionContext {
             n_emitted_events: 50,
-            version: 51,
+            version: 51.into(),
             account_contract_address: Address(260.into()),
             max_fee: 261,
             transaction_hash: 262.into(),
@@ -819,8 +819,8 @@ mod tests {
 
         // TxInfoStruct
         assert_matches!(
-            get_integer(&vm, relocatable!(4, 0)),
-            Ok(field) if field == tx_execution_context.version as usize
+            get_big_int(&vm, relocatable!(4, 0)),
+            Ok(field) if field == tx_execution_context.version
         );
         assert_matches!(
             get_big_int(&vm, relocatable!(4, 1)),
@@ -1090,7 +1090,7 @@ mod tests {
 
         let tx_execution_context = TransactionExecutionContext {
             n_emitted_events: 50,
-            version: 51,
+            version: 51.into(),
             account_contract_address: Address(260.into()),
             max_fee: 261,
             transaction_hash: 262.into(),

--- a/src/core/transaction_hash/starknet_transaction_hash.rs
+++ b/src/core/transaction_hash/starknet_transaction_hash.rs
@@ -52,7 +52,7 @@ impl TransactionHashPrefix {
 #[allow(clippy::too_many_arguments)]
 pub fn calculate_transaction_hash_common(
     tx_hash_prefix: TransactionHashPrefix,
-    version: u64,
+    version: Felt252,
     contract_address: &Address,
     entry_point_selector: Felt252,
     calldata: &[Felt252],
@@ -64,7 +64,7 @@ pub fn calculate_transaction_hash_common(
 
     let mut data_to_hash: Vec<Felt252> = vec![
         tx_hash_prefix.get_prefix(),
-        version.into(),
+        version,
         contract_address.0.clone(),
         entry_point_selector,
         calldata_hash,
@@ -78,7 +78,7 @@ pub fn calculate_transaction_hash_common(
 }
 
 pub fn calculate_deploy_transaction_hash(
-    version: u64,
+    version: Felt252,
     contract_address: &Address,
     constructor_calldata: &[Felt252],
     chain_id: Felt252,
@@ -97,7 +97,7 @@ pub fn calculate_deploy_transaction_hash(
 
 #[allow(clippy::too_many_arguments)]
 pub fn calculate_deploy_account_transaction_hash(
-    version: u64,
+    version: Felt252,
     contract_address: &Address,
     class_hash: Felt252,
     constructor_calldata: &[Felt252],
@@ -126,16 +126,16 @@ pub fn calculate_declare_transaction_hash(
     chain_id: Felt252,
     sender_address: &Address,
     max_fee: u64,
-    version: u64,
+    version: Felt252,
     nonce: Felt252,
 ) -> Result<Felt252, SyscallHandlerError> {
     let class_hash =
         compute_class_hash(contract_class).map_err(|_| SyscallHandlerError::FailToComputeHash)?;
 
-    let (calldata, additional_data) = if version > 0 {
-        (Vec::new(), vec![class_hash])
-    } else {
+    let (calldata, additional_data) = if version.is_zero() {
         (vec![class_hash], vec![nonce])
+    } else {
+        (Vec::new(), vec![class_hash])
     };
 
     calculate_transaction_hash_common(
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn calculate_transaction_hash_common_test() {
         let tx_hash_prefix = TransactionHashPrefix::Declare;
-        let version = 0;
+        let version = 0.into();
         let contract_address = Address(42.into());
         let entry_point_selector = 100.into();
         let calldata = vec![540.into(), 338.into()];

--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -46,6 +46,9 @@ lazy_static! {
         )),
         gas_price: 0,
     };
+
+    pub static ref TRANSACTION_VERSION: Felt252 = 1.into();
+    pub static ref DECLARE_VERSION: Felt252 = 2.into();
 }
 
 pub const DEFAULT_GAS_PRICE: u64 = 100_000_000_000; // 100 * 10**9
@@ -53,9 +56,6 @@ pub const DEFAULT_CONTRACT_STORAGE_COMMITMENT_TREE_HEIGHT: u64 = 251;
 pub const DEFAULT_GLOBAL_STATE_COMMITMENT_TREE_HEIGHT: u64 = 251;
 pub const DEFAULT_INVOKE_TX_MAX_N_STEPS: u64 = 1000000;
 pub const DEFAULT_VALIDATE_MAX_N_STEPS: u64 = 1000000;
-
-pub const DECLARE_VERSION: u64 = 2;
-pub const TRANSACTION_VERSION: u64 = 1;
 
 lazy_static! {
     /// Value generated from `get_selector_from_name('constructor')`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn declare_parser(
         Felt252::zero(),
         &Address(0.into()),
         0,
-        DECLARE_VERSION,
+        DECLARE_VERSION.clone(),
         Felt252::zero(),
     )?;
     Ok((class_hash, tx_hash))
@@ -152,7 +152,7 @@ fn deploy_parser(
             .map_err(|_| ParserError::ParseFelt(args.class_hash.clone()))?,
     )?;
     let tx_hash = calculate_deploy_transaction_hash(
-        0,
+        0.into(),
         &Address(address.clone()),
         &constructor_calldata,
         Felt252::zero(),
@@ -202,7 +202,7 @@ fn invoke_parser(
 
     let tx_hash = calculate_transaction_hash_common(
         TransactionHashPrefix::Invoke,
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
         &contract_address,
         entrypoint_selector,
         &calldata,

--- a/src/testing/starknet_state.rs
+++ b/src/testing/starknet_state.rs
@@ -98,7 +98,7 @@ impl StarknetState {
             self.chain_id(),
             Address(Felt252::one()),
             0,
-            0,
+            0.into(),
             Vec::new(),
             0.into(),
         )?;
@@ -187,7 +187,7 @@ impl StarknetState {
             contract_class.clone(),
             constructor_calldata,
             chain_id,
-            TRANSACTION_VERSION,
+            TRANSACTION_VERSION.clone(),
         )?);
 
         self.state

--- a/tests/complex_contracts/utils.rs
+++ b/tests/complex_contracts/utils.rs
@@ -120,7 +120,7 @@ pub fn execute_entry_point(
         0,
         10.into(),
         call_config.general_config.invoke_tx_max_n_steps(),
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
     );
 
     exec_entry_point.execute(
@@ -145,7 +145,7 @@ pub fn deploy(
         contract_class.clone(),
         calldata.to_vec(),
         0.into(),
-        0,
+        0.into(),
     )?;
     let class_hash = internal_deploy.class_hash();
     state.set_contract_class(&class_hash, &contract_class)?;

--- a/tests/deploy_account.rs
+++ b/tests/deploy_account.rs
@@ -40,7 +40,7 @@ fn internal_deploy_account() {
     let internal_deploy_account = InternalDeployAccount::new(
         class_hash,
         0,
-        0,
+        0.into(),
         Felt252::zero(),
         vec![],
         vec![

--- a/tests/fibonacci.rs
+++ b/tests/fibonacci.rs
@@ -94,7 +94,7 @@ fn integration_test() {
         0,
         10.into(),
         general_config.invoke_tx_max_n_steps(),
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
     );
     let mut resources_manager = ExecutionResourcesManager::default();
 

--- a/tests/increase_balance.rs
+++ b/tests/increase_balance.rs
@@ -103,7 +103,7 @@ fn hello_starknet_increase_balance() {
         0,
         10.into(),
         general_config.invoke_tx_max_n_steps(),
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
     );
     let mut resources_manager = ExecutionResourcesManager::default();
     let expected_key = calculate_sn_keccak("balance".as_bytes());

--- a/tests/internal_calls.rs
+++ b/tests/internal_calls.rs
@@ -31,7 +31,7 @@ fn test_internal_calls() {
         10,
         0.into(),
         general_config.invoke_tx_max_n_steps(),
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
     );
 
     let address = Address(1111.into());

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -579,7 +579,7 @@ fn declare_tx() -> InternalDeclare {
         sender_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
         tx_type: TransactionType::Declare,
         validate_entry_point_selector: VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone(),
-        version: 1,
+        version: 1.into(),
         max_fee: 2,
         signature: vec![],
         nonce: 0.into(),
@@ -812,7 +812,7 @@ fn test_deploy_account() {
     let deploy_account_tx = InternalDeployAccount::new(
         TEST_ACCOUNT_CONTRACT_CLASS_HASH.to_be_bytes(),
         2,
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -1324,7 +1324,7 @@ fn test_deploy_undeclared_account() {
     let deploy_account_tx = InternalDeployAccount::new(
         not_deployed_class_hash,
         2,
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
         Default::default(),
         Default::default(),
         Default::default(),

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -100,7 +100,7 @@ fn integration_storage_test() {
         0,
         10.into(),
         general_config.invoke_tx_max_n_steps(),
-        TRANSACTION_VERSION,
+        TRANSACTION_VERSION.clone(),
     );
     let mut resources_manager = ExecutionResourcesManager::default();
 

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -60,7 +60,7 @@ fn test_contract<'a>(
             10,
             0.into(),
             general_config.invoke_tx_max_n_steps(),
-            TRANSACTION_VERSION,
+            TRANSACTION_VERSION.clone(),
         )
     });
 
@@ -422,9 +422,9 @@ fn get_sequencer_address_syscall() {
 
 #[test]
 fn get_tx_info_syscall() {
-    let run = |version,
+    let run = |version: Felt252,
                account_contract_address: Address,
-               max_fee,
+               max_fee: u64,
                signature: Vec<Felt252>,
                transaction_hash: Felt252,
                chain_id| {
@@ -446,7 +446,7 @@ fn get_tx_info_syscall() {
                 max_fee,
                 3.into(),
                 n_steps,
-                version,
+                version.clone(),
             )),
             [],
             [],
@@ -456,7 +456,7 @@ fn get_tx_info_syscall() {
             [],
             [],
             [
-                version.into(),
+                version,
                 account_contract_address.0,
                 max_fee.into(),
                 signature.len().into(),
@@ -471,7 +471,7 @@ fn get_tx_info_syscall() {
     };
 
     run(
-        0,
+        0.into(),
         Address::default(),
         12,
         vec![],
@@ -479,7 +479,7 @@ fn get_tx_info_syscall() {
         StarknetChainId::TestNet,
     );
     run(
-        10,
+        10.into(),
         Address::default(),
         12,
         vec![],
@@ -487,7 +487,7 @@ fn get_tx_info_syscall() {
         StarknetChainId::TestNet,
     );
     run(
-        10,
+        10.into(),
         Address(1111.into()),
         12,
         vec![],
@@ -495,7 +495,7 @@ fn get_tx_info_syscall() {
         StarknetChainId::TestNet,
     );
     run(
-        10,
+        10.into(),
         Address(1111.into()),
         50,
         vec![],
@@ -503,7 +503,7 @@ fn get_tx_info_syscall() {
         StarknetChainId::TestNet,
     );
     run(
-        10,
+        10.into(),
         Address(1111.into()),
         50,
         [0x12, 0x34, 0x56, 0x78].map(Felt252::from).to_vec(),
@@ -511,7 +511,7 @@ fn get_tx_info_syscall() {
         StarknetChainId::TestNet,
     );
     run(
-        10,
+        10.into(),
         Address(1111.into()),
         50,
         [0x12, 0x34, 0x56, 0x78].map(Felt252::from).to_vec(),
@@ -519,7 +519,7 @@ fn get_tx_info_syscall() {
         StarknetChainId::TestNet,
     );
     run(
-        10,
+        10.into(),
         Address(1111.into()),
         50,
         [0x12, 0x34, 0x56, 0x78].map(Felt252::from).to_vec(),
@@ -548,7 +548,7 @@ fn get_tx_signature_syscall() {
                 12,
                 3.into(),
                 n_steps,
-                0,
+                0.into(),
             )),
             [],
             [],

--- a/tests/syscalls_errors.rs
+++ b/tests/syscalls_errors.rs
@@ -51,7 +51,7 @@ fn test_contract<'a>(
             10,
             0.into(),
             general_config.invoke_tx_max_n_steps(),
-            TRANSACTION_VERSION,
+            TRANSACTION_VERSION.clone(),
         )
     });
 


### PR DESCRIPTION
The previous u64 value couldn't properly represent the full allowed value range of the version field -- notably not covering the QUERY flag.

This change converts the version into a felt -- but does _not_ add proper handling of the QUERY flag.

Fixes #356