### PR TITLE
Allow to use starknet in rust as a dependency

### DIFF
--- a/src/core/contract_address/starknet_contract_address.rs
+++ b/src/core/contract_address/starknet_contract_address.rs
@@ -12,19 +12,12 @@ use cairo_vm::{
         vm_core::VirtualMachine,
     },
 };
-use lazy_static::lazy_static;
 use sha3::{Digest, Keccak256};
 use std::path::Path;
+use std::fs;
 
 /// Instead of doing a Mask with 250 bits, we are only masking the most significant byte.
 pub const MASK_3: u8 = 3;
-pub const CONTRACT_STR: &str = include_str!("../../../cairo_programs/contracts.json");
-
-lazy_static! {
-    // static ref PATH_BUF_CONTRACTS = BufReader::from(CONTRACT_STR);
-    static ref HASH_CALCULATION_PROGRAM: Program =
-        Program::from_bytes(CONTRACT_STR.as_bytes(), None).unwrap();
-}
 
 #[allow(dead_code)]
 fn load_program() -> Result<Program, ContractAddressError> {
@@ -179,8 +172,10 @@ impl From<StructContractClass> for CairoArg {
 
 // TODO: Maybe this could be hard-coded (to avoid returning a result)?
 pub fn compute_class_hash(contract_class: &ContractClass) -> Result<Felt252, ContractAddressError> {
-    // Since we are not using a cache, this function replace compute_class_hash_inner.
-    let hash_calculation_program = HASH_CALCULATION_PROGRAM.clone();
+    let contract_str = fs::read_to_string("cairo_programs/contracts.json").unwrap();
+
+    let hash_calculation_program: Program =
+            Program::from_bytes(contract_str.as_bytes(), None).unwrap();
 
     let contract_class_struct = &get_contract_class_struct(
         hash_calculation_program

--- a/src/core/contract_address/starknet_contract_address.rs
+++ b/src/core/contract_address/starknet_contract_address.rs
@@ -13,8 +13,8 @@ use cairo_vm::{
     },
 };
 use sha3::{Digest, Keccak256};
-use std::path::Path;
 use std::fs;
+use std::path::Path;
 
 /// Instead of doing a Mask with 250 bits, we are only masking the most significant byte.
 pub const MASK_3: u8 = 3;
@@ -175,7 +175,7 @@ pub fn compute_class_hash(contract_class: &ContractClass) -> Result<Felt252, Con
     let contract_str = fs::read_to_string("cairo_programs/contracts.json").unwrap();
 
     let hash_calculation_program: Program =
-            Program::from_bytes(contract_str.as_bytes(), None).unwrap();
+        Program::from_bytes(contract_str.as_bytes(), None).unwrap();
 
     let contract_class_struct = &get_contract_class_struct(
         hash_calculation_program


### PR DESCRIPTION
For now, starknet in rust cannot be used as a dependency (show me how if it can, pls 🙏 ) without running all the builds which are slow. The goal here is to allow it.

The problem is that there is macro checking for a file existence and this file is only for tests. Macros in Rust are evaluated in compile time and the target file is generated during compilation when `make build` is run. So `cargo check` will not pass (and it is necessary when using this repo as a dependency) without running an expensive build. This PR allows it.