### PR TITLE
DeclareV2 class hash fix

### DIFF
--- a/src/core/transaction_hash/mod.rs
+++ b/src/core/transaction_hash/mod.rs
@@ -1,12 +1,9 @@
 use crate::{
-    core::contract_address::{compute_deprecated_class_hash, compute_sierra_class_hash},
-    definitions::constants::CONSTRUCTOR_ENTRY_POINT_SELECTOR,
-    hash_utils::compute_hash_on_elements,
+    core::contract_address::compute_deprecated_class_hash,
+    definitions::constants::CONSTRUCTOR_ENTRY_POINT_SELECTOR, hash_utils::compute_hash_on_elements,
     services::api::contract_classes::deprecated_contract_class::ContractClass,
-    syscalls::syscall_handler_errors::SyscallHandlerError,
-    utils::Address,
+    syscalls::syscall_handler_errors::SyscallHandlerError, utils::Address,
 };
-use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::Zero;
 
@@ -152,7 +149,7 @@ pub fn calculate_declare_transaction_hash(
 // ----------------------------
 
 pub fn calculate_declare_v2_transaction_hash(
-    contract_class: &SierraContractClass,
+    sierra_class_hash: Felt252,
     compiled_class_hash: Felt252,
     chain_id: Felt252,
     sender_address: &Address,
@@ -160,10 +157,7 @@ pub fn calculate_declare_v2_transaction_hash(
     version: Felt252,
     nonce: Felt252,
 ) -> Result<Felt252, SyscallHandlerError> {
-    let class_hash = compute_sierra_class_hash(contract_class)
-        .map_err(|_| SyscallHandlerError::FailToComputeHash)?;
-
-    let calldata = [class_hash].to_vec();
+    let calldata = [sierra_class_hash].to_vec();
     let additional_data = [nonce, compiled_class_hash].to_vec();
 
     calculate_transaction_hash_common(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ mod test {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    use crate::core::contract_address::compute_deprecated_class_hash;
+    use crate::core::contract_address::{compute_deprecated_class_hash, compute_sierra_class_hash};
     use crate::definitions::{
         block_context::StarknetChainId,
         constants::{
@@ -836,6 +836,8 @@ mod test {
         let sierra_contract_class: SierraContractClass =
             serde_json::from_slice(program_data).unwrap();
 
+        let sierra_class_hash = compute_sierra_class_hash(&sierra_contract_class).unwrap();
+
         DeclareV2 {
             sender_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
             tx_type: TransactionType::Declare,
@@ -847,6 +849,7 @@ mod test {
             hash_value: 0.into(),
             compiled_class_hash: TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone(),
             sierra_contract_class,
+            sierra_class_hash,
             casm_class: Default::default(),
             skip_execute: false,
             skip_fee_transfer: false,

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -268,7 +268,7 @@ impl DeclareV2 {
             })
             .map_err(|e| TransactionError::SierraCompileError(e.to_string()))?;
 
-        state.set_compiled_class_hash(&self.hash_value, &self.compiled_class_hash)?;
+        state.set_compiled_class_hash(&self.sierra_class_hash, &self.compiled_class_hash)?;
         state.set_compiled_class(&self.compiled_class_hash, casm_class.clone())?;
 
         Ok(())

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -12,6 +12,7 @@ use cairo_vm::vm::{
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Num, One, Zero};
+use starknet_in_rust::core::contract_address::compute_sierra_class_hash;
 use starknet_in_rust::core::errors::state_errors::StateError;
 use starknet_in_rust::definitions::constants::{
     DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS, VALIDATE_ENTRY_POINT_SELECTOR,
@@ -698,6 +699,7 @@ fn declarev2_tx() -> DeclareV2 {
     #[cfg(feature = "cairo_1_tests")]
     let program_data = include_bytes!("../starknet_programs/cairo1/fibonacci.sierra");
     let sierra_contract_class: SierraContractClass = serde_json::from_slice(program_data).unwrap();
+    let sierra_class_hash = compute_sierra_class_hash(&sierra_contract_class).unwrap();
 
     DeclareV2 {
         sender_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
@@ -710,6 +712,7 @@ fn declarev2_tx() -> DeclareV2 {
         hash_value: 0.into(),
         compiled_class_hash: TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone(),
         sierra_contract_class,
+        sierra_class_hash,
         casm_class: Default::default(),
         skip_execute: false,
         skip_fee_transfer: false,


### PR DESCRIPTION
# DeclareV2 should declare the class with the correct class hash

## Description

DeclareV2 code used the _transaction hash_ (maybe we could use the Rust type system to make sure no such problems are there in the code?) instead of the _class hash_ when adding the declared class to storage.
