### PR TITLE
Add `utils::integration_test_utils::test_cairo_1_external_entrypoint`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -522,6 +522,116 @@ pub mod test_utils {
     pub(crate) use run_syscall_hint;
 }
 
+pub mod integration_test_utils {
+    use crate::{
+        business_logic::{
+            execution::{
+                execution_entry_point::ExecutionEntryPoint,
+                objects::{CallInfo, CallType, TransactionExecutionContext},
+            },
+            fact_state::{
+                in_memory_state_reader::InMemoryStateReader, state::ExecutionResourcesManager,
+            },
+            state::cached_state::CachedState,
+        },
+        definitions::{constants::TRANSACTION_VERSION, general_config::StarknetGeneralConfig},
+        services::api::contract_classes::deprecated_contract_class::EntryPointType,
+        utils::ClassHash,
+    };
+    use num_traits::Zero;
+    use std::collections::HashMap;
+
+    use crate::utils::Address;
+    use cairo_lang_starknet::casm_contract_class::CasmContractClass;
+    use cairo_vm::{felt::Felt252, vm::runners::cairo_runner::ExecutionResources};
+
+    pub fn test_cairo_1_external_entrypoint(
+        program_data: &[u8],
+        entrypoint: usize,
+        expected_retdata: &[Felt252],
+        expected_execution_resources: &ExecutionResources,
+    ) {
+        let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
+        let entrypoints = contract_class.clone().entry_points_by_type;
+        let entrypoint_selector = &entrypoints.external.get(entrypoint).unwrap().selector;
+
+        // Create state reader with class hash data
+        let mut contract_class_cache = HashMap::new();
+
+        let address = Address(1111.into());
+        let class_hash: ClassHash = [1; 32];
+        let nonce = Felt252::zero();
+
+        contract_class_cache.insert(class_hash, contract_class);
+        let mut state_reader = InMemoryStateReader::default();
+        state_reader
+            .address_to_class_hash_mut()
+            .insert(address.clone(), class_hash);
+        state_reader
+            .address_to_nonce_mut()
+            .insert(address.clone(), nonce);
+
+        // Create state from the state_reader and contract cache.
+        let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
+
+        // Create an execution entry point
+        let calldata = [0.into(), 1.into(), 12.into()].to_vec();
+        let caller_address = Address(0000.into());
+        let entry_point_type = EntryPointType::External;
+
+        let exec_entry_point = ExecutionEntryPoint::new(
+            address,
+            calldata.clone(),
+            Felt252::new(entrypoint_selector.clone()),
+            caller_address,
+            entry_point_type,
+            Some(CallType::Delegate),
+            Some(class_hash),
+            100000,
+        );
+
+        // Execute the entrypoint
+        let general_config = StarknetGeneralConfig::default();
+        let tx_execution_context = TransactionExecutionContext::new(
+            Address(0.into()),
+            Felt252::zero(),
+            Vec::new(),
+            0,
+            10.into(),
+            general_config.invoke_tx_max_n_steps(),
+            TRANSACTION_VERSION,
+        );
+        let mut resources_manager = ExecutionResourcesManager::default();
+
+        // expected results
+        let expected_call_info = CallInfo {
+            caller_address: Address(0.into()),
+            call_type: Some(CallType::Delegate),
+            contract_address: Address(1111.into()),
+            entry_point_selector: Some(Felt252::new(entrypoint_selector)),
+            entry_point_type: Some(EntryPointType::External),
+            calldata,
+            retdata: expected_retdata.to_vec(),
+            execution_resources: expected_execution_resources.clone(),
+            class_hash: Some(class_hash),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            exec_entry_point
+                .execute(
+                    &mut state,
+                    &general_config,
+                    &mut resources_manager,
+                    &tx_execution_context,
+                    false,
+                )
+                .unwrap(),
+            expected_call_info
+        );
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/tests/fibonacci.rs
+++ b/tests/fibonacci.rs
@@ -1,8 +1,6 @@
 #![deny(warnings)]
 
-use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-use cairo_vm::felt::Felt252;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use cairo_vm::{felt::Felt252, vm::runners::cairo_runner::ExecutionResources};
 use num_traits::Zero;
 use starknet_rs::{
     business_logic::{
@@ -128,85 +126,12 @@ fn integration_test() {
 }
 
 #[test]
-fn integration_test_cairo1() {
-    //  Create program and entry point types for contract class
+fn test_cairo_1_external_entrypoint() {
     let program_data = include_bytes!("../starknet_programs/cairo1/fibonacci.casm");
-    let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
-    let entrypoints = contract_class.clone().entry_points_by_type;
-    let fib_entrypoint_selector = &entrypoints.external.get(0).unwrap().selector;
-
-    // Create state reader with class hash data
-    let mut contract_class_cache = HashMap::new();
-
-    let address = Address(1111.into());
-    let class_hash: ClassHash = [1; 32];
-    let nonce = Felt252::zero();
-
-    contract_class_cache.insert(class_hash, contract_class);
-    let mut state_reader = InMemoryStateReader::default();
-    state_reader
-        .address_to_class_hash_mut()
-        .insert(address.clone(), class_hash);
-    state_reader
-        .address_to_nonce_mut()
-        .insert(address.clone(), nonce);
-
-    // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
-
-    // Create an execution entry point
-    let calldata = [0.into(), 1.into(), 12.into()].to_vec();
-    let caller_address = Address(0000.into());
-    let entry_point_type = EntryPointType::External;
-
-    let exec_entry_point = ExecutionEntryPoint::new(
-        address,
-        calldata.clone(),
-        Felt252::new(fib_entrypoint_selector.clone()),
-        caller_address,
-        entry_point_type,
-        Some(CallType::Delegate),
-        Some(class_hash),
-        100000,
-    );
-
-    // Execute the entrypoint
-    let general_config = StarknetGeneralConfig::default();
-    let tx_execution_context = TransactionExecutionContext::new(
-        Address(0.into()),
-        Felt252::zero(),
-        Vec::new(),
+    starknet_rs::utils::integration_test_utils::test_cairo_1_external_entrypoint(
+        program_data,
         0,
-        10.into(),
-        general_config.invoke_tx_max_n_steps(),
-        TRANSACTION_VERSION,
-    );
-    let mut resources_manager = ExecutionResourcesManager::default();
-
-    // expected results
-    let expected_call_info = CallInfo {
-        caller_address: Address(0.into()),
-        call_type: Some(CallType::Delegate),
-        contract_address: Address(1111.into()),
-        entry_point_selector: Some(Felt252::new(fib_entrypoint_selector)),
-        entry_point_type: Some(EntryPointType::External),
-        calldata,
-        retdata: [144.into()].to_vec(),
-        execution_resources: ExecutionResources::default(),
-        class_hash: Some(class_hash),
-        ..Default::default()
-    };
-
-    assert_eq!(
-        exec_entry_point
-            .execute(
-                &mut state,
-                &general_config,
-                &mut resources_manager,
-                &tx_execution_context,
-                false,
-            )
-            .unwrap(),
-        expected_call_info
+        &[144.into()],
+        &ExecutionResources::default(),
     );
 }


### PR DESCRIPTION
This PR extracts the logic from the test in `tests::fibonacci::test_cairo_1_external_entrypoint` to be reused by other integration tests
Notes: I couldn't get the import to work if I added the function to the test module directly, so this was a fast solution