### PR TITLE
Add integration test executing Tx with RabbitX contract

### DIFF
--- a/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/helpers/bool_cmp.cairo
+++ b/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/helpers/bool_cmp.cairo
@@ -1,0 +1,43 @@
+namespace BoolCmp {
+    func is_valid(a: felt) {
+        with_attr error_message("Value should be either 0 or 1. Current value: {a}") {
+            assert a * a = a;
+        }
+        return ();
+    }
+
+    func eq(a: felt, b: felt) -> (res: felt) {
+        if (a == b) {
+            return (res=1);
+        } else {
+            return (res=0);
+        }
+    }
+
+    func either(x: felt, y: felt) -> (res: felt) {
+        assert x * x = x;
+        assert y * y = y;
+        let (res) = eq((x - 1) * (y - 1), 0);
+        return (res=res);
+    }
+
+    func both(x: felt, y: felt) -> (res: felt) {
+        assert x * x = x;
+        assert y * y = y;
+        let (res) = eq((x + y), 2);
+        return (res=res);
+    }
+
+    func neither(x: felt, y: felt) -> (res: felt) {
+        assert x * x = x;
+        assert y * y = y;
+        let (res) = eq((x + y), 0);
+        return (res=res);
+    }
+
+    func not(x: felt) -> (res: felt) {
+        assert x * x = x;
+        let res = (1 - x);
+        return (res=res);
+    }
+}

--- a/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/helpers/constants.cairo
+++ b/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/helpers/constants.cairo
@@ -1,0 +1,34 @@
+from starkware.cairo.common.uint256 import Uint256
+from blockifier.rabbitx.contracts.protocol.libraries.types.data_types import DataTypes
+
+const UINT128_MAX = 2 ** 128 - 1;
+const INITIALIZE_SELECTOR = 215307247182100370520050591091822763712463273430149262739280891880522753123;
+
+// P - the prime number defined in Cairo documentation. Every artithmetic operation is done with mod P.
+// NOTE: This number shouldn't change for StartkNet, but if you are using Cairo with other P, please adjust this number to your needs.
+const CAIRO_FIELD_ORDER = 2 ** 251 + 17 * 2 ** 192 + 1;  // 3618502788666131213697322783095070105623107215331596699973092056135872020481 == 0
+
+// MAX_UNSIGNED_FELT
+const MAX_UNSIGNED_FELT = CAIRO_FIELD_ORDER - 1;
+
+// MAX_SIGNED_FELT
+const MAX_SIGNED_FELT = (CAIRO_FIELD_ORDER - 1) / 2;
+
+// MIN_SIGNED_FELT - the lowest number possible in Cairo if felts are interpreted as signed integers.
+// (Recall : floor(P/2) = (P-1)/2)
+// (P-1/2) is done to be able to express floor(P/2) (no floor function in Cairo)
+// +1 is added, because (P-1/2): highest signed integer and (P-1/2)+1: lowest signed integer
+const MIN_SIGNED_FELT = MAX_SIGNED_FELT + 1;  // as signed: -1809251394333065606848661391547535052811553607665798349986546028067936010240 or as unsigned: 1809251394333065606848661391547535052811553607665798349986546028067936010241
+
+func empty_reserve_configuration() -> (res: DataTypes.ReserveConfiguration) {
+    return (DataTypes.ReserveConfiguration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),);
+}
+
+func empty_reserve_data() -> (res: DataTypes.ReserveData) {
+    let (empty_config) = empty_reserve_configuration();
+    return (DataTypes.ReserveData(empty_config, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),);
+}
+
+func uint256_max() -> (max: Uint256) {
+    return (Uint256(UINT128_MAX, UINT128_MAX),);
+}

