### PR TITLE
bugfix: Mutate `TransactionExecutionContext` between executions

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -253,7 +253,7 @@ fn call_parser(
         cached_state,
         &BlockContext::default(),
         &mut ExecutionResourcesManager::default(),
-        &TransactionExecutionContext::default(),
+        &mut TransactionExecutionContext::default(),
         false,
     )?;
     Ok(call_info.retdata)

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -149,7 +149,7 @@ fn main() {
             //*   Execute contract
             //* ---------------------
             let block_context = BlockContext::default();
-            let tx_execution_context = TransactionExecutionContext::new(
+            let mut tx_execution_context = TransactionExecutionContext::new(
                 Address(0.into()),
                 Felt252::zero(),
                 Vec::new(),
@@ -186,7 +186,7 @@ fn main() {
                         &mut state,
                         &block_context,
                         &mut resources_manager,
-                        &tx_execution_context,
+                        &mut tx_execution_context,
                         false,
                     )
                     .unwrap(),

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -87,7 +87,7 @@ impl ExecutionEntryPoint {
         state: &mut T,
         block_context: &BlockContext,
         resources_manager: &mut ExecutionResourcesManager,
-        tx_execution_context: &TransactionExecutionContext,
+        tx_execution_context: &mut TransactionExecutionContext,
         support_reverted: bool,
     ) -> Result<CallInfo, TransactionError>
     where
@@ -290,7 +290,7 @@ impl ExecutionEntryPoint {
         state: &mut T,
         resources_manager: &mut ExecutionResourcesManager,
         block_context: &BlockContext,
-        tx_execution_context: &TransactionExecutionContext,
+        tx_execution_context: &mut TransactionExecutionContext,
         contract_class: Box<ContractClass>,
         class_hash: [u8; 32],
     ) -> Result<CallInfo, TransactionError>
@@ -370,6 +370,12 @@ impl ExecutionEntryPoint {
             .resources_manager
             .clone();
 
+        *tx_execution_context = runner
+            .hint_processor
+            .syscall_handler
+            .tx_execution_context
+            .clone();
+
         // Update resources usage (for bouncer).
         resources_manager.cairo_usage += &runner.get_execution_resources()?;
 
@@ -391,7 +397,7 @@ impl ExecutionEntryPoint {
         state: &mut T,
         resources_manager: &mut ExecutionResourcesManager,
         block_context: &BlockContext,
-        tx_execution_context: &TransactionExecutionContext,
+        tx_execution_context: &mut TransactionExecutionContext,
         contract_class: Box<CasmContractClass>,
         class_hash: [u8; 32],
         support_reverted: bool,
@@ -508,6 +514,12 @@ impl ExecutionEntryPoint {
             .hint_processor
             .syscall_handler
             .resources_manager
+            .clone();
+
+        *tx_execution_context = runner
+            .hint_processor
+            .syscall_handler
+            .tx_execution_context
             .clone();
 
         // Update resources usage (for bouncer).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub fn call_contract<T: State + StateReader>(
         initial_gas,
     );
 
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         contract_address,
         transaction_hash,
         signature,
@@ -87,7 +87,7 @@ pub fn call_contract<T: State + StateReader>(
         state,
         &block_context,
         &mut ExecutionResourcesManager::default(),
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     )?;
 

--- a/src/syscalls/business_logic_syscall_handler.rs
+++ b/src/syscalls/business_logic_syscall_handler.rs
@@ -244,7 +244,7 @@ impl<'a, T: State + StateReader> BusinessLogicSyscallHandler<'a, T> {
                 self.starknet_storage_state.state,
                 &self.block_context,
                 &mut self.resources_manager,
-                &self.tx_execution_context,
+                &mut self.tx_execution_context,
                 self.support_reverted,
             )
             .map_err(|err| SyscallHandlerError::ExecutionError(err.to_string()))?;
@@ -345,7 +345,7 @@ impl<'a, T: State + StateReader> BusinessLogicSyscallHandler<'a, T> {
                 self.starknet_storage_state.state,
                 &self.block_context,
                 &mut self.resources_manager,
-                &self.tx_execution_context,
+                &mut self.tx_execution_context,
                 self.support_reverted,
             )
             .map_err(|_| StateError::ExecutionEntryPoint())?;

--- a/src/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -229,7 +229,7 @@ impl<'a, T: State + StateReader> DeprecatedBLSyscallHandler<'a, T> {
                 self.starknet_storage_state.state,
                 &self.block_context,
                 &mut self.resources_manager,
-                &self.tx_execution_context,
+                &mut self.tx_execution_context,
                 false,
             )
             .map_err(|_| StateError::ExecutionEntryPoint())?;
@@ -446,12 +446,14 @@ where
         );
         entry_point.code_address = code_address;
 
+        dbg!(self.tx_execution_context.n_sent_messages);
+
         entry_point
             .execute(
                 self.starknet_storage_state.state,
                 &self.block_context,
                 &mut self.resources_manager,
-                &self.tx_execution_context,
+                &mut self.tx_execution_context,
                 false,
             )
             .map(|x| {

--- a/src/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -446,8 +446,6 @@ where
         );
         entry_point.code_address = code_address;
 
-        dbg!(self.tx_execution_context.n_sent_messages);
-
         entry_point
             .execute(
                 self.starknet_storage_state.state,

--- a/src/testing/state.rs
+++ b/src/testing/state.rs
@@ -147,12 +147,12 @@ impl StarknetState {
 
         let mut resources_manager = ExecutionResourcesManager::default();
 
-        let tx_execution_context = TransactionExecutionContext::default();
+        let mut tx_execution_context = TransactionExecutionContext::default();
         let call_info = call.execute(
             &mut self.state,
             &self.block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )?;
 

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -193,7 +193,7 @@ impl Declare {
             state,
             block_context,
             resources_manager,
-            &self.get_execution_context(block_context.invoke_tx_max_n_steps),
+            &mut self.get_execution_context(block_context.invoke_tx_max_n_steps),
             false,
         )?;
 
@@ -220,9 +220,10 @@ impl Declare {
             block_context,
         )?;
 
-        let tx_execution_context = self.get_execution_context(block_context.invoke_tx_max_n_steps);
+        let mut tx_execution_context =
+            self.get_execution_context(block_context.invoke_tx_max_n_steps);
         let fee_transfer_info =
-            execute_fee_transfer(state, block_context, &tx_execution_context, actual_fee)?;
+            execute_fee_transfer(state, block_context, &mut tx_execution_context, actual_fee)?;
 
         Ok((Some(fee_transfer_info), actual_fee))
     }

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -145,9 +145,10 @@ impl DeclareV2 {
             block_context,
         )?;
 
-        let tx_execution_context = self.get_execution_context(block_context.invoke_tx_max_n_steps);
+        let mut tx_execution_context =
+            self.get_execution_context(block_context.invoke_tx_max_n_steps);
         let fee_transfer_info =
-            execute_fee_transfer(state, block_context, &tx_execution_context, actual_fee)?;
+            execute_fee_transfer(state, block_context, &mut tx_execution_context, actual_fee)?;
 
         Ok((Some(fee_transfer_info), actual_fee))
     }
@@ -259,13 +260,14 @@ impl DeclareV2 {
             call_type: CallType::Call,
         };
 
-        let tx_execution_context = self.get_execution_context(block_context.validate_max_n_steps);
+        let mut tx_execution_context =
+            self.get_execution_context(block_context.validate_max_n_steps);
 
         let call_info = entry_point.execute(
             state,
             block_context,
             resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )?;
 

--- a/src/transaction/deploy.rs
+++ b/src/transaction/deploy.rs
@@ -155,7 +155,7 @@ impl Deploy {
             0,
         );
 
-        let tx_execution_context = TransactionExecutionContext::new(
+        let mut tx_execution_context = TransactionExecutionContext::new(
             Address(Felt252::zero()),
             self.hash_value.clone(),
             Vec::new(),
@@ -170,7 +170,7 @@ impl Deploy {
             state,
             block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )?;
 

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -249,7 +249,7 @@ impl DeployAccount {
             state,
             block_context,
             resources_manager,
-            &self.get_execution_context(block_context.validate_max_n_steps),
+            &mut self.get_execution_context(block_context.validate_max_n_steps),
             false,
         )?;
 
@@ -304,7 +304,7 @@ impl DeployAccount {
             state,
             block_context,
             resources_manager,
-            &self.get_execution_context(block_context.validate_max_n_steps),
+            &mut self.get_execution_context(block_context.validate_max_n_steps),
             false,
         )?;
 
@@ -333,9 +333,10 @@ impl DeployAccount {
             block_context,
         )?;
 
-        let tx_execution_context = self.get_execution_context(block_context.invoke_tx_max_n_steps);
+        let mut tx_execution_context =
+            self.get_execution_context(block_context.invoke_tx_max_n_steps);
         let fee_transfer_info =
-            execute_fee_transfer(state, block_context, &tx_execution_context, actual_fee)?;
+            execute_fee_transfer(state, block_context, &mut tx_execution_context, actual_fee)?;
 
         Ok((Some(fee_transfer_info), actual_fee))
     }

--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -20,7 +20,7 @@ pub type FeeInfo = (Option<CallInfo>, u128);
 pub(crate) fn execute_fee_transfer<S: State + StateReader>(
     state: &mut S,
     block_context: &BlockContext,
-    tx_execution_context: &TransactionExecutionContext,
+    tx_execution_context: &mut TransactionExecutionContext,
     actual_fee: u128,
 ) -> Result<CallInfo, TransactionError> {
     if actual_fee > tx_execution_context.max_fee {

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -141,7 +141,7 @@ impl InvokeFunction {
             state,
             block_context,
             resources_manager,
-            &self.get_execution_context(block_context.validate_max_n_steps)?,
+            &mut self.get_execution_context(block_context.validate_max_n_steps)?,
             false,
         )?;
 
@@ -177,7 +177,7 @@ impl InvokeFunction {
             state,
             block_context,
             resources_manager,
-            &self.get_execution_context(block_context.invoke_tx_max_n_steps)?,
+            &mut self.get_execution_context(block_context.invoke_tx_max_n_steps)?,
             false,
         )
     }
@@ -237,10 +237,10 @@ impl InvokeFunction {
             block_context,
         )?;
 
-        let tx_execution_context =
+        let mut tx_execution_context =
             self.get_execution_context(block_context.invoke_tx_max_n_steps)?;
         let fee_transfer_info =
-            execute_fee_transfer(state, block_context, &tx_execution_context, actual_fee)?;
+            execute_fee_transfer(state, block_context, &mut tx_execution_context, actual_fee)?;
 
         Ok((Some(fee_transfer_info), actual_fee))
     }

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -90,7 +90,7 @@ impl L1Handler {
             state,
             block_context,
             &mut resources_manager,
-            &self.get_execution_context(block_context.invoke_tx_max_n_steps)?,
+            &mut self.get_execution_context(block_context.invoke_tx_max_n_steps)?,
             false,
         )?;
 

--- a/tests/cairo_1_syscalls.rs
+++ b/tests/cairo_1_syscalls.rs
@@ -56,7 +56,7 @@ fn storage_write_read() {
     let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
 
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -99,7 +99,7 @@ fn storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -119,7 +119,7 @@ fn storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -140,7 +140,7 @@ fn storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -160,7 +160,7 @@ fn storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -229,7 +229,7 @@ fn library_call() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -295,7 +295,7 @@ fn library_call() {
                 &mut state,
                 &block_context,
                 &mut resources_manager,
-                &tx_execution_context,
+                &mut tx_execution_context,
                 false,
             )
             .unwrap(),
@@ -358,7 +358,7 @@ fn call_contract_storage_write_read() {
     let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
 
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -405,7 +405,7 @@ fn call_contract_storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -427,7 +427,7 @@ fn call_contract_storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -450,7 +450,7 @@ fn call_contract_storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -472,7 +472,7 @@ fn call_contract_storage_write_read() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -524,7 +524,7 @@ fn emit_event() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -539,7 +539,7 @@ fn emit_event() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -634,7 +634,7 @@ fn deploy_cairo1_from_cairo1() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -649,7 +649,7 @@ fn deploy_cairo1_from_cairo1() {
         &mut state,
         &block_context,
         &mut resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     );
 
@@ -732,7 +732,7 @@ fn deploy_cairo0_from_cairo1_without_constructor() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -747,7 +747,7 @@ fn deploy_cairo0_from_cairo1_without_constructor() {
         &mut state,
         &block_context,
         &mut resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     );
 
@@ -830,7 +830,7 @@ fn deploy_cairo0_from_cairo1_with_constructor() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -845,7 +845,7 @@ fn deploy_cairo0_from_cairo1_with_constructor() {
         &mut state,
         &block_context,
         &mut resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     );
 
@@ -928,7 +928,7 @@ fn deploy_cairo0_and_invoke() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -943,7 +943,7 @@ fn deploy_cairo0_and_invoke() {
         &mut state,
         &block_context,
         &mut resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     );
 
@@ -983,7 +983,7 @@ fn deploy_cairo0_and_invoke() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1048,7 +1048,7 @@ fn test_send_message_to_l1_syscall() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1065,7 +1065,7 @@ fn test_send_message_to_l1_syscall() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1126,7 +1126,7 @@ fn test_get_execution_info() {
     let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
 
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         vec![22.into(), 33.into()],
@@ -1168,7 +1168,7 @@ fn test_get_execution_info() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1258,7 +1258,7 @@ fn replace_class_internal() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1274,7 +1274,7 @@ fn replace_class_internal() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1353,7 +1353,7 @@ fn replace_class_contract_call() {
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1386,7 +1386,7 @@ fn replace_class_contract_call() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1412,7 +1412,7 @@ fn replace_class_contract_call() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1437,7 +1437,7 @@ fn replace_class_contract_call() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1507,7 +1507,7 @@ fn replace_class_contract_call_same_transaction() {
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1540,7 +1540,7 @@ fn replace_class_contract_call_same_transaction() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1617,7 +1617,7 @@ fn call_contract_upgrade_cairo_0_to_cairo_1_same_transaction() {
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1650,7 +1650,7 @@ fn call_contract_upgrade_cairo_0_to_cairo_1_same_transaction() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1725,7 +1725,7 @@ fn call_contract_downgrade_cairo_1_to_cairo_0_same_transaction() {
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1758,7 +1758,7 @@ fn call_contract_downgrade_cairo_1_to_cairo_0_same_transaction() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1833,7 +1833,7 @@ fn call_contract_replace_class_cairo_0() {
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1866,7 +1866,7 @@ fn call_contract_replace_class_cairo_0() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1919,7 +1919,7 @@ fn test_out_of_gas_failure() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1934,7 +1934,7 @@ fn test_out_of_gas_failure() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1990,7 +1990,7 @@ fn deploy_syscall_failure_uninitialized_class_hash() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -2005,7 +2005,7 @@ fn deploy_syscall_failure_uninitialized_class_hash() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -2068,7 +2068,7 @@ fn deploy_syscall_failure_in_constructor() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -2083,7 +2083,7 @@ fn deploy_syscall_failure_in_constructor() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -2125,7 +2125,7 @@ fn storage_read_no_value() {
     let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
 
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -2168,7 +2168,7 @@ fn storage_read_no_value() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -2205,7 +2205,7 @@ fn storage_read_unavailable_address_domain() {
     let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
 
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -2248,7 +2248,7 @@ fn storage_read_unavailable_address_domain() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -2288,7 +2288,7 @@ fn storage_write_unavailable_address_domain() {
     let mut state = CachedState::new(state_reader, None, Some(contract_class_cache));
 
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -2331,7 +2331,7 @@ fn storage_write_unavailable_address_domain() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -2404,7 +2404,7 @@ fn library_call_failure() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -2425,7 +2425,7 @@ fn library_call_failure() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();

--- a/tests/complex_contracts/utils.rs
+++ b/tests/complex_contracts/utils.rs
@@ -107,7 +107,7 @@ pub fn execute_entry_point(
     //* --------------------
     //*   Execute contract
     //* ---------------------
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -121,7 +121,7 @@ pub fn execute_entry_point(
         call_config.state,
         call_config.block_context,
         call_config.resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     )
 }

--- a/tests/delegate_call.rs
+++ b/tests/delegate_call.rs
@@ -102,7 +102,7 @@ fn delegate_call() {
     //*   Execute contract
     //* ---------------------
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -118,7 +118,7 @@ fn delegate_call() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .is_ok());

--- a/tests/delegate_l1_handler.rs
+++ b/tests/delegate_l1_handler.rs
@@ -97,7 +97,7 @@ fn delegate_l1_handler() {
     //*   Execute contract
     //* ---------------------
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -112,7 +112,7 @@ fn delegate_l1_handler() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .is_ok());

--- a/tests/fibonacci.rs
+++ b/tests/fibonacci.rs
@@ -86,7 +86,7 @@ fn integration_test() {
     //*   Execute contract
     //* ---------------------
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -119,7 +119,7 @@ fn integration_test() {
                 &mut state,
                 &block_context,
                 &mut resources_manager,
-                &tx_execution_context,
+                &mut tx_execution_context,
                 false,
             )
             .unwrap(),
@@ -172,7 +172,7 @@ fn integration_test_cairo1() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -208,7 +208,7 @@ fn integration_test_cairo1() {
                 &mut state,
                 &block_context,
                 &mut resources_manager,
-                &tx_execution_context,
+                &mut tx_execution_context,
                 false,
             )
             .unwrap(),

--- a/tests/increase_balance.rs
+++ b/tests/increase_balance.rs
@@ -95,7 +95,7 @@ fn hello_starknet_increase_balance() {
     //*   Execute contract
     //* ---------------------
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -135,7 +135,7 @@ fn hello_starknet_increase_balance() {
                 &mut state,
                 &block_context,
                 &mut resources_manager,
-                &tx_execution_context,
+                &mut tx_execution_context,
                 false,
             )
             .unwrap(),

--- a/tests/internal_calls.rs
+++ b/tests/internal_calls.rs
@@ -22,7 +22,7 @@ fn test_internal_calls() {
             .expect("Could not load contract from JSON");
 
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::create_for_testing(
+    let mut tx_execution_context = TransactionExecutionContext::create_for_testing(
         Address(0.into()),
         10,
         0.into(),
@@ -70,7 +70,7 @@ fn test_internal_calls() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .expect("Could not execute contract");

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -90,7 +90,7 @@ fn integration_storage_test() {
     //*   Execute contract
     //* ---------------------
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -130,7 +130,7 @@ fn integration_storage_test() {
                 &mut state,
                 &block_context,
                 &mut resources_manager,
-                &tx_execution_context,
+                &mut tx_execution_context,
                 false,
             )
             .unwrap(),

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -60,7 +60,7 @@ fn test_contract<'a>(
     let contract_class = ContractClass::try_from(contract_path.as_ref().to_path_buf())
         .expect("Could not load contract from JSON");
 
-    let tx_execution_context = tx_execution_context_option.unwrap_or_else(|| {
+    let mut tx_execution_context = tx_execution_context_option.unwrap_or_else(|| {
         TransactionExecutionContext::create_for_testing(
             Address(0.into()),
             10,
@@ -140,7 +140,7 @@ fn test_contract<'a>(
                 &mut state,
                 &block_context,
                 &mut resources_manager,
-                &tx_execution_context,
+                &mut tx_execution_context,
                 false,
             )
             .expect("Could not execute contract"),
@@ -1112,7 +1112,7 @@ fn deploy_cairo1_from_cairo0_with_constructor() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1127,7 +1127,7 @@ fn deploy_cairo1_from_cairo0_with_constructor() {
         &mut state,
         &block_context,
         &mut resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     );
 
@@ -1210,7 +1210,7 @@ fn deploy_cairo1_from_cairo0_without_constructor() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1226,7 +1226,7 @@ fn deploy_cairo1_from_cairo0_without_constructor() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();
@@ -1310,7 +1310,7 @@ fn deploy_cairo1_and_invoke() {
 
     // Execute the entrypoint
     let block_context = BlockContext::default();
-    let tx_execution_context = TransactionExecutionContext::new(
+    let mut tx_execution_context = TransactionExecutionContext::new(
         Address(0.into()),
         Felt252::zero(),
         Vec::new(),
@@ -1325,7 +1325,7 @@ fn deploy_cairo1_and_invoke() {
         &mut state,
         &block_context,
         &mut resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     );
 
@@ -1363,7 +1363,7 @@ fn deploy_cairo1_and_invoke() {
             &mut state,
             &block_context,
             &mut resources_manager,
-            &tx_execution_context,
+            &mut tx_execution_context,
             false,
         )
         .unwrap();

--- a/tests/syscalls_errors.rs
+++ b/tests/syscalls_errors.rs
@@ -42,7 +42,7 @@ fn test_contract<'a>(
     let contract_class = ContractClass::try_from(contract_path.as_ref().to_path_buf())
         .expect("Could not load contract from JSON");
 
-    let tx_execution_context = tx_execution_context_option.unwrap_or_else(|| {
+    let mut tx_execution_context = tx_execution_context_option.unwrap_or_else(|| {
         TransactionExecutionContext::create_for_testing(
             Address(0.into()),
             10,
@@ -120,7 +120,7 @@ fn test_contract<'a>(
         &mut state,
         &block_context,
         &mut resources_manager,
-        &tx_execution_context,
+        &mut tx_execution_context,
         false,
     );
 


### PR DESCRIPTION
As the `TransactionExecutionContext` was not updated between executions, inner calls (such as contracts called through the `call_contract` syscall) would modify their execution context, but this change would have no effect on the caller's execution context.
This bug caused bugs to a appear such as the one reported #604 
What happened here is that two different contract calls sent messages to l1, but as the transaction_execution_context.n_messages update was lost between executions, they both had the same order number (0), leading to the `UnexpectedHolesL2toL1Messages` error

A test for this specific case will be added following #663 

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
