### PR TITLE
bugfix: Use `class_hash` when creating `ExecutionExtryPoint` in `BusinessLogicSyscallHandler::library_call`

### DIFF
--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -679,7 +679,7 @@ where
             self.caller_address.clone(),
             EntryPointType::External,
             Some(CallType::Delegate),
-            None,
+            Some(request.class_hash.to_be_bytes()),
             0,
         );
 


### PR DESCRIPTION
Otherwise if fails to find the lib contract