### PR TITLE
rename crate to starknet_in_rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,19 +3221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-contract-class"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b4f336705886ab6837b40298237f8f2c77d7a9604474a96e7103e98ca9126b"
-dependencies = [
- "cairo-vm",
- "getset",
- "lambda_starknet_api",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "starknet-crypto"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,7 +3296,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "starknet-contract-class 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-contract-class",
  "starknet-crypto",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,6 +3221,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet-contract-class"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b4f336705886ab6837b40298237f8f2c77d7a9604474a96e7103e98ca9126b"
+dependencies = [
+ "cairo-vm",
+ "getset",
+ "lambda_starknet_api",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "starknet-crypto"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,7 +3286,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-rs"
+name = "starknet_in_rust"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -3296,7 +3309,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "starknet-contract-class",
+ "starknet-contract-class 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-crypto",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-name = "starknet-rs"
+name = "starknet_in_rust"
 version = "0.1.0"
 edition = "2021"
+description = "A Rust implementation of Starknet execution logic"
+license = "Apache-2.0"
 
 [features]
 default = ["with_mimalloc"]
@@ -12,6 +14,8 @@ members = ["crates/starknet-contract-class"]
 
 [workspace.dependencies]
 cairo-vm = { version = "0.8.0", features = ["cairo-1-hints"]}
+
+
 lambda_starknet_api = "0.1.0"
 
 [dependencies]
@@ -34,7 +38,7 @@ mimalloc = { version = "0.1.29", default-features = false, optional = true }
 hex = "0.4.3"
 cargo-llvm-cov = "0.5.14"
 anyhow = "1.0.66"
-starknet-contract-class = { path = "crates/starknet-contract-class" }
+starknet-contract-class = "0.1.0"
 once_cell = "1.17.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ members = ["crates/starknet-contract-class"]
 
 [workspace.dependencies]
 cairo-vm = { version = "0.8.0", features = ["cairo-1-hints"]}
-
-
 lambda_starknet_api = "0.1.0"
 
 [dependencies]
@@ -30,7 +28,7 @@ num-traits = "0.2.15"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision", "raw_value"] }
 sha3 = "0.10.1"
-lambda_starknet_api = { workspace = true}
+lambda_starknet_api = { workspace = true }
 starknet-crypto = "0.5.1"
 thiserror = "1.0.32"
 awc = "3.1.1"
@@ -38,7 +36,7 @@ mimalloc = { version = "0.1.29", default-features = false, optional = true }
 hex = "0.4.3"
 cargo-llvm-cov = "0.5.14"
 anyhow = "1.0.66"
-starknet-contract-class = "0.1.0"
+starknet-contract-class = { path = "./crates/starknet-contract-class", version = "0.1.0" }
 once_cell = "1.17.1"
 
 [dev-dependencies]

--- a/bench/internals.rs
+++ b/bench/internals.rs
@@ -4,7 +4,7 @@ use cairo_vm::felt;
 use felt::{felt_str, Felt252};
 use lazy_static::lazy_static;
 use num_traits::Zero;
-use starknet_rs::{
+use starknet_in_rust::{
     core::contract_address::compute_deprecated_class_hash,
     definitions::{
         block_context::StarknetChainId,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use cairo_vm::felt::Felt252;
 use clap::{Args, Parser, Subcommand};
 use num_traits::{Num, Zero};
 use serde::{Deserialize, Serialize};
-use starknet_rs::{
+use starknet_in_rust::{
     core::{
         contract_address::compute_deprecated_class_hash,
         errors::{contract_address_errors::ContractAddressError, state_errors::StateError},

--- a/crates/starknet-contract-class/Cargo.toml
+++ b/crates/starknet-contract-class/Cargo.toml
@@ -2,6 +2,8 @@
 name = "starknet-contract-class"
 version = "0.1.0"
 edition = "2021"
+description = "Crate that parses a Starknet contract class from API"
+license = "Apache-2.0"
 
 [dependencies]
 serde = "1.0.156"

--- a/examples/contract_execution/execute_contract.rs
+++ b/examples/contract_execution/execute_contract.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 use cairo_vm::felt::Felt252;
-use starknet_rs::{
+use starknet_in_rust::{
         execution::{
             execution_entry_point::ExecutionEntryPoint,
             objects::{CallInfo, CallType, TransactionExecutionContext},

--- a/examples/contract_execution/main.rs
+++ b/examples/contract_execution/main.rs
@@ -10,7 +10,7 @@
 //! running some pre-compiled contracts is as expected.
 
 use cairo_vm::felt::Felt252;
-use starknet_rs::{
+use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
     testing::state::StarknetState,
     utils::{calculate_sn_keccak, Address},

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -7,7 +7,7 @@ use cairo_vm::felt::Felt252;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, TransactionExecutionContext,

--- a/src/bin/deploy.rs
+++ b/src/bin/deploy.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use lazy_static::lazy_static;
-use starknet_rs::{
+use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
     testing::state::StarknetState,
 };

--- a/src/bin/deploy_invoke.rs
+++ b/src/bin/deploy_invoke.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::Zero;
 
-use starknet_rs::{
+use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
     testing::state::StarknetState, utils::Address,
 };

--- a/src/bin/fibonacci.rs
+++ b/src/bin/fibonacci.rs
@@ -4,7 +4,7 @@ use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::Zero;
 
 use lazy_static::lazy_static;
-use starknet_rs::{
+use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
     state::cached_state::CachedState, state::in_memory_state_reader::InMemoryStateReader,
     testing::state::StarknetState, utils::Address,

--- a/src/bin/invoke.rs
+++ b/src/bin/invoke.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::Zero;
 
-use starknet_rs::{
+use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
     state::cached_state::CachedState, state::in_memory_state_reader::InMemoryStateReader,
     testing::state::StarknetState, utils::Address,

--- a/src/bin/invoke_with_cachedstate.rs
+++ b/src/bin/invoke_with_cachedstate.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::Zero;
 
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{
         block_context::{BlockContext, StarknetChainId, StarknetOsConfig},
         constants::TRANSACTION_VERSION,

--- a/tests/cairo_1_syscalls.rs
+++ b/tests/cairo_1_syscalls.rs
@@ -12,7 +12,7 @@ use cairo_vm::{
 use num_bigint::BigUint;
 use num_traits::{Num, One, Zero};
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, L2toL1MessageInfo,

--- a/tests/complex_contracts/amm_contracts/amm.rs
+++ b/tests/complex_contracts/amm_contracts/amm.rs
@@ -5,8 +5,8 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use cairo_vm::{felt::Felt252, vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME};
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::definitions::block_context::BlockContext;
-use starknet_rs::{
+use starknet_in_rust::definitions::block_context::BlockContext;
+use starknet_in_rust::{
     execution::{CallInfo, CallType},
     services::api::contract_classes::deprecated_contract_class::ContractClass,
     state::{cached_state::CachedState, state_api::StateReader},

--- a/tests/complex_contracts/amm_contracts/amm_proxy.rs
+++ b/tests/complex_contracts/amm_contracts/amm_proxy.rs
@@ -3,9 +3,9 @@ use cairo_vm::felt::Felt252;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use starknet_contract_class::EntryPointType;
 use starknet_crypto::FieldElement;
-use starknet_rs::definitions::block_context::BlockContext;
-use starknet_rs::services::api::contract_classes::deprecated_contract_class::ContractClass;
-use starknet_rs::{
+use starknet_in_rust::definitions::block_context::BlockContext;
+use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass;
+use starknet_in_rust::{
     execution::{CallInfo, CallType},
     state::{cached_state::CachedState, state_api::StateReader},
     state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},

--- a/tests/complex_contracts/nft/erc721.rs
+++ b/tests/complex_contracts/nft/erc721.rs
@@ -7,11 +7,11 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
 use starknet_crypto::FieldElement;
-use starknet_rs::definitions::block_context::BlockContext;
-use starknet_rs::services::api::contract_classes::deprecated_contract_class::ContractClass;
-use starknet_rs::state::cached_state::CachedState;
-use starknet_rs::transaction::error::TransactionError;
-use starknet_rs::{
+use starknet_in_rust::definitions::block_context::BlockContext;
+use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass;
+use starknet_in_rust::state::cached_state::CachedState;
+use starknet_in_rust::transaction::error::TransactionError;
+use starknet_in_rust::{
     execution::{CallInfo, CallType, OrderedEvent},
     state::state_api::StateReader,
     state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},

--- a/tests/complex_contracts/utils.rs
+++ b/tests/complex_contracts/utils.rs
@@ -4,7 +4,7 @@ use cairo_vm::felt::Felt252;
 use num_traits::Zero;
 use starknet_contract_class::{ContractEntryPoint, EntryPointType};
 use starknet_crypto::{pedersen_hash, FieldElement};
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{
         block_context::{BlockContext, StarknetChainId},
         constants::TRANSACTION_VERSION,

--- a/tests/delegate_call.rs
+++ b/tests/delegate_call.rs
@@ -5,7 +5,7 @@ mod cairo_1_syscalls;
 use cairo_vm::felt::Felt252;
 use num_traits::{One, Zero};
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,

--- a/tests/delegate_l1_handler.rs
+++ b/tests/delegate_l1_handler.rs
@@ -5,7 +5,7 @@ mod cairo_1_syscalls;
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::{One, Zero};
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,

--- a/tests/deploy_account.rs
+++ b/tests/deploy_account.rs
@@ -5,7 +5,7 @@ use cairo_vm::{
 use lazy_static::lazy_static;
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     core::contract_address::compute_deprecated_class_hash,
     definitions::{
         block_context::StarknetChainId, constants::CONSTRUCTOR_ENTRY_POINT_SELECTOR,

--- a/tests/fibonacci.rs
+++ b/tests/fibonacci.rs
@@ -5,8 +5,8 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use cairo_vm::{felt::Felt252, vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME};
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::definitions::block_context::BlockContext;
-use starknet_rs::{
+use starknet_in_rust::definitions::block_context::BlockContext;
+use starknet_in_rust::{
     definitions::constants::TRANSACTION_VERSION,
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, TransactionExecutionContext,

--- a/tests/increase_balance.rs
+++ b/tests/increase_balance.rs
@@ -6,7 +6,7 @@ use cairo_vm::felt::Felt252;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, TransactionExecutionContext,

--- a/tests/internal_calls.rs
+++ b/tests/internal_calls.rs
@@ -3,7 +3,7 @@
 use cairo_vm::felt::Felt252;
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -13,17 +13,17 @@ use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use num_traits::{Num, One, ToPrimitive, Zero};
 use starknet_contract_class::EntryPointType;
-use starknet_rs::core::errors::state_errors::StateError;
-use starknet_rs::definitions::constants::{
+use starknet_in_rust::core::errors::state_errors::StateError;
+use starknet_in_rust::definitions::constants::{
     DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS, VALIDATE_ENTRY_POINT_SELECTOR,
 };
-use starknet_rs::execution::execution_entry_point::ExecutionEntryPoint;
-use starknet_rs::execution::TransactionExecutionContext;
-use starknet_rs::services::api::contract_classes::deprecated_contract_class::ContractClass;
-use starknet_rs::state::ExecutionResourcesManager;
-use starknet_rs::transaction::{DeclareV2, Deploy};
-use starknet_rs::CasmContractClass;
-use starknet_rs::{
+use starknet_in_rust::execution::execution_entry_point::ExecutionEntryPoint;
+use starknet_in_rust::execution::TransactionExecutionContext;
+use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass;
+use starknet_in_rust::state::ExecutionResourcesManager;
+use starknet_in_rust::transaction::{DeclareV2, Deploy};
+use starknet_in_rust::CasmContractClass;
+use starknet_in_rust::{
     definitions::{
         block_context::{BlockContext, StarknetChainId, StarknetOsConfig},
         constants::{

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -2,7 +2,7 @@ use cairo_vm::felt::Felt252;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_traits::Zero;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, TransactionExecutionContext,

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -10,7 +10,7 @@ use cairo_vm::{
 };
 use num_traits::{Num, One, Zero};
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     definitions::{
         block_context::{BlockContext, StarknetChainId},
         constants::{CONSTRUCTOR_ENTRY_POINT_SELECTOR, TRANSACTION_VERSION},

--- a/tests/syscalls_errors.rs
+++ b/tests/syscalls_errors.rs
@@ -2,7 +2,7 @@
 
 use cairo_vm::felt::Felt252;
 use starknet_contract_class::EntryPointType;
-use starknet_rs::{
+use starknet_in_rust::{
     core::errors::state_errors::StateError,
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{


### PR DESCRIPTION
# Rename crate to starknet_in_rust

## Description

This PR renames the crate name to starknet in rust.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
