### PR TITLE
Handle `Io` errors in `storage_read` syscall

### DIFF
--- a/src/business_logic/state/cached_state.rs
+++ b/src/business_logic/state/cached_state.rs
@@ -373,10 +373,7 @@ mod tests {
             cached_state.get_class_hash_at(&contract_address).unwrap(),
             class_hash
         );
-        assert_eq!(
-            cached_state.get_nonce_at(&contract_address).unwrap(),
-            nonce
-        );
+        assert_eq!(cached_state.get_nonce_at(&contract_address).unwrap(), nonce);
         cached_state.increment_nonce(&contract_address).unwrap();
         assert_eq!(
             cached_state.get_nonce_at(&contract_address).unwrap(),

--- a/src/business_logic/state/in_memory_state_reader.rs
+++ b/src/business_logic/state/in_memory_state_reader.rs
@@ -147,13 +147,13 @@ mod tests {
             .insert(storage_entry.clone(), storage_value.clone());
 
         assert_eq!(
-            state_reader.get_class_hash_at(&contract_address),
-            Ok(class_hash)
+            state_reader.get_class_hash_at(&contract_address).unwrap(),
+            class_hash
         );
-        assert_eq!(state_reader.get_nonce_at(&contract_address), Ok(nonce));
+        assert_eq!(state_reader.get_nonce_at(&contract_address).unwrap(), nonce);
         assert_eq!(
-            state_reader.get_storage_at(&storage_entry),
-            Ok(storage_value)
+            state_reader.get_storage_at(&storage_entry).unwrap(),
+            storage_value
         );
     }
 

--- a/src/business_logic/state/mod.rs
+++ b/src/business_logic/state/mod.rs
@@ -324,8 +324,10 @@ mod test {
             cached_state.contract_classes()
         );
         assert_eq!(
-            cached_state_original.get_nonce_at(&contract_address),
-            cached_state.get_nonce_at(&contract_address)
+            cached_state_original
+                .get_nonce_at(&contract_address)
+                .unwrap(),
+            cached_state.get_nonce_at(&contract_address).unwrap()
         );
     }
 

--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Eq, Error)]
+#[derive(Debug, Error)]
 pub enum StateError {
     #[error("Missing ContractClassCache")]
     MissingContractClassCache,
@@ -53,5 +53,5 @@ pub enum StateError {
     #[error("Uninitializes class_hash")]
     UninitiaizedClassHash,
     #[error(transparent)]
-    Io(#[from] std::io::Error)
+    Io(#[from] std::io::Error),
 }

--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -52,4 +52,6 @@ pub enum StateError {
     MissingClassHash(),
     #[error("Uninitializes class_hash")]
     UninitiaizedClassHash,
+    #[error(transparent)]
+    Io(#[from] std::io::Error)
 }

--- a/src/syscalls/business_logic_syscall_handler.rs
+++ b/src/syscalls/business_logic_syscall_handler.rs
@@ -535,8 +535,12 @@ where
         })
     }
 
-    fn _storage_read(&mut self, key: [u8; 32]) -> Felt252 {
-        self.starknet_storage_state.read(&key).unwrap_or_default()
+    fn _storage_read(&mut self, key: [u8; 32]) -> Result<Felt252, StateError> {
+        match self.starknet_storage_state.read(&key) {
+            Ok(value) => Ok(value),
+            Err(e @ StateError::Io(_)) => Err(e),
+            Err(_) => Ok(Felt252::zero()),
+        }
     }
 
     fn storage_write(
@@ -681,7 +685,7 @@ where
             });
         }
 
-        let value = self._storage_read(request.key);
+        let value = self._storage_read(request.key)?;
 
         Ok(SyscallResponse {
             gas: remaining_gas,

--- a/src/syscalls/deprecated_syscall_handler.rs
+++ b/src/syscalls/deprecated_syscall_handler.rs
@@ -900,9 +900,10 @@ mod tests {
         let write = syscall_handler_hint_processor
             .syscall_handler
             .starknet_storage_state
-            .read(&felt_to_hash(&address));
+            .read(&felt_to_hash(&address))
+            .unwrap();
 
-        assert_eq!(write, Ok(Felt252::new(45)));
+        assert_eq!(write, Felt252::new(45));
     }
 
     #[test]
@@ -988,8 +989,9 @@ mod tests {
                 .syscall_handler
                 .starknet_storage_state
                 .state
-                .get_class_hash_at(&Address(deployed_address)),
-            Ok(class_hash)
+                .get_class_hash_at(&Address(deployed_address))
+                .unwrap(),
+            class_hash
         );
     }
 
@@ -1085,8 +1087,9 @@ mod tests {
                 .syscall_handler
                 .starknet_storage_state
                 .state
-                .get_class_hash_at(&Address(deployed_address.clone())),
-            Ok(class_hash)
+                .get_class_hash_at(&Address(deployed_address.clone()))
+                .unwrap(),
+            class_hash
         );
 
         /*

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -1170,10 +1170,16 @@ fn test_state_for_declare_tx() {
     let declare_tx = declare_tx();
     // Check ContractClass is not set before the declare_tx
     assert!(state.get_contract_class(&declare_tx.class_hash).is_err());
-    assert_eq!(state.get_nonce_at(&declare_tx.sender_address), Ok(0.into()));
+    assert!(state
+        .get_nonce_at(&declare_tx.sender_address)
+        .unwrap()
+        .is_zero());
     // Execute declare_tx
     assert!(declare_tx.execute(&mut state, &general_config).is_ok());
-    assert_eq!(state.get_nonce_at(&declare_tx.sender_address), Ok(1.into()));
+    assert!(state
+        .get_nonce_at(&declare_tx.sender_address)
+        .unwrap()
+        .is_one());
 
     // Check state.state_reader
     let mut state_reader = state.state_reader().clone();


### PR DESCRIPTION
Also removes `PartialEq + Eq` derive traits from `StateError`

Note: I opted for using unwraps in the cases of `assert_eq(func_call, Ok(val)`in tests instead of using `assert_matches`, as codecov takes the `assert_matches` lines as uncovered lines