### PR TITLE
Reexport cairo-vm's `Felt252`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ use crate::{
     transaction::{error::TransactionError, Transaction},
 };
 
-use cairo_vm::felt::Felt252;
 use definitions::block_context::BlockContext;
 use starknet_contract_class::EntryPointType;
 use state::cached_state::CachedState;
@@ -25,6 +24,7 @@ use utils::Address;
 extern crate assert_matches;
 
 // Re-exports
+pub use cairo_vm::felt::Felt252;
 pub use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 pub use cairo_lang_starknet::contract_class::ContractClass;
 pub use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 
 use definitions::block_context::BlockContext;
-use starknet_contract_class::EntryPointType;
 use state::cached_state::CachedState;
 use transaction::InvokeFunction;
 use utils::Address;
@@ -24,10 +23,11 @@ use utils::Address;
 extern crate assert_matches;
 
 // Re-exports
-pub use cairo_vm::felt::Felt252;
 pub use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 pub use cairo_lang_starknet::contract_class::ContractClass;
 pub use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
+pub use cairo_vm::felt::Felt252;
+pub use starknet_contract_class::EntryPointType;
 
 pub mod core;
 pub mod definitions;


### PR DESCRIPTION
## Description

This PR reexports cairo-vm's `Felt252` type, to help users avoid having to add the cairo-vm as a dependency when using this lib.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