--- a/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/math/safe_cmp.cairo
+++ b/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/math/safe_cmp.cairo
@@ -1,0 +1,186 @@
+from starkware.cairo.common.math_cmp import is_le_felt
+from starkware.cairo.common.math import assert_le_felt, assert_lt_felt
+from starkware.cairo.common.bool import FALSE, TRUE
+from blockifier.rabbitx.contracts.protocol.libraries.helpers.bool_cmp import BoolCmp
+from blockifier.rabbitx.contracts.protocol.libraries.helpers.constants import (
+    MAX_SIGNED_FELT,
+    MIN_SIGNED_FELT,
+)
+
+// @notice Function checks if the a < b. Interprets a, b in range [0, P)
+// @dev Internal function meant to only be used by functions of SafeCmp library
+// @param a Unsigned felt integer
+// @param b Unsigned felt integer
+// @returns res Bool felt indicating if a < b
+func _is_lt_felt{range_check_ptr}(a: felt, b: felt) -> (res: felt) {
+    if (a == b) {
+        return (FALSE,);
+    }
+    return (is_le_felt(a, b),);
+}
+
+// @notice Library to safely compare felts interpreted as unsigned or signed integers.
+//
+//         Motivation:
+//         Cairo felts represent signed or unsigned integers.
+//         To compare unsigned integers developers can use: is_le_felt, assert_le_felt from math_cmp and math library
+//         However, currently there is no safe way to compare felts interpreted as signed integers.
+//         Developer when working with signed integers tend to use functions: is_le, assert_le, is_nn, assert_nn.
+//         This is not safe, because those functions work in range [0, 2**128) and should only be used with context of Uint256 type (with low and high members)
+//         Functions provided in this library allow for safe work with felts interpreted as signed and unsigned integers, outside of Uint256 context.
+//
+// @author Nethermind
+namespace SafeCmp {
+    //
+    //
+    // UNSIGNED FELTS
+    //
+    //
+
+    // @notice Checks if the a <= b. Interprets a, b in range [0, P)
+    // @param a Unsigned felt integer
+    // @param b Unsigned felt integer
+    // @returns res Bool felt indicating if a <= b
+    func is_le_unsigned{range_check_ptr}(a: felt, b: felt) -> (res: felt) {
+        return (is_le_felt(a, b),);
+    }
+
+    // @notice Checks if the a < b. Interprets a, b in range [0, P)
+    // @param a Unsigned felt integer
+    // @param b Unsigned felt integer
+    // @returns res Bool felt indicating if a < b
+    func is_lt_unsigned{range_check_ptr}(a: felt, b: felt) -> (res: felt) {
+        return _is_lt_felt(a, b);
+    }
+
+    // @notice Checks if the vale is in range [low, high). Interprets value, low, high in range [0, P)
+    // @param value Unsigned felt integer, checked if is in range
+    // @param low Unsigned felt integer, lower bound of the range
+    // @param high Unsigned felt integer, upper bound of the range
+    // @returns res Bool felt indicating if low <= value < high
+    func is_in_range_unsigned{range_check_ptr}(value: felt, low: felt, high: felt) -> (res: felt) {
+        alloc_locals;
+        with_attr error_message("Range definition error: low >= high") {
+            let (check) = _is_lt_felt(low, high);
+            assert check = TRUE;
+        }
+        let ok_low = is_le_felt(low, value);
+        let (ok_high) = _is_lt_felt(value, high);
+        let (res) = BoolCmp.both(ok_low, ok_high);
+        return (res,);
+    }
+
+    // @notice Asserts that a <= b. Interprets a, b in range [0, P)
+    // @param a Unsigned felt integer
+    // @param b Unsigned felt integer
+    func assert_le_unsigned{range_check_ptr}(a: felt, b: felt) {
+        assert_le_felt(a, b);
+        return ();
+    }
+
+    // @notice Asserts that a < b. Interprets a, b in range [0, P)
+    // @param a Unsigned felt integer
+    // @param b Unsigned felt integer
+    func assert_lt_unsigned{range_check_ptr}(a: felt, b: felt) {
+        assert_lt_felt(a, b);
+        return ();
+    }
+
+    // @notice Asserts that the value is in range [low, high). Interprets value, low, high in range [0, P)
+    // @param value Unsigned felt integer, checked if is in range
+    // @param low Unsigned felt integer, lower bound of the range
+    // @param high Unsigned felt integer, upper bound of the range
+    func assert_in_range_unsigned{range_check_ptr}(value: felt, low: felt, high: felt) {
+        alloc_locals;
+        with_attr error_message("Range definition error: low >= high") {
+            let (check) = _is_lt_felt(low, high);
+            assert check = TRUE;
+        }
+        let ok_low = is_le_felt(low, value);
+        let (ok_high) = _is_lt_felt(value, high);
+        assert ok_low * ok_high = TRUE;
+        return ();
+    }
+
+    //
+    //
+    // SIGNED FELTS
+    //
+    //
+
+    // @notice Checks if the value is non-negative integer, i.e. 0 <= value < floor(P/2) + 1. Interprets a in range [floor(-P/2), floor(P/2)]
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1]
+    // @param a Signed felt integer
+    // @returns res Bool felt indicating if 0 <= value < floor(P/2) + 1 (Recall : floor(P/2) = (P-1)/2)
+    func is_nn_signed{range_check_ptr}(value: felt) -> (res: felt) {
+        return _is_lt_felt(value, MIN_SIGNED_FELT);
+    }
+
+    // @notice Checks if the a <= b. Interprets a, b in range [floor(-P/2), floor(P/2)] (Recall : floor(P/2) = (P-1)/2)
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1], and non-negative [0(P), floor(P/2)]
+    // @param a Signed felt integer
+    // @param b Signed felt integer
+    // @returns res Bool felt indicating if a <= b
+    func is_le_signed{range_check_ptr}(a: felt, b: felt) -> (res: felt) {
+        return (is_le_felt(a + MAX_SIGNED_FELT, b + MAX_SIGNED_FELT),);
+    }
+
+    // @notice Checks if the a < b. Interprets a, b in range [floor(-P/2), floor(P/2)]
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1], and non-negative [P, floor(P/2)]
+    // @param a Signed felt integer
+    // @param b Signed felt integer
+    // @returns res Bool felt indicating if a < b
+    func is_lt_signed{range_check_ptr}(a: felt, b: felt) -> (res: felt) {
+        return _is_lt_felt(a + MAX_SIGNED_FELT, b + MAX_SIGNED_FELT);
+    }
+
+    // @notice Checks if the [low, high). Interprets value, low, high in range [floor(-P/2), floor(P/2)]
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1], and non-negative [P, floor(P/2)]
+    // @param value Signed felt integer, checked if is in range
+    // @param low Signed felt integer, lower bound of the range
+    // @param high Signed felt integer, upper bound of the range
+    // @returns res Bool felt indicating if value is in [low, high) range
+    func is_in_range_signed{range_check_ptr}(value: felt, low: felt, high: felt) -> (res: felt) {
+        return is_in_range_unsigned(
+            value + MAX_SIGNED_FELT, low + MAX_SIGNED_FELT, high + MAX_SIGNED_FELT
+        );
+    }
+
+    // @notice Asserts that a is non-negative integer, i.e. 0 <= a < floor(P/2) + 1. Interprets a in range [floor(-P/2), floor(P/2)]
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1]
+    // @param a Signed felt integer
+    func assert_nn_signed{range_check_ptr}(value: felt) {
+        assert_lt_felt(value, MIN_SIGNED_FELT);
+        return ();
+    }
+
+    // @notice Asserts that a <= b. Interprets a, b in range [floor(-P/2), floor(P/2)]
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1], and non-negative [P, floor(P/2)]
+    // @param a Signed felt integer
+    // @param b Signed felt integer
+    func assert_le_signed{range_check_ptr}(a: felt, b: felt) {
+        assert_le_felt(a + MAX_SIGNED_FELT, b + MAX_SIGNED_FELT);
+        return ();
+    }
+
+    // @notice Asserts that a < b. Interprets a, b in range [floor(-P/2), floor(P/2)]
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1], and non-negative [P, floor(P/2)]
+    // @param a Signed felt integer
+    // @param b Signed felt integer
+    func assert_lt_signed{range_check_ptr}(a: felt, b: felt) {
+        assert_lt_felt(a + MAX_SIGNED_FELT, b + MAX_SIGNED_FELT);
+        return ();
+    }
+
+    // @notice Asserts that the value is in [low, high). Interprets value, low, high in range [floor(-P/2), floor(P/2)]
+    // @dev Note that floor(-P/2) is equal to floor(P/2) + 1. If felt is signed, then negative numbers are [floor(P/2)+1, P-1], and non-negative [P, floor(P/2)]
+    // @param value Signed felt integer, checked if is in range
+    // @param low Signed felt integer, lower bound of the range
+    // @param high Signed felt integer, upper bound of the range
+    func assert_in_range_signed{range_check_ptr}(value: felt, low: felt, high: felt) {
+        assert_in_range_unsigned(
+            value + MAX_SIGNED_FELT, low + MAX_SIGNED_FELT, high + MAX_SIGNED_FELT
+        );
+        return ();
+    }
+}

