### PR TITLE
Remove Default + Clone from States implemententations

### DIFF
--- a/src/business_logic/execution/execution_entry_point.rs
+++ b/src/business_logic/execution/execution_entry_point.rs
@@ -92,7 +92,7 @@ impl ExecutionEntryPoint {
         support_reverted: bool,
     ) -> Result<CallInfo, TransactionError>
     where
-        T: State + StateReader + Default,
+        T: State + StateReader,
     {
         // lookup the compiled class from the state.
         let class_hash = self.get_code_class_hash(state)?;
@@ -256,7 +256,7 @@ impl ExecutionEntryPoint {
         class_hash: [u8; 32],
     ) -> Result<CallInfo, TransactionError>
     where
-        T: State + StateReader + Default,
+        T: State + StateReader,
     {
         let previous_cairo_usage = resources_manager.cairo_usage.clone();
 
@@ -353,7 +353,7 @@ impl ExecutionEntryPoint {
         support_reverted: bool,
     ) -> Result<CallInfo, TransactionError>
     where
-        T: State + StateReader + Default,
+        T: State + StateReader,
     {
         let previous_cairo_usage = resources_manager.cairo_usage.clone();
         // fetch selected entry point

--- a/src/business_logic/fact_state/in_memory_state_reader.rs
+++ b/src/business_logic/fact_state/in_memory_state_reader.rs
@@ -12,7 +12,7 @@ use cairo_vm::felt::Felt252;
 use getset::{Getters, MutGetters};
 use std::collections::HashMap;
 
-#[derive(Debug, MutGetters, Getters, PartialEq)]
+#[derive(Debug, MutGetters, Getters, PartialEq, Clone, Default)]
 pub struct InMemoryStateReader {
     #[getset(get_mut = "pub")]
     pub address_to_class_hash: HashMap<Address, ClassHash>,

--- a/src/business_logic/fact_state/in_memory_state_reader.rs
+++ b/src/business_logic/fact_state/in_memory_state_reader.rs
@@ -12,7 +12,7 @@ use cairo_vm::felt::Felt252;
 use getset::{Getters, MutGetters};
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, Default, MutGetters, Getters, PartialEq)]
+#[derive(Debug, MutGetters, Getters, PartialEq)]
 pub struct InMemoryStateReader {
     #[getset(get_mut = "pub")]
     pub address_to_class_hash: HashMap<Address, ClassHash>,

--- a/src/business_logic/fact_state/state.rs
+++ b/src/business_logic/fact_state/state.rs
@@ -54,27 +54,29 @@ pub struct StateDiff {
 impl StateDiff {
     pub fn from_cached_state<T>(cached_state: CachedState<T>) -> Result<Self, StateError>
     where
-        T: StateReader + Clone,
+        T: StateReader,
     {
         let state_cache = cached_state.cache().to_owned();
 
         let substracted_maps = subtract_mappings(
-            state_cache.storage_writes,
-            state_cache.storage_initial_values,
+            state_cache.storage_writes.clone(),
+            state_cache.storage_initial_values.clone(),
         );
 
         let storage_updates = to_state_diff_storage_mapping(substracted_maps);
 
-        let address_to_nonce =
-            subtract_mappings(state_cache.nonce_writes, state_cache.nonce_initial_values);
+        let address_to_nonce = subtract_mappings(
+            state_cache.nonce_writes.clone(),
+            state_cache.nonce_initial_values.clone(),
+        );
 
         let class_hash_to_compiled_class = subtract_mappings(
-            state_cache.compiled_class_hash_writes,
-            state_cache.compiled_class_hash_initial_values,
+            state_cache.compiled_class_hash_writes.clone(),
+            state_cache.compiled_class_hash_initial_values.clone(),
         );
 
         let address_to_class_hash = subtract_mappings(
-            state_cache.class_hash_writes,
+            state_cache.class_hash_writes.clone(),
             state_cache.class_hash_initial_values,
         );
 

--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -22,7 +22,7 @@ pub type CasmClassCache = HashMap<ClassHash, CasmContractClass>;
 
 pub const UNINITIALIZED_CLASS_HASH: &ClassHash = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
-#[derive(Debug, Eq, Getters, MutGetters, PartialEq)]
+#[derive(Default, Clone, Debug, Eq, Getters, MutGetters, PartialEq)]
 pub struct CachedState<T: StateReader> {
     #[get = "pub"]
     pub(crate) state_reader: T,
@@ -34,7 +34,7 @@ pub struct CachedState<T: StateReader> {
     pub(crate) casm_contract_classes: Option<CasmClassCache>,
 }
 
-impl<T: StateReader + Clone> CachedState<T> {
+impl<T: StateReader> CachedState<T> {
     pub fn new(
         state_reader: T,
         contract_class_cache: Option<ContractClassCache>,
@@ -85,21 +85,9 @@ impl<T: StateReader + Clone> CachedState<T> {
             .as_ref()
             .ok_or(StateError::MissingCasmClassCache)
     }
-
-    /// Apply updates to parent state.
-    pub(crate) fn apply(&self, parent: &mut CachedState<T>) {
-        // TODO assert: if self.state_reader == parent
-        parent.cache.update_writes_from_other(&self.cache);
-    }
-
-    pub(crate) fn apply_to_copy(&mut self) -> Self {
-        let copied_state = self.clone();
-        copied_state.apply(self);
-        copied_state
-    }
 }
 
-impl<T: StateReader + Clone> StateReader for CachedState<T> {
+impl<T: StateReader> StateReader for CachedState<T> {
     fn get_contract_class(&mut self, class_hash: &ClassHash) -> Result<ContractClass, StateError> {
         if !self.get_contract_classes()?.contains_key(class_hash) {
             let contract_class = self.state_reader.get_contract_class(class_hash)?;
@@ -224,7 +212,7 @@ impl<T: StateReader + Clone> StateReader for CachedState<T> {
     }
 }
 
-impl<T: StateReader + Clone> State for CachedState<T> {
+impl<T: StateReader> State for CachedState<T> {
     fn set_contract_class(
         &mut self,
         class_hash: &ClassHash,

--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -22,8 +22,8 @@ pub type CasmClassCache = HashMap<ClassHash, CasmContractClass>;
 
 pub const UNINITIALIZED_CLASS_HASH: &ClassHash = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
-#[derive(Debug, Clone, Default, Eq, Getters, MutGetters, PartialEq)]
-pub struct CachedState<T: StateReader + Clone> {
+#[derive(Debug, Eq, Getters, MutGetters, PartialEq)]
+pub struct CachedState<T: StateReader> {
     #[get = "pub"]
     pub(crate) state_reader: T,
     #[getset(get = "pub", get_mut = "pub")]

--- a/src/business_logic/state/state_cache.rs
+++ b/src/business_logic/state/state_cache.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 // TODO: Change [u8; 32] to Felt252.
 pub type StorageEntry = (Address, [u8; 32]);
 
-#[derive(Debug, Default, Clone, Eq, Getters, MutGetters, PartialEq)]
+#[derive(Debug, Eq, Getters, MutGetters, PartialEq)]
 pub struct StateCache {
     // Reader's cached information; initial values, read before any write operation (per cell)
     #[get_mut = "pub"]

--- a/src/business_logic/state/state_cache.rs
+++ b/src/business_logic/state/state_cache.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 // TODO: Change [u8; 32] to Felt252.
 pub type StorageEntry = (Address, [u8; 32]);
 
-#[derive(Debug, Eq, Getters, MutGetters, PartialEq)]
+#[derive(Default, Clone, Debug, Eq, Getters, MutGetters, PartialEq)]
 pub struct StateCache {
     // Reader's cached information; initial values, read before any write operation (per cell)
     #[get_mut = "pub"]
@@ -130,15 +130,6 @@ impl StateCache {
         self.storage_initial_values.get(storage_entry)
     }
 
-    pub(crate) fn update_writes_from_other(&mut self, other: &Self) {
-        self.class_hash_writes
-            .extend(other.class_hash_writes.clone());
-        self.compiled_class_hash_writes
-            .extend(other.compiled_class_hash_writes.clone());
-        self.nonce_writes.extend(other.nonce_writes.clone());
-        self.storage_writes.extend(other.storage_writes.clone());
-    }
-
     pub(crate) fn update_writes(
         &mut self,
         address_to_class_hash: &HashMap<Address, ClassHash>,
@@ -229,66 +220,6 @@ mod tests {
         assert_eq!(
             state_cache.get_accessed_contract_addresses(),
             HashSet::from([Address(10.into()), Address(9.into()), Address(4.into())])
-        );
-    }
-
-    #[test]
-    fn state_chache_update_writes_from_other() {
-        let mut state_cache = StateCache::default();
-        let address_to_class_hash = HashMap::from([(Address(10.into()), [11; 32])]);
-        let compiled_class = CompiledClass::Deprecated(Box::new(
-            ContractClass::new(Program::default(), HashMap::new(), None).unwrap(),
-        ));
-        let class_hash_to_compiled_class_hash = HashMap::from([([8; 32], compiled_class.clone())]);
-        let address_to_nonce = HashMap::from([(Address(9.into()), 12.into())]);
-        let storage_updates = HashMap::from([((Address(20.into()), [1; 32]), 18.into())]);
-
-        state_cache
-            .set_initial_values(
-                &address_to_class_hash,
-                &class_hash_to_compiled_class_hash,
-                &address_to_nonce,
-                &storage_updates,
-            )
-            .expect("Error setting StateCache values");
-
-        let mut other_state_cache = StateCache::default();
-        let other_address_to_class_hash = HashMap::from([(Address(10.into()), [13; 32])]);
-        let other_address_to_nonce = HashMap::from([(Address(401.into()), 100.into())]);
-        let other_storage_updates = HashMap::from([((Address(4002.into()), [2; 32]), 101.into())]);
-
-        other_state_cache
-            .set_initial_values(
-                &other_address_to_class_hash,
-                &class_hash_to_compiled_class_hash,
-                &other_address_to_nonce,
-                &other_storage_updates,
-            )
-            .expect("Error setting StateCache values");
-
-        state_cache.update_writes_from_other(&other_state_cache);
-
-        assert_eq!(
-            state_cache.get_class_hash(&Address(10.into())),
-            Some(&[13; 32])
-        );
-        assert_eq!(
-            state_cache.get_compiled_class_hash(&[8; 32]),
-            Some(&compiled_class)
-        );
-        assert_eq!(
-            state_cache.nonce_writes,
-            HashMap::from([
-                (Address(9.into()), 12.into()),
-                (Address(401.into()), 100.into())
-            ])
-        );
-        assert_eq!(
-            state_cache.storage_writes,
-            HashMap::from([
-                ((Address(20.into()), [1; 32]), 18.into()),
-                ((Address(4002.into()), [2; 32]), 101.into())
-            ])
         );
     }
 }

--- a/src/business_logic/transaction/fee.rs
+++ b/src/business_logic/transaction/fee.rs
@@ -22,7 +22,7 @@ pub type FeeInfo = (Option<CallInfo>, u64);
 
 /// Transfers the amount actual_fee from the caller account to the sequencer.
 /// Returns the resulting CallInfo of the transfer call.
-pub(crate) fn execute_fee_transfer<S: State + StateReader + Default>(
+pub(crate) fn execute_fee_transfer<S: State + StateReader>(
     state: &mut S,
     general_config: &StarknetGeneralConfig,
     tx_context: &TransactionExecutionContext,

--- a/src/business_logic/transaction/objects/internal_declare.rs
+++ b/src/business_logic/transaction/objects/internal_declare.rs
@@ -127,7 +127,7 @@ impl InternalDeclare {
 
     /// Executes a call to the cairo-vm using the accounts_validation.cairo contract to validate
     /// the contract that is being declared. Then it returns the transaction execution info of the run.
-    pub fn apply<S: Default + State + StateReader + Clone>(
+    pub fn apply<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -174,7 +174,7 @@ impl InternalDeclare {
         )
     }
 
-    pub fn run_validate_entrypoint<S: Default + State + StateReader>(
+    pub fn run_validate_entrypoint<S: State + StateReader>(
         &self,
         state: &mut S,
         resources_manager: &mut ExecutionResourcesManager,
@@ -212,7 +212,7 @@ impl InternalDeclare {
     }
 
     /// Calculates and charges the actual fee.
-    pub fn charge_fee<S: Default + State + StateReader + Clone>(
+    pub fn charge_fee<S: State + StateReader>(
         &self,
         state: &mut S,
         resources: &HashMap<String, usize>,
@@ -235,10 +235,7 @@ impl InternalDeclare {
         Ok((Some(fee_transfer_info), actual_fee))
     }
 
-    fn handle_nonce<S: Default + State + StateReader + Clone>(
-        &self,
-        state: &mut S,
-    ) -> Result<(), TransactionError> {
+    fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
         if self.version == 0 {
             return Ok(());
         }
@@ -259,7 +256,7 @@ impl InternalDeclare {
 
     /// Calculates actual fee used by the transaction using the execution
     /// info returned by apply(), then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/business_logic/transaction/objects/internal_deploy.rs
+++ b/src/business_logic/transaction/objects/internal_deploy.rs
@@ -81,7 +81,7 @@ impl InternalDeploy {
         self.contract_hash
     }
 
-    pub fn apply<S: Default + State + StateReader + Clone>(
+    pub fn apply<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -102,9 +102,9 @@ impl InternalDeploy {
         }
     }
 
-    pub fn handle_empty_constructor<T: Default + State + StateReader + Clone>(
+    pub fn handle_empty_constructor<S: State + StateReader>(
         &self,
-        state: &mut T,
+        state: &mut S,
     ) -> Result<TransactionExecutionInfo, StarkwareError> {
         if !self.constructor_calldata.is_empty() {
             return Err(StarkwareError::TransactionFailed);
@@ -139,7 +139,7 @@ impl InternalDeploy {
         )
     }
 
-    pub fn invoke_constructor<S: Default + State + StateReader + Clone>(
+    pub fn invoke_constructor<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -195,7 +195,7 @@ impl InternalDeploy {
 
     /// Calculates actual fee used by the transaction using the execution
     /// info returned by apply(), then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/business_logic/transaction/objects/internal_deploy_account.rs
+++ b/src/business_logic/transaction/objects/internal_deploy_account.rs
@@ -118,7 +118,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        S: State + StateReader + Default,
+        S: State + StateReader,
     {
         let tx_info = self.apply(state, general_config)?;
 
@@ -143,7 +143,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        S: State + StateReader + Default,
+        S: State + StateReader,
     {
         let contract_class = state.get_contract_class(&self.class_hash)?;
 
@@ -187,7 +187,7 @@ impl InternalDeployAccount {
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError>
     where
-        S: State + StateReader + Default,
+        S: State + StateReader,
     {
         let num_constructors = contract_class
             .entry_points_by_type
@@ -238,7 +238,7 @@ impl InternalDeployAccount {
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError>
     where
-        S: State + StateReader + Default,
+        S: State + StateReader,
     {
         let entry_point = ExecutionEntryPoint::new(
             self.contract_address.clone(),
@@ -293,7 +293,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<Option<CallInfo>, TransactionError>
     where
-        S: State + StateReader + Default,
+        S: State + StateReader,
     {
         if self.version == 0 {
             return Ok(None);
@@ -337,7 +337,7 @@ impl InternalDeployAccount {
         general_config: &StarknetGeneralConfig,
     ) -> Result<FeeInfo, TransactionError>
     where
-        S: State + StateReader + Default,
+        S: State + StateReader,
     {
         if self.max_fee.is_zero() {
             return Ok((None, 0));

--- a/src/business_logic/transaction/objects/internal_invoke_function.rs
+++ b/src/business_logic/transaction/objects/internal_invoke_function.rs
@@ -118,7 +118,7 @@ impl InternalInvokeFunction {
         general_config: &StarknetGeneralConfig,
     ) -> Result<Option<CallInfo>, TransactionError>
     where
-        T: Default + State + StateReader,
+        T: State + StateReader,
     {
         if self.entry_point_selector != *EXECUTE_ENTRY_POINT_SELECTOR {
             return Ok(None);
@@ -163,7 +163,7 @@ impl InternalInvokeFunction {
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError>
     where
-        T: Default + State + StateReader,
+        T: State + StateReader,
     {
         let call = ExecutionEntryPoint::new(
             self.contract_address.clone(),
@@ -189,13 +189,13 @@ impl InternalInvokeFunction {
 
     /// Execute a call to the cairo-vm using the accounts_validation.cairo contract to validate
     /// the contract that is being declared. Then it returns the transaction execution info of the run.
-    pub fn apply<T>(
+    pub fn apply<S>(
         &self,
-        state: &mut T,
+        state: &mut S,
         general_config: &StarknetGeneralConfig,
     ) -> Result<TransactionExecutionInfo, TransactionError>
     where
-        T: Default + State + StateReader + Clone,
+        S: State + StateReader,
     {
         let mut resources_manager = ExecutionResourcesManager::default();
 
@@ -230,7 +230,7 @@ impl InternalInvokeFunction {
         general_config: &StarknetGeneralConfig,
     ) -> Result<FeeInfo, TransactionError>
     where
-        S: Clone + Default + State + StateReader,
+        S: State + StateReader,
     {
         if self.max_fee.is_zero() {
             return Ok((None, 0));
@@ -251,7 +251,7 @@ impl InternalInvokeFunction {
 
     /// Calculates actual fee used by the transaction using the execution info returned by apply(),
     /// then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -274,10 +274,7 @@ impl InternalInvokeFunction {
         )
     }
 
-    fn handle_nonce<S: Default + State + StateReader + Clone>(
-        &self,
-        state: &mut S,
-    ) -> Result<(), TransactionError> {
+    fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
         if self.version == 0 {
             return Ok(());
         }

--- a/src/business_logic/transaction/objects/v2/declare_v2.rs
+++ b/src/business_logic/transaction/objects/v2/declare_v2.rs
@@ -130,7 +130,7 @@ impl InternalDeclareV2 {
     }
 
     /// Calculates and charges the actual fee.
-    pub fn charge_fee<S: Default + State + StateReader + Clone>(
+    pub fn charge_fee<S: State + StateReader>(
         &self,
         state: &mut S,
         resources: &HashMap<String, usize>,
@@ -155,10 +155,7 @@ impl InternalDeclareV2 {
 
     // TODO: delete once used
     #[allow(dead_code)]
-    fn handle_nonce<S: Default + State + StateReader + Clone>(
-        &self,
-        state: &mut S,
-    ) -> Result<(), TransactionError> {
+    fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
         if self.version == 0 {
             return Ok(());
         }
@@ -177,7 +174,7 @@ impl InternalDeclareV2 {
         Ok(())
     }
 
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &mut self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,
@@ -214,7 +211,7 @@ impl InternalDeclareV2 {
         )
     }
 
-    pub(crate) fn compile_and_store_casm_class<S: Default + State + StateReader + Clone>(
+    pub(crate) fn compile_and_store_casm_class<S: State + StateReader>(
         &mut self,
         state: &mut S,
     ) -> Result<(), TransactionError> {
@@ -230,7 +227,7 @@ impl InternalDeclareV2 {
         Ok(())
     }
 
-    fn run_validate_entrypoint<S: Default + State + StateReader + Clone>(
+    fn run_validate_entrypoint<S: State + StateReader>(
         &mut self,
         mut remaining_gas: u64,
         state: &mut S,

--- a/src/business_logic/transaction/transactions.rs
+++ b/src/business_logic/transaction/transactions.rs
@@ -32,7 +32,7 @@ impl Transaction {
         }
     }
 
-    pub fn execute<S: Default + State + StateReader + Clone>(
+    pub fn execute<S: State + StateReader>(
         &self,
         state: &mut S,
         general_config: &StarknetGeneralConfig,

--- a/src/core/syscalls/business_logic_syscall_handler.rs
+++ b/src/core/syscalls/business_logic_syscall_handler.rs
@@ -135,7 +135,7 @@ pub struct BusinessLogicSyscallHandler<'a, T: State + StateReader> {
 
 // TODO: execution entry point may no be a parameter field, but there is no way to generate a default for now
 
-impl<'a, T: State + StateReader + Default> BusinessLogicSyscallHandler<'a, T> {
+impl<'a, T: State + StateReader> BusinessLogicSyscallHandler<'a, T> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         tx_execution_context: TransactionExecutionContext,
@@ -411,7 +411,7 @@ impl<'a, T: State + StateReader + Default> BusinessLogicSyscallHandler<'a, T> {
 
 impl<'a, T> BusinessLogicSyscallHandler<'a, T>
 where
-    T: State + StateReader + Default,
+    T: State + StateReader,
 {
     fn emit_event(
         &mut self,

--- a/src/core/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/core/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -43,7 +43,7 @@ use std::borrow::{Borrow, BorrowMut};
 //* -----------------------------------
 /// Deprecated version of BusinessLogicSyscallHandler.
 #[derive(Debug)]
-pub struct DeprecatedBLSyscallHandler<'a, T: State + StateReader + Default> {
+pub struct DeprecatedBLSyscallHandler<'a, T: State + StateReader> {
     pub(crate) tx_execution_context: TransactionExecutionContext,
     /// Events emitted by the current contract call.
     pub(crate) events: Vec<OrderedEvent>,
@@ -60,7 +60,7 @@ pub struct DeprecatedBLSyscallHandler<'a, T: State + StateReader + Default> {
     pub(crate) expected_syscall_ptr: Relocatable,
 }
 
-impl<'a, T: State + StateReader + Default> DeprecatedBLSyscallHandler<'a, T> {
+impl<'a, T: State + StateReader> DeprecatedBLSyscallHandler<'a, T> {
     pub fn new(
         tx_execution_context: TransactionExecutionContext,
         state: &'a mut T,
@@ -230,7 +230,7 @@ impl<'a, T: State + StateReader + Default> DeprecatedBLSyscallHandler<'a, T> {
 
 impl<'a, T> Borrow<T> for DeprecatedBLSyscallHandler<'a, T>
 where
-    T: State + StateReader + Default,
+    T: State + StateReader,
 {
     fn borrow(&self) -> &T {
         self.starknet_storage_state.state
@@ -239,7 +239,7 @@ where
 
 impl<'a, T> BorrowMut<T> for DeprecatedBLSyscallHandler<'a, T>
 where
-    T: State + StateReader + Default,
+    T: State + StateReader,
 {
     fn borrow_mut(&mut self) -> &mut T {
         self.starknet_storage_state.state
@@ -248,7 +248,7 @@ where
 
 impl<'a, T> DeprecatedBLSyscallHandler<'a, T>
 where
-    T: State + StateReader + Default,
+    T: State + StateReader,
 {
     pub(crate) fn emit_event(
         &mut self,

--- a/src/core/syscalls/deprecated_syscall_handler.rs
+++ b/src/core/syscalls/deprecated_syscall_handler.rs
@@ -21,12 +21,12 @@ use cairo_vm::{
 };
 use std::{any::Any, collections::HashMap};
 
-pub(crate) struct DeprecatedSyscallHintProcessor<'a, T: State + StateReader + Default> {
+pub(crate) struct DeprecatedSyscallHintProcessor<'a, T: State + StateReader> {
     pub(crate) builtin_hint_processor: BuiltinHintProcessor,
     pub(crate) syscall_handler: DeprecatedBLSyscallHandler<'a, T>,
 }
 
-impl<'a, T: State + StateReader + Default> DeprecatedSyscallHintProcessor<'a, T> {
+impl<'a, T: State + StateReader> DeprecatedSyscallHintProcessor<'a, T> {
     pub fn new(syscall_handler: DeprecatedBLSyscallHandler<'a, T>) -> Self {
         DeprecatedSyscallHintProcessor {
             builtin_hint_processor: BuiltinHintProcessor::new_empty(),
@@ -131,7 +131,7 @@ impl<'a, T: State + StateReader + Default> DeprecatedSyscallHintProcessor<'a, T>
     }
 }
 
-impl<'a, T: State + StateReader + Default> HintProcessor for DeprecatedSyscallHintProcessor<'a, T> {
+impl<'a, T: State + StateReader> HintProcessor for DeprecatedSyscallHintProcessor<'a, T> {
     fn execute_hint(
         &mut self,
         vm: &mut VirtualMachine,
@@ -153,9 +153,7 @@ impl<'a, T: State + StateReader + Default> HintProcessor for DeprecatedSyscallHi
     }
 }
 
-impl<'a, T: State + StateReader + Default> HintProcessorPostRun
-    for DeprecatedSyscallHintProcessor<'a, T>
-{
+impl<'a, T: State + StateReader> HintProcessorPostRun for DeprecatedSyscallHintProcessor<'a, T> {
     fn post_run(
         &self,
         runner: &mut VirtualMachine,

--- a/src/core/syscalls/syscall_handler.rs
+++ b/src/core/syscalls/syscall_handler.rs
@@ -50,7 +50,7 @@ impl<'a, T: State + StateReader> SyscallHintProcessor<'a, T> {
     }
 }
 
-impl<'a, T: Default + State + StateReader> HintProcessor for SyscallHintProcessor<'a, T> {
+impl<'a, T: State + StateReader> HintProcessor for SyscallHintProcessor<'a, T> {
     fn execute_hint(
         &mut self,
         vm: &mut VirtualMachine,

--- a/src/testing/starknet_state.rs
+++ b/src/testing/starknet_state.rs
@@ -102,7 +102,6 @@ impl StarknetState {
         )?;
 
         let tx_execution_info = tx.execute(&mut self.state, &self.general_config)?;
-        self.state = self.state.apply_to_copy();
 
         Ok((tx.class_hash, tx_execution_info))
     }
@@ -154,12 +153,11 @@ impl StarknetState {
             0,
         );
 
-        let mut state_copy = self.state.apply_to_copy();
         let mut resources_manager = ExecutionResourcesManager::default();
 
         let tx_execution_context = TransactionExecutionContext::default();
         let call_info = call.execute(
-            &mut state_copy,
+            &mut self.state,
             &self.general_config,
             &mut resources_manager,
             &tx_execution_context,
@@ -205,7 +203,6 @@ impl StarknetState {
         &mut self,
         tx: &mut Transaction,
     ) -> Result<TransactionExecutionInfo, StarknetStateError> {
-        self.state = self.state.apply_to_copy();
         let tx = tx.execute(&mut self.state, &self.general_config)?;
         let tx_execution_info = ExecutionInfo::Transaction(Box::new(tx.clone()));
         self.add_messages_and_events(&tx_execution_info)?;


### PR DESCRIPTION
Refactor struct implementations to remove the requirement of implementing `Default` and `Clone` traits for generics that implement either `State` or `StateReader`