### PR TITLE
Update `cairo-vm` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,15 +270,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "ascii-canvas"
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-felt"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451a9144bbe8bf0b351672fa0bf34e6dcc8733e2ff3a3201c8f7480fe7eb68a6"
+checksum = "fb1ceee24a02475932277c5354d5acf8dcc373944af8e7527de258b5effbea42"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -1457,25 +1457,25 @@ dependencies = [
 
 [[package]]
 name = "cairo-take_until_unbalanced"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec66f846411e5fdecd2527d429135fd39ca98ef46b0df3f1558cc272b596a30"
+checksum = "847ac5da858bfccf41ca81ce51e2f39f43c7b8ce5616c5405e6ac99006f9d01e"
 dependencies = [
  "nom",
 ]
 
 [[package]]
 name = "cairo-vm"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c73ed69023e595a18799552803550fe0a3af83713f1fc97f9edaaa677f59a8"
+checksum = "16e859bef70476e5094fc5b5c5bdc8c842e9d59480e808856fe54370991610f6"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
  "ark-std 0.3.0",
  "bincode",
  "bitvec",
- "cairo-felt 0.5.2",
+ "cairo-felt 0.6.0",
  "cairo-lang-casm 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-lang-starknet 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-take_until_unbalanced",
@@ -1495,7 +1495,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "starknet-crypto 0.5.1",
  "thiserror",
@@ -1587,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70d3ad08698a0568b0562f22710fe6bfc1f4a61a367c77d0398c562eadd453a"
+checksum = "215c0072ecc28f92eeb0eea38ba63ddfcb65c2828c46311d646f1a3ff5f9841c"
 dependencies = [
  "smallvec",
 ]
@@ -1602,9 +1602,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.2"
+version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
+checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.1"
+version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1699,9 +1699,9 @@ checksum = "a9db510e477cf3c14a6c56aa2ed28e499f1e27e01c17723b41ece793d11cf3fe"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -1717,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2520,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lru"
@@ -2785,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2799,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2877,9 +2877,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2982,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -3183,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -3280,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -3298,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3309,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
@@ -3365,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3511,10 +3511,10 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.15",
  "rfc6979 0.3.1",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "starknet-crypto-codegen 0.3.1",
  "starknet-curve 0.2.1",
- "starknet-ff 0.3.2",
+ "starknet-ff 0.3.4",
  "zeroize",
 ]
 
@@ -3531,10 +3531,10 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.15",
  "rfc6979 0.4.0",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "starknet-crypto-codegen 0.3.1",
  "starknet-curve 0.3.0",
- "starknet-ff 0.3.2",
+ "starknet-ff 0.3.4",
  "zeroize",
 ]
 
@@ -3556,7 +3556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6dc88f1f470d9de1001ffbb90d2344c9dd1a615f5467daf0574e2975dfd9ebd"
 dependencies = [
  "starknet-curve 0.3.0",
- "starknet-ff 0.3.2",
+ "starknet-ff 0.3.4",
  "syn 2.0.18",
 ]
 
@@ -3575,7 +3575,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0dbde7ef14d54c2117bc6d2efb68c2383005f1cd749b277c11df874d07b7af"
 dependencies = [
- "starknet-ff 0.3.2",
+ "starknet-ff 0.3.4",
 ]
 
 [[package]]
@@ -3584,7 +3584,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
 dependencies = [
- "starknet-ff 0.3.2",
+ "starknet-ff 0.3.4",
 ]
 
 [[package]]