--- a/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/types/data_types.cairo
+++ b/starknet_programs/blockifier/rabbitx/contracts/protocol/libraries/types/data_types.cairo
@@ -1,0 +1,105 @@
+from starkware.cairo.common.uint256 import Uint256
+
+namespace DataTypes {
+    struct ReserveConfiguration {
+        ltv: felt,
+        liquidation_threshold: felt,
+        liquidation_bonus: felt,
+        decimals: felt,
+        reserve_active: felt,
+        reserve_frozen: felt,
+        borrowing_enabled: felt,
+        stable_rate_borrowing_enabled: felt,
+        asset_paused: felt,
+        borrowable_in_isolation: felt,
+        siloed_borrowing: felt,
+        reserve_factor: felt,
+        borrow_cap: felt,
+        supply_cap: felt,
+        liquidation_protocol_fee: felt,
+        eMode_category: felt,
+        unbacked_mint_cap: felt,
+        debt_ceiling: felt,
+    }
+
+    struct ReserveData {
+        configuration: ReserveConfiguration,
+        liquidity_index: felt,
+        current_liquidity_rate: felt,
+        variable_borrow_index: felt,
+        current_variable_borrow_rate: felt,
+        current_stable_borrow_rate: felt,
+        last_update_timestamp: felt,
+        id: felt,
+        a_token_address: felt,
+        stable_debt_token_address: felt,
+        variable_debt_token_address: felt,
+        interest_rate_strategy_address: felt,
+        accrued_to_treasury: felt,
+        unbacked: felt,
+        isolation_mode_total_debt: felt,
+    }
+
+    struct ReserveCache {
+        curr_scaled_variable_debt: felt,
+        next_scaled_variable_debt: felt,
+        curr_principal_stable_debt: felt,
+        curr_avg_stable_borrow_rate: felt,
+        curr_total_stable_debt: felt,
+        next_avg_stable_borrow_rate: felt,
+        next_total_stable_debt: felt,
+        curr_liquidity_index: felt,
+        next_liquidity_index: felt,
+        curr_variable_borrow_index: felt,
+        next_variable_borrow_index: felt,
+        curr_liquidity_rate: felt,
+        curr_variable_borrow_rate: felt,
+        reserve_factor: felt,
+        a_token_address: felt,
+        stable_debt_token_address: felt,
+        variable_debt_token_address: felt,
+        reserve_last_update_timestamp: felt,
+        stable_debt_last_update_timestamp: felt,
+        configuration: ReserveConfiguration,
+    }
+
+    struct InitReserveParams {
+        asset: felt,
+        a_token_address: felt,
+        stable_debt_token_address: felt,
+        variable_debt_token_address: felt,
+        interest_rate_strategy_address: felt,
+        reserves_count: felt,
+        max_number_reserves: felt,
+    }
+
+    struct UserConfigurationMap {
+        borrowing: felt,
+        using_as_collateral: felt,
+    }
+
+    struct ExecuteSupplyParams {
+        asset: felt,
+        amount: Uint256,
+        on_behalf_of: felt,
+        referral_code: felt,
+    }
+
+    struct ExecuteWithdrawParams {
+        asset: felt,
+        amount: Uint256,
+        to: felt,
+        reserves_count: felt,
+        // TODO add the rest of the fields
+        // member oracle  : felt
+        // member user_eMode_category  : felt
+    }
+
+    // @dev UserState - additionalData is a flexible field.
+    // ATokens and VariableDebtTokens use this field store the index of the user's last supply/withdrawal/borrow/repayment.
+    // StableDebtTokens use this field to store the user's stable rate.
+    struct UserState {
+        balance: felt,
+        additional_data: felt,
+    }
+}

