### PR TITLE
Fix CallInfo::get_sorted_l2_to_l1_messages

### DIFF
--- a/src/business_logic/execution/objects.rs
+++ b/src/business_logic/execution/objects.rs
@@ -152,8 +152,8 @@ impl CallInfo {
             for ordered_msg in call.l2_to_l1_messages {
                 let l2tol1msg =
                     L2toL1MessageInfo::new(ordered_msg.clone(), call.caller_address.clone());
-                starknet_events.remove(ordered_msg.order - 1);
-                starknet_events.insert(ordered_msg.order - 1, Some(l2tol1msg));
+                starknet_events.remove(ordered_msg.order);
+                starknet_events.insert(ordered_msg.order, Some(l2tol1msg));
             }
         }
 
@@ -766,10 +766,10 @@ mod tests {
         let mut ord_msg4 = OrderedL2ToL1Message::default();
 
         // set orders
-        ord_msg1.order = 1;
-        ord_msg2.order = 2;
-        ord_msg3.order = 3;
-        ord_msg4.order = 4;
+        ord_msg1.order = 0;
+        ord_msg2.order = 1;
+        ord_msg3.order = 2;
+        ord_msg4.order = 3;
 
         // store events
         child1.l2_to_l1_messages = Vec::from([ord_msg3.clone(), ord_msg4.clone()]);
@@ -806,10 +806,10 @@ mod tests {
         let mut ord_msg4 = OrderedL2ToL1Message::default();
 
         // set orders
-        ord_msg1.order = 1;
-        ord_msg2.order = 2;
-        ord_msg3.order = 3;
-        ord_msg4.order = 3;
+        ord_msg1.order = 0;
+        ord_msg2.order = 1;
+        ord_msg3.order = 2;
+        ord_msg4.order = 2;
 
         // store events
         child1.l2_to_l1_messages = Vec::from([ord_msg3, ord_msg4]);

--- a/src/testing/starknet_state.rs
+++ b/src/testing/starknet_state.rs
@@ -591,12 +591,12 @@ mod tests {
     fn test_add_messages_and_events() {
         let mut starknet_state = StarknetState::new(None);
         let test_msg_1 = OrderedL2ToL1Message {
-            order: 1,
+            order: 0,
             to_address: Address(0.into()),
             payload: vec![0.into()],
         };
         let test_msg_2 = OrderedL2ToL1Message {
-            order: 2,
+            order: 1,
             to_address: Address(0.into()),
             payload: vec![0.into()],
         };
@@ -621,12 +621,12 @@ mod tests {
     fn test_consume_message_hash() {
         let mut starknet_state = StarknetState::new(None);
         let test_msg_1 = OrderedL2ToL1Message {
-            order: 1,
+            order: 0,
             to_address: Address(0.into()),
             payload: vec![0.into()],
         };
         let test_msg_2 = OrderedL2ToL1Message {
-            order: 2,
+            order: 1,
             to_address: Address(0.into()),
             payload: vec![0.into()],
         };
@@ -654,7 +654,7 @@ mod tests {
     fn test_consume_message_hash_twice_should_fail() {
         let mut starknet_state = StarknetState::new(None);
         let test_msg = OrderedL2ToL1Message {
-            order: 1,
+            order: 0,
             to_address: Address(0.into()),
             payload: vec![0.into()],
         };


### PR DESCRIPTION
closes #552

The order of L2 to L1 messages starts with zero and not one.