### PR TITLE
refactor: change compute hinted_class_hash on ContractClass init

### DIFF
--- a/src/core/contract_address/deprecated_contract_address.rs
+++ b/src/core/contract_address/deprecated_contract_address.rs
@@ -213,10 +213,10 @@ pub struct CairoProgramToHash<'a> {
 
 /// Computes the hash of the contract class, including hints.
 /// We are not supporting backward compatibility now.
-fn compute_hinted_class_hash(
-    contract_class: &ContractClass,
+pub(crate) fn compute_hinted_class_hash(
+    contract_class: &serde_json::Value,
 ) -> Result<Felt252, ContractAddressError> {
-    let program_as_string = contract_class.program_json.to_string();
+    let program_as_string = contract_class.to_string();
     let mut cairo_program_hash: CairoContractDefinition = serde_json::from_str(&program_as_string)
         .map_err(|err| ContractAddressError::InvalidProgramJson(err.to_string()))?;
 
@@ -322,7 +322,7 @@ pub fn compute_deprecated_class_hash(
 
     let builtin_list = compute_hash_on_elements(&builtin_list_vec)?;
 
-    let hinted_class_hash = compute_hinted_class_hash(contract_class)?;
+    let hinted_class_hash = contract_class.hinted_class_hash();
 
     let mut bytecode_vector = Vec::new();
 
@@ -342,7 +342,7 @@ pub fn compute_deprecated_class_hash(
         l1_handlers,
         constructors,
         builtin_list,
-        hinted_class_hash,
+        hinted_class_hash.clone(),
         bytecode,
     ];
 
@@ -364,8 +364,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            compute_hinted_class_hash(&contract_class).unwrap(),
-            Felt252::from_str_radix(
+            contract_class.hinted_class_hash(),
+            &Felt252::from_str_radix(
                 "1164033593603051336816641706326288678020608687718343927364853957751413025239",
                 10
             )

--- a/src/core/contract_address/mod.rs
+++ b/src/core/contract_address/mod.rs
@@ -2,4 +2,5 @@ mod deprecated_contract_address;
 mod sierra_contract_address;
 
 pub use deprecated_contract_address::compute_deprecated_class_hash;
+pub(crate) use deprecated_contract_address::compute_hinted_class_hash;
 pub use sierra_contract_address::compute_sierra_class_hash;

--- a/src/services/api/contract_classes/deprecated_contract_class.rs
+++ b/src/services/api/contract_classes/deprecated_contract_class.rs
@@ -1,3 +1,4 @@
+use crate::core::contract_address::compute_hinted_class_hash;
 use crate::services::api::contract_class_errors::ContractClassError;
 use cairo_vm::felt::{Felt252, PRIME_STR};
 use cairo_vm::serde::deserialize_program::{
@@ -75,7 +76,7 @@ pub struct ContractClass {
     #[getset(get = "pub")]
     pub(crate) program: Program,
     #[getset(get = "pub")]
-    pub(crate) program_json: serde_json::Value,
+    pub(crate) hinted_class_hash: Felt252,
     #[getset(get = "pub")]
     pub(crate) entry_points_by_type: HashMap<EntryPointType, Vec<ContractEntryPoint>>,
     #[getset(get = "pub")]
@@ -96,9 +97,9 @@ impl ContractClass {
                 }
             }
         }
-
+        let hinted_class_hash = compute_hinted_class_hash(&program_json).unwrap();
         Ok(ContractClass {
-            program_json,
+            hinted_class_hash,
             program,
             entry_points_by_type,
             abi,
@@ -126,9 +127,9 @@ impl TryFrom<&str> for ContractClass {
         let program = to_cairo_runner_program(&contract_class.program)?;
         let entry_points_by_type =
             convert_entry_points(contract_class.clone().entry_points_by_type);
-        let program_json = serde_json::from_str(s)?;
+        let hinted_class_hash = compute_hinted_class_hash(&serde_json::from_str(s)?).unwrap();
         Ok(ContractClass {
-            program_json,
+            hinted_class_hash,
             program,
             entry_points_by_type,
             abi: contract_class.abi,

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -337,11 +337,9 @@ impl<T: StateReader> State for CachedState<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::api::contract_classes::deprecated_contract_class::{
-        ContractEntryPoint, EntryPointType,
-    };
+
     use crate::state::in_memory_state_reader::InMemoryStateReader;
-    use cairo_vm::types::program::Program;
+
     use num_traits::One;
 
     #[test]
@@ -395,18 +393,10 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
         );
-
-        let program_json: serde_json::Value = serde_json::Value::from("{}");
-        let contract_class = ContractClass::new(
-            program_json,
-            Program::default(),
-            HashMap::from([(
-                EntryPointType::Constructor,
-                vec![ContractEntryPoint::default()],
-            )]),
-            None,
+        let contract_class = ContractClass::new_from_path(
+            "starknet_programs/raw_contract_classes/class_with_abi.json",
         )
-        .expect("Error creating contract class");
+        .unwrap();
 
         state_reader
             .class_hash_to_contract_class

--- a/src/state/in_memory_state_reader.rs
+++ b/src/state/in_memory_state_reader.rs
@@ -116,10 +116,6 @@ impl StateReader for InMemoryStateReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::api::contract_classes::deprecated_contract_class::{
-        ContractEntryPoint, EntryPointType,
-    };
-    use cairo_vm::types::program::Program;
 
     #[test]
     fn get_contract_state_test() {
@@ -170,18 +166,11 @@ mod tests {
             HashMap::new(),
         );
 
-        let program_json: serde_json::Value = serde_json::Value::from("{}");
         let contract_class_key = [0; 32];
-        let contract_class = ContractClass::new(
-            program_json,
-            Program::default(),
-            HashMap::from([(
-                EntryPointType::Constructor,
-                vec![ContractEntryPoint::default()],
-            )]),
-            None,
+        let contract_class = ContractClass::new_from_path(
+            "starknet_programs/raw_contract_classes/class_with_abi.json",
         )
-        .expect("Error creating contract class");
+        .unwrap();
 
         state_reader
             .class_hash_to_contract_class

--- a/src/state/state_cache.rs
+++ b/src/state/state_cache.rs
@@ -182,9 +182,6 @@ impl StateCache {
 
 #[cfg(test)]
 mod tests {
-
-    use cairo_vm::types::program::Program;
-
     use crate::services::api::contract_classes::deprecated_contract_class::ContractClass;
 
     use super::*;
@@ -193,10 +190,11 @@ mod tests {
     fn state_chache_set_initial_values() {
         let mut state_cache = StateCache::default();
         let address_to_class_hash = HashMap::from([(Address(10.into()), [8; 32])]);
-        let program_json: serde_json::Value = serde_json::Value::from("{}");
-        let compiled_class = CompiledClass::Deprecated(Box::new(
-            ContractClass::new(program_json, Program::default(), HashMap::new(), None).unwrap(),
-        ));
+        let contract_class = ContractClass::new_from_path(
+            "starknet_programs/raw_contract_classes/class_with_abi.json",
+        )
+        .unwrap();
+        let compiled_class = CompiledClass::Deprecated(Box::new(contract_class));
         let class_hash_to_compiled_class_hash = HashMap::from([([8; 32], compiled_class)]);
         let address_to_nonce = HashMap::from([(Address(9.into()), 12.into())]);
         let storage_updates = HashMap::from([((Address(4.into()), [1; 32]), 18.into())]);

--- a/src/transaction/deploy.rs
+++ b/src/transaction/deploy.rs
@@ -382,7 +382,7 @@ mod tests {
 
         // Make a new contract class with the same program but with errors
         let error_contract_class = ContractClass {
-            program_json: contract_class.program_json,
+            hinted_class_hash: contract_class.hinted_class_hash,
             program: contract_class.program,
             entry_points_by_type: HashMap::new(),
             abi: None,


### PR DESCRIPTION
## Description

Updates the `ContractClass`, removing the `program_json` field and adding a `hinted_class_hash` field.
Now is being calculated on init of the struct.

Thanks to @kkovaacs for letting us know where the issue was and how to improve it.

Closes #770 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