@@ -3605,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5e4d14a7e5a93027baa42f514459acd1e07799f886604d8bf5d30a0d28111f"
+checksum = "db2cb1d9c0a50380cddab99cb202c6bfb3332728a2769bd0ca2ee80b0b390dd4"
 dependencies = [
  "ark-ff 0.4.2",
  "crypto-bigint 0.5.2",
@@ -3825,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "libc",
@@ -4078,9 +4078,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4088,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -4103,9 +4103,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4113,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4126,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "winapi"
@@ -4229,9 +4229,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ with_mimalloc = ["mimalloc"]
 members = ["crates/starknet-contract-class", "fuzzer", "cli"]
 
 [workspace.dependencies]
-cairo-vm = { version = "0.5.2", features = ["cairo-1-hints"]}
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev="a891109ecc9c269e91b1afd2d44bc597728e1172", features = [
+cairo-vm = { version = "0.6.0", features = ["cairo-1-hints"] }
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "a891109ecc9c269e91b1afd2d44bc597728e1172", features = [
     "testing",
 ] }
 
 [dependencies]
 cairo-lang-starknet = "1.1.0"
 cairo-lang-casm = "1.1.0"
-cairo-vm = { workspace=true, features = ["cairo-1-hints"]}
+cairo-vm = { workspace = true, features = ["cairo-1-hints"] }
 getset = "0.1.2"
 lazy_static = "1.4.0"
 num-bigint = { version = "0.4", features = ["serde"] }
@@ -28,7 +28,7 @@ num-traits = "0.2.15"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 sha3 = "0.10.1"
-starknet_api = { workspace = true}
+starknet_api = { workspace = true }
 starknet-crypto = "0.4.3"
 thiserror = "1.0.32"
 awc = "3.1.1"

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -84,7 +84,7 @@ where
         self.cairo_runner.run_from_entrypoint(
             entrypoint,
             &args,
-            &mut None,
+            &mut Default::default(),
             verify_secure,
             program_segment_size,
             &mut self.vm,
@@ -139,7 +139,7 @@ where
         self.cairo_runner.run_from_entrypoint(
             entrypoint_offset,
             &entrypoint_args,
-            &mut None,
+            &mut Default::default(),
             true,
             Some(self.cairo_runner.get_program().data_len() + program_extra_data.len()),
             &mut self.vm,

--- a/src/syscalls/deprecated_syscall_handler.rs
+++ b/src/syscalls/deprecated_syscall_handler.rs
@@ -6,7 +6,7 @@ use crate::{
     state::state_api::{State, StateReader},
     syscalls::syscall_handler_errors::SyscallHandlerError,
 };
-use cairo_vm::felt::Felt252;
+use cairo_vm::{felt::Felt252, vm::runners::cairo_runner::RunResources};
 use cairo_vm::{
     hint_processor::{
         builtin_hint_processor::{
@@ -41,10 +41,13 @@ impl<'a, T: State + StateReader> DeprecatedSyscallHintProcessor<'a, T> {
         hint_data: &Box<dyn Any>,
         constants: &HashMap<String, Felt252>,
     ) -> Result<bool, HintError> {
-        match self
-            .builtin_hint_processor
-            .execute_hint(vm, exec_scopes, hint_data, constants)
-        {
+        match self.builtin_hint_processor.execute_hint(
+            vm,
+            exec_scopes,
+            hint_data,
+            constants,
+            &mut Default::default(),
+        ) {
             Ok(()) => Ok(false),
             Err(HintError::UnknownHint(_)) => Ok(true),
             Err(e) => Err(e),
@@ -150,6 +153,7 @@ impl<'a, T: State + StateReader> HintProcessor for DeprecatedSyscallHintProcesso
         exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,
         constants: &HashMap<String, Felt252>,
+        _run_resources: &mut RunResources,
     ) -> Result<(), HintError> {
         if self.should_run_syscall_hint(vm, exec_scopes, hint_data, constants)? {
             self.execute_syscall_hint(vm, exec_scopes, hint_data, constants)
@@ -308,6 +312,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .unwrap();
 
@@ -339,6 +344,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .unwrap();
 
@@ -390,6 +396,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .unwrap();
 
@@ -461,6 +468,7 @@ mod tests {
             &mut ExecutionScopes::new(),
             &any_box!(hint_data),
             &HashMap::new(),
+            &mut Default::default(),
         );
 
         assert_matches!(result, Ok(()));
@@ -555,6 +563,7 @@ mod tests {
             &mut ExecutionScopes::new(),
             &any_box!(hint_data),
             &HashMap::new(),
+            &mut Default::default(),
         );
 
         assert_matches!(result, Ok(()));
@@ -590,6 +599,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .unwrap();
 
@@ -635,6 +645,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .unwrap();
 
@@ -684,6 +695,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             ),
             Ok(())
         );
@@ -714,6 +726,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .unwrap();
 
@@ -768,6 +781,7 @@ mod tests {
             &mut ExecutionScopes::new(),
             &any_box!(hint_data),
             &HashMap::new(),
+            &mut Default::default(),
         );
 
         assert!(result.is_ok());
@@ -835,6 +849,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .is_ok());
 
@@ -896,6 +911,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
             .is_ok());
 
@@ -970,6 +986,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             ),
             Ok(())
         );
@@ -1068,6 +1085,7 @@ mod tests {
                 &mut ExecutionScopes::new(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             ),
             Ok(())
         );

--- a/src/syscalls/syscall_handler.rs
+++ b/src/syscalls/syscall_handler.rs
@@ -5,6 +5,7 @@ use cairo_lang_casm::{
     hints::{Hint, StarknetHint},
     operand::{CellRef, DerefOrImmediate, Register, ResOperand},
 };
+use cairo_vm::vm::runners::cairo_runner::RunResources;
 use cairo_vm::{
     felt::Felt252,
     hint_processor::{
@@ -55,6 +56,7 @@ impl<'a, T: State + StateReader> HintProcessor for SyscallHintProcessor<'a, T> {
         exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,
         _constants: &HashMap<String, Felt252>,
+        _run_resources: &mut RunResources,
     ) -> Result<(), HintError> {
         let hints: &Vec<Hint> = hint_data.downcast_ref().ok_or(HintError::WrongHintData)?;
         for hint in hints {
@@ -94,7 +96,7 @@ impl<'a, T: State + StateReader> HintProcessor for SyscallHintProcessor<'a, T> {
         //(may contain other variables aside from those used by the hint)
         reference_ids: &HashMap<String, usize>,
         //List of all references (key corresponds to element of the previous dictionary)
-        references: &HashMap<usize, HintReference>,
+        references: &[HintReference],
     ) -> Result<Box<dyn Any>, VirtualMachineError> {
         self.cairo1_hint_processor.compile_hint(
             hint_code,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -479,6 +479,7 @@ pub mod test_utils {
                 exec_scopes_ref!(),
                 &any_box!(hint_data),
                 &HashMap::new(),
+                &mut Default::default(),
             )
         }};
     }


### PR DESCRIPTION
# TITLE

## Description

This PR updates the version of the VM to `v0.6.0`. Among other changes, some functions now receive `&mut RunResources` as a parameter so I used `&mut Default::default()` in places where they are used.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
