### PR TITLE
bugfix: Convert ` SyscallResponse` to cairo-compatible arguments before witing them into memory

### DIFF
--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -380,7 +380,7 @@ impl<'a, T: State + StateReader + Default> BusinessLogicSyscallHandler<'a, T> {
 
         // Write response to the syscall segment.
         self.expected_syscall_ptr = vm
-            .write_arg(syscall_ptr, &response)?
+            .write_arg(syscall_ptr, &response.to_cairo_compatible_args())?
             .get_relocatable()
             .ok_or(MemoryError::WriteArg)?;
 

--- a/src/core/syscalls/syscall_response.rs
+++ b/src/core/syscalls/syscall_response.rs
@@ -1,5 +1,5 @@
 use cairo_vm::felt::Felt252;
-use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 
 // TODO: remove once used.
 #[allow(dead_code)]
@@ -17,6 +17,41 @@ pub(crate) struct SyscallResponse {
     pub gas: u64,
     /// Syscall specific response fields.
     pub body: Option<ResponseBody>,
+}
+
+impl SyscallResponse {
+    pub(crate) fn to_cairo_compatible_args(&self) -> Vec<MaybeRelocatable> {
+        let mut cairo_args = Vec::<MaybeRelocatable>::with_capacity(5);
+        cairo_args.push(Felt252::from(self.gas).into());
+        cairo_args
+            .push(Felt252::from(matches!(self.body, Some(ResponseBody::Failure(_))) as u8).into());
+        match self.body.as_ref() {
+            Some(ResponseBody::StorageReadResponse { value }) => {
+                if let Some(v) = value.as_ref() {
+                    cairo_args.push(v.clone().into())
+                }
+            }
+            Some(ResponseBody::GetBlockNumber { number }) => cairo_args.push(number.into()),
+            Some(ResponseBody::Deploy(deploy_response)) => {
+                cairo_args.push(deploy_response.contract_address.clone().into());
+                cairo_args.push(deploy_response.retdata_start.into());
+                cairo_args.push(deploy_response.retdata_end.into());
+            }
+            Some(ResponseBody::CallContract(call_contract_response)) => {
+                cairo_args.push(call_contract_response.retdata_start.into());
+                cairo_args.push(call_contract_response.retdata_end.into());
+            }
+            Some(ResponseBody::Failure(failure_reason)) => {
+                cairo_args.push(failure_reason.retdata_start.into());
+                cairo_args.push(failure_reason.retdata_end.into());
+            }
+            Some(ResponseBody::GetBlockTimestamp(get_block_timestamp_response)) => {
+                cairo_args.push(get_block_timestamp_response.timestamp.clone().into())
+            }
+            None => {}
+        }
+        cairo_args
+    }
 }
 
 // ----------------------


### PR DESCRIPTION
`BusinessLogicSyscallHandler::syscall` currently fails when writing the `SyscallResponse` struct into memory as cairo memory doesn't understant this struct. This PR adds the conversion to Vec<MaybeRelocatable> + adds the failure flag that wasnt present and is present in the cairo1 codebase