### PR TITLE
Implement `assert_le_assert_third_arc_excluded` hint

### DIFF
--- a/crates/cairo-1-hint-processor/src/hint_processor.rs
+++ b/crates/cairo-1-hint-processor/src/hint_processor.rs
@@ -139,6 +139,22 @@ fn as_cairo_short_string(value: &Felt252) -> Option<String> {
 }
 
 impl Cairo1HintProcessor {
+    fn assert_le_assert_third_arc_excluded(
+        &self,
+        _vm: &mut VirtualMachine,
+        exec_scopes: &mut ExecutionScopes,
+    ) -> Result<(), HintError> {
+        let excluded_arc: i32 = exec_scopes.get("excluded_arc")?;
+
+        if excluded_arc != 2 {
+            Ok(())
+        } else {
+            Err(HintError::AssertionFailed(
+                "AssertLeAssertThirdArcExcluded assertion failed".to_string(),
+            ))
+        }
+    }
+
     fn alloc_segment(&mut self, vm: &mut VirtualMachine, dst: &CellRef) -> Result<(), HintError> {
         let segment = vm.add_memory_segment();
         vm.insert_value(cell_ref_to_relocatable(dst, vm), segment)
@@ -1073,8 +1089,13 @@ impl HintProcessor for Cairo1HintProcessor {
             Hint::Core(CoreHint::ShouldSkipSquashLoop { should_skip_loop }) => {
                 self.should_skip_squash_loop(vm, exec_scopes, should_skip_loop)
             }
+
             Hint::Core(CoreHint::AssertLtAssertValidInput { a, b }) => {
                 self.assert_lt_assert_valid_input(vm, exec_scopes, a, b)
+            }
+
+            Hint::Core(CoreHint::AssertLeAssertThirdArcExcluded) => {
+                self.assert_le_assert_third_arc_excluded(vm, exec_scopes)
             }
 
             _ => unimplemented!(),


### PR DESCRIPTION
Closes #404 
Because [this hint (among others) has been deprecated](https://github.com/starkware-libs/cairo/pull/2998/files) this PR/issue might be outdated already.