--- a/starknet_programs/rabbit.cairo
+++ b/starknet_programs/rabbit.cairo
@@ -1,0 +1,726 @@
+%lang starknet
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_not, bitwise_or
+from starkware.cairo.common.bool import FALSE, TRUE
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
+from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
+from starkware.cairo.common.dict import dict_read, dict_write
+from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.math import unsigned_div_rem
+from starkware.cairo.common.math_cmp import is_le_felt
+from starkware.starknet.common.messages import send_message_to_l1
+from starkware.starknet.common.syscalls import emit_event, get_caller_address
+from blockifier.rabbitx.contracts.protocol.libraries.math.safe_cmp import SafeCmp
+
+const MESSAGE_WITHDRAW_RECEIVED = 0x1010101010101010;
+const MESSAGE_DEPOSIT_RECEIVED = 1;
+const WITHDRAWAL_LIMIT = 984652000000;
+const NOT_FOUND_INDEX = 12345678987654321;
+const WITHDRAWALS_IN_FELT = 251;
+
+@storage_var
+func admin() -> (admin_address: felt) {
+}
+
+@view
+func get_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (admin: felt) {
+    let (res) = admin.read();
+    return (admin=res);
+}
+
+@storage_var
+func settler() -> (settler_address: felt) {
+}
+
+@view
+func get_settler{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    settler: felt
+) {
+    let (res) = settler.read();
+    return (settler=res);
+}
+
+@storage_var
+func rabbit_l1() -> (rabbit_l1_address: felt) {
+}
+
+@view
+func get_rabbit_l1{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    rabbit_l1: felt
+) {
+    let (res) = rabbit_l1.read();
+    return (rabbit_l1=res);
+}
+
+// A mapping from a trader id to their total deposited funds to date.
+@storage_var
+func total_deposited(trader: felt) -> (res: felt) {
+}
+
+@view
+func get_total_deposited{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    trader: felt
+) -> (total_deposited: felt) {
+    let (res) = total_deposited.read(trader=trader);
+    return (total_deposited=res);
+}
+
+// A mapping from a trader id to their total withdrawn funds to date.
+@storage_var
+func total_withdrawn(trader: felt) -> (res: felt) {
+}
+
+@view
+func get_total_withdrawn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    trader: felt
+) -> (total_withdrawn: felt) {
+    let (res) = total_withdrawn.read(trader=trader);
+    return (total_withdrawn=res);
+}
+
+struct Deposit {
+    trader: felt,
+    amount: felt,
+}
+
+struct Withdrawal {
+    id: felt,
+    trader: felt,
+    amount: felt,
+}
+
+@storage_var
+func deactivated() -> (is_deactivated: felt) {
+}
+
+@view
+func get_deactivated{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    is_deactivated: felt
+) {
+    let (res) = deactivated.read();
+    return (is_deactivated=res);
+}
+
+// A record of the ids of withdrawals that have been sent to L1. To save on L1 storage
+// costs there are WITHDRAWALS_IN_FELT values packed into each felt. Each value is 1 or 0,
+// 1 if the corresponding withdrawal has been sent, 0 if it hasn't.
+
+@storage_var
+func processed_withdrawals(withdrawal_id: felt) -> (processed: felt) {
+}
+
+@storage_var
+func num_pending_deposits() -> (num_pending: felt) {
+}
+
+@view
+func get_num_pending_deposits{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    ) -> (num_pending: felt) {
+    let (res) = num_pending_deposits.read();
+    return (num_pending=res);
+}
+
+@storage_var
+func first_pending_deposit() -> (first_pending: felt) {
+}
+
+@view
+func get_first_pending_deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    ) -> (first_pending: felt) {
+    let (res) = first_pending_deposit.read();
+    return (first_pending=res);
+}
+
+// list of pending deposits
+//
+// entries are added by the deposit_handler @l1_handler
+// function when a deposit notification is received
+//
+// entries are removed when acknowledgement of their receipt is
+// made by a call to the acknowledge_deposits function
+//
+
+@storage_var
+func pending_deposits(index: felt) -> (deposit_id: felt) {
+}
+
+// list of all deposits, both pending and processed
+//
+// entries are added by the deposit_handler @l1_handler
+// function when a deposit notification is received
+// entries are never removed or changed
+
+@storage_var
+func all_deposits(deposit_id: felt) -> (deposit: Deposit) {
+}
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    admin_address: felt, settler_address: felt, rabbit_l1_address: felt
+) {
+    admin.write(admin_address);
+    settler.write(settler_address);
+    rabbit_l1.write(rabbit_l1_address);
+    return ();
+}
+
+func only_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (admin_address) = admin.read();
+    let (caller_address) = get_caller_address();
+    with_attr error_message("Only admin") {
+        assert admin_address = caller_address;
+    }
+    return ();
+}
+
+func only_settler{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (settler_address) = settler.read();
+    let (caller_address) = get_caller_address();
+    with_attr error_message("Only settler") {
+        assert settler_address = caller_address;
+    }
+    return ();
+}
+
+func only_active{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (contract_deactivated) = deactivated.read();
+    with_attr error_message("Deactivated") {
+        assert contract_deactivated = 0;
+    }
+    return ();
+}
+
+@external
+func deactivate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    only_admin();
+    deactivated.write(1);
+    return ();
+}
+
+@l1_handler
+func deposit_handler{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_address: felt, id: felt, trader: felt, amount: felt
+) {
+    // Make sure the message was sent by the rabbit L1 contract.
+    let (l1_contract) = rabbit_l1.read();
+    assert from_address = l1_contract;
+    // implementation in separate function so we can call it from a unit test since
+    // @l1_handler can only be called by StarkNet when a message is received from L1
+    deposit(id=id, trader=trader, amount=amount);
+    return ();
+}
+
+func deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    id: felt, trader: felt, amount: felt
+) {
+    alloc_locals;
+    only_active();
+    SafeCmp.assert_nn_signed(amount);
+    tempvar pd: Deposit* = new Deposit(trader=trader, amount=amount);
+    let (local first_p) = first_pending_deposit.read();
+    let (local num_p) = num_pending_deposits.read();
+    pending_deposits.write(first_p + num_p, id);
+    all_deposits.write(id, [pd]);
+    num_pending_deposits.write(num_p + 1);
+    return ();
+}
+
+@external
+func process_pending_deposits{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+    only_active();
+    only_settler();
+    let (local first_p) = first_pending_deposit.read();
+    let (local num_p) = num_pending_deposits.read();
+    return do_process_pending_deposits(next_pending=first_p, stop_pending=first_p + num_p);
+}
+
+func do_process_pending_deposits{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    next_pending: felt, stop_pending: felt
+) {
+    alloc_locals;
+    if (next_pending == stop_pending) {
+        return ();
+    }
+    let (local id) = pending_deposits.read(next_pending);
+    let (local pd) = all_deposits.read(id);
+    let (keys: felt*) = alloc();
+    assert keys[0] = 'deposit';
+    assert keys[1] = id;
+    assert keys[2] = pd.trader;
+    let (data: felt*) = alloc();
+    assert data[0] = pd.amount;
+    emit_event(3, keys, 1, data);
+
+    return do_process_pending_deposits(next_pending + 1, stop_pending);
+}
+
+// records where in the pending_deposits a particular deposit_id is
+// and whether or not it has been seen and processed
+struct DepositInfo {
+    pending_index: felt,
+    processed: felt,
+}
+
+@external
+func acknowledge_deposits{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    ack_len: felt, ack: felt*
+) {
+    alloc_locals;
+    only_active();
+    only_settler();
+    let (local first_p) = first_pending_deposit.read();
+    let (local num_p) = num_pending_deposits.read();
+
+    // index_dict is a mapping from deposit_id to a DepositInfo struct which records the index
+    // of that deposit_id in the pending_deposits and whether or not the deposit has been processed.
+    // We use it to efficiently find the pending deposit corresponding to each deposit_id in the
+    // list of deposit ids being acknowledged, and also to track which deposit_ids we have seen.
+    //
+    // The dict has a default value of a struct with a pending_index of INDEX_NOT_FOUND. If this
+    // default value is returned for a key of deposit_id then it is not the id of any pending deposit
+    // in the dict.
+    //
+    // Populating the index_dict means scanning the pending
+    // deposits, which is O(n) where n is the number of pending deposits. Without the dict we would
+    // have to scan the pending deposits to find each acknowledged deposit_id. That would be O(n*m)
+    // where m is the number of deposit ids being acknowledged. Typically m will be equal, or close,
+    // to n, making that approach O(n^2).
+
+    local deposit_not_found: DepositInfo* = new DepositInfo(
+        pending_index=NOT_FOUND_INDEX, processed=0
+    );
+    let cast_not_found = cast(deposit_not_found, felt);
+    let (local dict) = default_dict_new(default_value=cast_not_found);
+    let (dict_start, dict_end) = populate_index_dict(
+        num_left=num_p, pending_index=first_p, dict_start=dict, dict_end=dict
+    );
+
+    let (dict_start, dict_end) = do_acknowledge_deposits(
+        num_left=ack_len,
+        first=ack,
+        first_pending=first_p,
+        num_pending=num_p,
+        dict_start=dict_start,
+        dict_end=dict_end,
+    );
+    let (dict_start, dict_end) = pack_pending(dict_start, dict_end);
+    default_dict_finalize(dict_start, dict_end, cast_not_found);
+    return ();
+}
+
+// go through all the pending deposits recursively and add a dict entry for each one
+
+func populate_index_dict{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    num_left: felt, pending_index: felt, dict_start: DictAccess*, dict_end: DictAccess*
+) -> (dict_start: DictAccess*, dict_end: DictAccess*) {
+    alloc_locals;
+    if (num_left == 0) {
+        return (dict_start, dict_end);
+    }
+    let (local deposit_id) = pending_deposits.read(pending_index);
+    local deposit_info: DepositInfo* = new DepositInfo(pending_index=pending_index, processed=0);
+    let felt_info = cast(deposit_info, felt);
+    dict_write{dict_ptr=dict_end}(deposit_id, felt_info);
+    return populate_index_dict(num_left - 1, pending_index + 1, dict_start, dict_end);
+}
+
+func do_acknowledge_deposits{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    num_left: felt,
+    first: felt*,
+    first_pending: felt,
+    num_pending: felt,
+    dict_start: DictAccess*,
+    dict_end: DictAccess*,
+) -> (dict_start: DictAccess*, dict_end: DictAccess*) {
+    alloc_locals;
+    if (num_left == 0) {
+        return (dict_start, dict_end);
+    }
+
+    local deposit_id = [first];
+    let (dict_info) = dict_read{dict_ptr=dict_end}(deposit_id);
+    let deposit_info = cast(dict_info, DepositInfo*);
+    local pending_index = deposit_info.pending_index;
+
+    if (pending_index != NOT_FOUND_INDEX) {
+        // record this pending_deposit as having been processed
+        local updated_deposit_info: DepositInfo* = new DepositInfo(
+            pending_index=pending_index, processed=1
+        );
+        let felt_info = cast(updated_deposit_info, felt);
+        dict_write{dict_ptr=dict_end}(deposit_id, felt_info);
+
+        // update total_deposited
+        let (local d) = all_deposits.read(deposit_id);
+        let (local prev_total_deposited) = total_deposited.read(d.trader);
+        tempvar new_total_deposited = prev_total_deposited + d.amount;
+        total_deposited.write(d.trader, new_total_deposited);
+
+        tempvar dict_end = dict_end;
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    } else {
+        tempvar dict_end = dict_end;
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    }
+
+    return do_acknowledge_deposits(
+        num_left - 1, first + 1, first_pending, num_pending, dict_start, dict_end
+    );
+}
+
+func pack_pending{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    dict_start: DictAccess*, dict_end: DictAccess*
+) -> (dict_start: DictAccess*, dict_end: DictAccess*) {
+    alloc_locals;
+    let (local first_p) = first_pending_deposit.read();
+    let (local num_p) = num_pending_deposits.read();
+    let (zero_slots: felt*) = alloc();
+    let (non_zeros: felt*) = alloc();
+    let (
+        local num_zero_slots, local num_non_zeros, local dict_start, local dict_end
+    ) = scan_pending(first_p, first_p + num_p, 0, zero_slots, 0, non_zeros, dict_start, dict_end);
+    num_pending_deposits.write(num_non_zeros);
+    if (num_non_zeros == 0) {
+        first_pending_deposit.write(0);
+    } else {
+        let first_non_zero = non_zeros[0];
+        first_pending_deposit.write(first_non_zero);
+        if (num_zero_slots != 0) {
+            // some but not all pending deposits have been acknowledged, rearrange
+            // the pending_deposits so all the unacknowledged ones are at the start
+            rewrite_pending(
+                num_zero_slots=num_zero_slots,
+                next_zero_slot=0,
+                zero_slots=zero_slots,
+                num_non_zeros=num_non_zeros,
+                next_non_zero=num_non_zeros - 1,
+                non_zeros=non_zeros,
+            );
+        }
+    }
+    return (dict_start, dict_end);
+}
+
+func scan_pending{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    next_pending: felt,
+    stop_pending: felt,
+    next_zero_slot: felt,
+    zero_slots: felt*,
+    next_non_zero: felt,
+    non_zeros: felt*,
+    dict_start: DictAccess*,
+    dict_end: DictAccess*,
+) -> (num_zero_slots: felt, num_non_zeros: felt, dict_start: DictAccess*, dict_end: DictAccess*) {
+    alloc_locals;
+    if (next_pending == stop_pending) {
+        return (
+            num_zero_slots=next_zero_slot,
+            num_non_zeros=next_non_zero,
+            dict_start=dict_start,
+            dict_end=dict_end,
+        );
+    }
+    let (deposit_id) = pending_deposits.read(next_pending);
+    let (dict_entry) = dict_read{dict_ptr=dict_end}(deposit_id);
+    let deposit_info = cast(dict_entry, DepositInfo*);
+    let processed = deposit_info.processed;
+    if (processed == 1) {
+        // this pending index is marked as already seen
+        assert zero_slots[next_zero_slot] = next_pending;
+        return scan_pending(
+            next_pending + 1,
+            stop_pending,
+            next_zero_slot + 1,
+            zero_slots,
+            next_non_zero,
+            non_zeros,
+            dict_start,
+            dict_end,
+        );
+    } else {
+        // this pending slot is not marked, so is still to be processed
+        assert non_zeros[next_non_zero] = next_pending;
+        return scan_pending(
+            next_pending + 1,
+            stop_pending,
+            next_zero_slot,
+            zero_slots,
+            next_non_zero + 1,
+            non_zeros,
+            dict_start,
+            dict_end,
+        );
+    }
+}
+
+func rewrite_pending{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    num_zero_slots: felt,
+    next_zero_slot: felt,
+    zero_slots: felt*,
+    num_non_zeros: felt,
+    next_non_zero: felt,
+    non_zeros: felt*,
+) {
+    alloc_locals;
+    // if we've already looked at all the zero slots then we are finsished
+    if (next_zero_slot == num_zero_slots) {
+        return ();
+    }
+    local next_zero = zero_slots[next_zero_slot];
+    local first_non_zero = non_zeros[0];
+    let (zero_slot_comes_after_first_non_zero) = SafeCmp.is_lt_unsigned(first_non_zero, next_zero);
+    if (zero_slot_comes_after_first_non_zero == TRUE) {
+        local last_non_zero = non_zeros[next_non_zero];
+        let (zero_slot_comes_before_last_non_zero) = SafeCmp.is_lt_unsigned(
+            next_zero, last_non_zero
+        );
+        if (zero_slot_comes_before_last_non_zero == TRUE) {
+            let (local last_unacknowledged_deposit_id) = pending_deposits.read(last_non_zero);
+            pending_deposits.write(next_zero, last_unacknowledged_deposit_id);
+            let (local any_non_zeros_left) = SafeCmp.is_lt_unsigned(1, next_non_zero);
+            if (any_non_zeros_left == TRUE) {
+                return rewrite_pending(
+                    num_zero_slots,
+                    next_zero_slot + 1,
+                    zero_slots,
+                    num_non_zeros,
+                    next_non_zero - 1,
+                    non_zeros,
+                );
+            }
+            tempvar syscall_ptr = syscall_ptr;
+            tempvar pedersen_ptr = pedersen_ptr;
+            tempvar range_check_ptr = range_check_ptr;
+        } else {
+            tempvar syscall_ptr = syscall_ptr;
+            tempvar pedersen_ptr = pedersen_ptr;
+            tempvar range_check_ptr = range_check_ptr;
+        }
+    } else {
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    }
+    return ();
+}
+
+@external
+func withdraw{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(withdrawals_len: felt, withdrawals: Withdrawal*) {
+    alloc_locals;
+    only_settler();
+    only_active();
+
+    // Use dict to hold mapping from trader to total withdrawn. The dict is populated and finalized
+    // by sum_withdrawals and then used by populate_payload which iterates over it to generate one
+    // trader/amount payload entry for each trader who requested any withdrawals, where the amount is
+    // the sum of all the withdrawal requests for that trader.
+
+    let (local dict) = default_dict_new(default_value=0);
+    let (local total_amount, local squashed_start, local squashed_end) = sum_withdrawals(
+        withdrawals_len=withdrawals_len,
+        withdrawals=withdrawals,
+        partial_sum=0,
+        dict_start=dict,
+        dict_end=dict,
+    );
+    if (squashed_start != squashed_end) {
+        let (small_enough) = SafeCmp.is_le_signed(total_amount, WITHDRAWAL_LIMIT);
+        if (small_enough == FALSE) {
+            deactivate();
+            return ();
+        }
+        do_withdraw(dict_start=squashed_start, dict_end=squashed_end);
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    } else {
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    }
+    return ();
+}
+
+func sum_withdrawals{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(
+    withdrawals_len: felt,
+    withdrawals: Withdrawal*,
+    partial_sum: felt,
+    dict_start: DictAccess*,
+    dict_end: DictAccess*,
+) -> (sum: felt, squashed_start: DictAccess*, squashed_end: DictAccess*) {
+    if (withdrawals_len == 0) {
+        let (squashed_start, squashed_end) = default_dict_finalize(dict_start, dict_end, 0);
+        return (sum=partial_sum, squashed_start=squashed_start, squashed_end=squashed_end);
+    }
+    alloc_locals;
+    local id = withdrawals[0].id;
+    local trader = withdrawals[0].trader;
+    local amount = withdrawals[0].amount;
+    let (local already_sent) = get_withdrawal_sent_to_L1(withdrawals[0].id);
+    // Make sure amount is positive.
+    SafeCmp.assert_nn_signed(amount);
+    let (keys: felt*) = alloc();
+    assert keys[0] = 'withdraw';
+    assert keys[1] = id;
+    assert keys[2] = trader;
+    let (data: felt*) = alloc();
+    assert data[0] = amount;
+    assert data[1] = already_sent;
+    emit_event(3, keys, 2, data);
+    if (already_sent == FALSE) {
+        // add this withdrawal to the dictionary, first get the current value as
+        // this might not be the first withdrawal for the trader in this batch
+        let (old_trader_withdrawal) = dict_read{dict_ptr=dict_end}(key=trader);
+
+        // then write the new total to the dictionary
+        dict_write{dict_ptr=dict_end}(trader, old_trader_withdrawal + amount);
+        // record the withdrawal so it can't be sent again
+        set_withdrawal_sent_to_L1(id);
+
+        return sum_withdrawals(
+            withdrawals_len - 1,
+            withdrawals + Withdrawal.SIZE,
+            partial_sum + withdrawals[0].amount,
+            dict_start,
+            dict_end,
+        );
+    }
+    return sum_withdrawals(
+        withdrawals_len - 1, withdrawals + Withdrawal.SIZE, partial_sum, dict_start, dict_end
+    );
+}
+
+func do_withdraw{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    dict_start: DictAccess*, dict_end: DictAccess*
+) {
+    alloc_locals;
+    // Send the withdrawal message.
+    let (local l1_address) = rabbit_l1.read();
+    let (message_payload: felt*) = alloc();
+    assert message_payload[0] = MESSAGE_WITHDRAW_RECEIVED;
+    let (payload_size) = populate_payload(message_payload + 1, 1, dict_start, dict_end);
+    send_message_to_l1(to_address=l1_address, payload_size=payload_size, payload=message_payload);
+    return ();
+}
+
+func populate_payload{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    payload: felt*, payload_len: felt, dict_start: DictAccess*, dict_end: DictAccess*
+) -> (payload_size: felt) {
+    alloc_locals;
+    if (dict_start == dict_end) {
+        return (payload_size=payload_len);
+    }
+    let trader = dict_start.key;
+    assert payload[0] = trader;
+    let amount = dict_start.new_value;
+    assert payload[1] = amount;
+    // Update the new total_withdrawn
+    let (prev_total_withdrawn) = total_withdrawn.read(trader=trader);
+    total_withdrawn.write(trader, prev_total_withdrawn + amount);
+    return populate_payload(
+        payload=payload + 2,
+        payload_len=payload_len + 2,
+        dict_start=dict_start + DictAccess.SIZE,
+        dict_end=dict_end,
+    );
+}
+
+func set_withdrawal_sent_to_L1{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(withdrawal_id: felt) {
+    alloc_locals;
+    let (local word_index, local bit_index) = find_bit(withdrawal_id);
+    let (local word_before) = processed_withdrawals.read(word_index);
+    let (bit_mask) = two_to_the_n(bit_index);
+    let (word_after) = bitwise_or(word_before, bit_mask);
+    processed_withdrawals.write(word_index, word_after);
+    return ();
+}
+
+@view
+func get_withdrawal_sent_to_L1{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(withdrawal_id: felt) -> (value: felt) {
+    alloc_locals;
+    let (local word_index, local bit_index) = find_bit(withdrawal_id);
+    let (local word) = processed_withdrawals.read(word_index);
+    let (bit_mask) = two_to_the_n(bit_index);
+    let (lsb_zeros) = bitwise_not(bit_mask - 1);
+    let (rounded_down) = bitwise_and(word, lsb_zeros);
+    let bit_in_lsb = rounded_down / bit_mask;
+    let (bit) = bitwise_and(bit_in_lsb, 1);
+    return (value=bit);
+}
+
+func find_bit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(key: felt) -> (
+    word_index: felt, bit_index: felt
+) {
+    let (word_index, bit_index) = unsigned_div_rem(key, WITHDRAWALS_IN_FELT);
+    return (word_index, bit_index);
+}
+
+func two_to_the_n{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(n: felt) -> (
+    result: felt
+) {
+    let result = two_to_the_n_acc(n=n, accumulator=1);
+    return (result);
+}
+
+// Multiplying by 2 up to 250 times in a recursive loop is a bit inefficient, and we
+// can't use the expression 2**n as Cairo v0.9 doesn't support that. We can use constant
+// expressions like 2**120, so one possible approach would be to store all 250 possible
+// powers of 2 and have a giant if statement that returns the correct one with no
+// mutliplications required. The compromise approach used here is to store just a
+// selection of the powers of 2 spread  over the range from 2 to 250 and build the
+// result in a series of up to 9 (but typically 4 or 5) multiplications.
+
+func two_to_the_n_acc{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    n: felt, accumulator: felt
+) -> (result: felt) {
+    if (n == 0) {
+        return (result=accumulator);
+    }
+    let n_gt_240 = is_le_felt(240, n);
+    if (n_gt_240 == 1) {
+        return two_to_the_n_acc(n=n - 240, accumulator=accumulator * (2 ** 240));
+    }
+    let n_gt_128 = is_le_felt(128, n);
+    if (n_gt_128 == 1) {
+        return two_to_the_n_acc(n=n - 128, accumulator=accumulator * (2 ** 128));
+    }
+    let n_gt_64 = is_le_felt(64, n);
+    if (n_gt_64 == 1) {
+        return two_to_the_n_acc(n=n - 64, accumulator=accumulator * (2 ** 64));
+    }
+    let n_gt_32 = is_le_felt(32, n);
+    if (n_gt_32 == 1) {
+        return two_to_the_n_acc(n=n - 32, accumulator=accumulator * (2 ** 32));
+    }
+    let n_gt_16 = is_le_felt(16, n);
+    if (n_gt_16 == 1) {
+        return two_to_the_n_acc(n=n - 16, accumulator=accumulator * (2 ** 16));
+    }
+    let n_gt_8 = is_le_felt(8, n);
+    if (n_gt_8 == 1) {
+        return two_to_the_n_acc(n=n - 8, accumulator=accumulator * (2 ** 8));
+    }
+    let n_gt_4 = is_le_felt(4, n);
+    if (n_gt_4 == 1) {
+        return two_to_the_n_acc(n=n - 4, accumulator=accumulator * (2 ** 4));
+    }
+    let n_gt_2 = is_le_felt(2, n);
+    if (n_gt_2 == 1) {
+        return two_to_the_n_acc(n=n - 2, accumulator=accumulator * (2 ** 2));
+    }
+    return two_to_the_n_acc(n=n - 1, accumulator=accumulator * 2);
+}

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -50,8 +50,9 @@ fn test_contract<'a>(
     accessed_storage_keys: impl Iterator<Item = ClassHash>,
     extra_contracts: impl Iterator<
         Item = (
-            ClassHash,
-            &'a Path,
+            ClassHash, // the contract's class hash
+            &'a Path,  // path to the compiled contract
+            // optionally, an address to deploy to and a storage (keys are hashed)
             Option<(Address, Vec<([u8; 32], Felt252)>)>,
         ),
     >,

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -164,7 +164,7 @@ fn test_contract<'a>(
     assert_eq!(result.execution_resources, execution_resources);
 
     assert_eq!(result.gas_consumed, 0);
-    assert_eq!(result.failure_flag, false);
+    assert!(!result.failure_flag);
 }
 
 #[test]
@@ -1535,7 +1535,7 @@ fn run_rabbitx_withdraw() {
         .collect();
 
     let extra_contracts = [(
-        class_hash.clone(),
+        class_hash,
         path.as_ref(),
         Some((contract_address.clone(), storage)),
     )];
@@ -1554,7 +1554,7 @@ fn run_rabbitx_withdraw() {
         "starknet_programs/rabbit.json",
         "withdraw",
         class_hash,
-        contract_address.clone(),
+        contract_address,
         caller_address,
         context,
         None,


### PR DESCRIPTION
## Description

Related to https://github.com/lambdaclass/cairo-rs/issues/1253

This PR adds a test executing the transaction `0x0568988e97ba4be44fd345421a61026b64a2e759bd8a2c6568b6af97d8e91b29` of block `68422`. This Tx was reported to fail in https://github.com/lambdaclass/cairo-rs/issues/1244. For this, I needed to change the `test_contract` util to receive hashed keys instead of keys.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [X] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
