### PR TITLE
Remove `test-py` job from ci workflow

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -70,25 +70,6 @@ jobs:
       run: make deps
     - name: Run tests
       run: make test
-  
-  test-py:
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-          components: rustfmt, clippy
-    - uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: true
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Deps
-      run: make deps
-    - name: Run rs-py tests
-      run: make test-py
 
   coverage:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This job is no longer needed after the removal of the python wrapper and is causing the CI to fail due to test-py target no longer existing in Makefile