### PR TITLE
Add AssertLtAssertValidInput input hint

### DIFF
--- a/crates/cairo-1-hint-processor/src/hint_processor.rs
+++ b/crates/cairo-1-hint-processor/src/hint_processor.rs
@@ -680,6 +680,22 @@ impl Cairo1HintProcessor {
 
         Ok(())
     }
+
+    fn assert_lt_assert_valid_input(
+        &self,
+        vm: &VirtualMachine,
+        _exec_scopes: &mut ExecutionScopes,
+        a: &ResOperand,
+        b: &ResOperand,
+    ) -> Result<(), HintError> {
+        let a_val = res_operand_get_val(vm, a)?;
+        let b_val = res_operand_get_val(vm, b)?;
+        if a_val >= b_val {
+            return Err(HintError::AssertLtFelt252(a_val, b_val));
+        };
+
+        Ok(())
+    }
 }
 
 impl HintProcessor for Cairo1HintProcessor {
@@ -818,6 +834,9 @@ impl HintProcessor for Cairo1HintProcessor {
 
             Hint::Core(CoreHint::ShouldSkipSquashLoop { should_skip_loop }) => {
                 self.should_skip_squash_loop(vm, exec_scopes, should_skip_loop)
+            }
+            Hint::Core(CoreHint::AssertLtAssertValidInput { a, b }) => {
+                self.assert_lt_assert_valid_input(vm, exec_scopes, a, b)
             }
 
             _ => unimplemented!(),


### PR DESCRIPTION
This was made using [this function in cairo-rs](https://github.com/lambdaclass/cairo-rs/blob/main/src/hint_processor/builtin_hint_processor/math_utils.rs#L643) as reference.

Closes #411 .