### PR TITLE
Remove duplicate function

### DIFF
--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -175,20 +175,6 @@ impl<'a, T: Default + State + StateReader> BusinessLogicSyscallHandler<'a, T> {
             .increment_syscall_counter(syscall_name, 1);
     }
 
-    fn allocate_segment(
-        &mut self,
-        vm: &mut VirtualMachine,
-        data: Vec<MaybeRelocatable>,
-    ) -> Result<Relocatable, SyscallHandlerError> {
-        let segment_start = vm.add_memory_segment();
-        let segment_end = vm.write_arg(segment_start, &data)?;
-        let sub = segment_end.sub(&segment_start.to_owned().into())?;
-        let segment = (segment_start.to_owned(), sub);
-        self.read_only_segments.push(segment);
-
-        Ok(segment_start)
-    }
-
     fn call_contract_helper(
         &mut self,
         vm: &mut VirtualMachine,
@@ -499,6 +485,7 @@ where
         let sub = segment_end.sub(&segment_start.to_owned().into())?;
         let segment = (segment_start.to_owned(), sub);
         self.read_only_segments.push(segment);
+
         Ok(segment_start)
     }
 


### PR DESCRIPTION
- Remove duplicate definition of `allocate_segment`

Even though #459 is a noop due to `allocate_segment` being a hint and not a syscall, there was a unnecessary (duplicate) definition of the function (one as part of the struct impl and the other for the trait implementation). This PR removes the struct implementation and leaves the trait function for no specific reason other than consistency, since the deprecated syscall handler trait also contains the definition.