### PR TITLE
feat: reexport whole `felt` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use crate::{
     transaction::{error::TransactionError, Transaction},
 };
 
+use cairo_vm::felt::Felt252;
 use definitions::block_context::BlockContext;
 use state::cached_state::CachedState;
 use transaction::L1Handler;
@@ -31,7 +32,7 @@ pub use crate::services::api::contract_classes::deprecated_contract_class::{
 pub use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 pub use cairo_lang_starknet::contract_class::ContractClass;
 pub use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
-pub use cairo_vm::felt::Felt252;
+pub use cairo_vm::felt;
 
 pub mod core;
 pub mod definitions;


### PR DESCRIPTION
## Description

Some users would like to use `felt_str`, and to avoid having to import the _felt_ crate independently for this.
Reexporting the whole crate should reduce future work when functionality is added.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
