### PR TITLE
perf: move arg for to_cairo_runner_program

### DIFF
--- a/src/services/api/contract_classes/deprecated_contract_class.rs
+++ b/src/services/api/contract_classes/deprecated_contract_class.rs
@@ -138,7 +138,7 @@ impl FromStr for ContractClass {
     fn from_str(program_json: &str) -> Result<Self, ProgramError> {
         let contract_class: starknet_api::deprecated_contract_class::ContractClass =
             serde_json::from_str(program_json)?;
-        let program = to_cairo_runner_program(&contract_class.program)?;
+        let program = to_cairo_runner_program(contract_class.program)?;
         let entry_points_by_type = convert_entry_points(contract_class.entry_points_by_type);
         let hinted_class_hash =
             compute_hinted_class_hash(&serde_json::from_str(program_json)?).unwrap();
@@ -178,9 +178,8 @@ pub(crate) fn convert_entry_points(
 }
 
 pub(crate) fn to_cairo_runner_program(
-    program: &starknet_api::deprecated_contract_class::Program,
+    program: starknet_api::deprecated_contract_class::Program,
 ) -> Result<Program, ProgramError> {
-    let program = program.clone();
     let identifiers = serde_json::from_value::<HashMap<String, Identifier>>(program.identifiers)?;
 
     if program.prime != *PRIME_STR {


### PR DESCRIPTION
Replaces a `clone` for the `program` argument to `to_cairo_runner_program` by a `move`.
A simple benchmark was performed in our server by reproducing 200 transactions with Pathfinder 5 times. The win is ~10%.

## Benchmark Results

```
[root@archlinux-latest-64-minimal pathfinder]# for i in {1..5}; do time ./re_execute_blockifier ./mainnet_83389.sqlite 68000 68200; done > /dev/null
                                                           
real    0m20.799s 
user    9m54.753s                              
sys     0m22.870s

real    0m20.649s
user    9m53.784s
sys     0m21.372s

real    0m20.685s
user    9m55.955s
sys     0m21.103s

real    0m20.688s
user    9m54.542s
sys     0m21.005s

real    0m20.714s
user    9m55.268s
sys     0m20.871s

[root@archlinux-latest-64-minimal pathfinder]# for i in {1..5}; do time ./re_execute_sir_base ./mainnet_83389.sqlite 68000 68200; done > /dev/null

real    0m33.326s
user    16m12.373s
sys     0m35.381s

real    0m33.320s
user    16m12.506s
sys     0m35.555s

real    0m33.402s
user    16m14.239s
sys     0m35.048s

real    0m33.365s
user    16m13.138s
sys     0m35.427s

real    0m33.282s
user    16m10.810s
sys     0m35.725s

[root@archlinux-latest-64-minimal pathfinder]# for i in {1..5}; do time ./re_execute_sir_owned ./mainnet_83389.sqlite 68000 68200; done > /dev/null

real    0m29.778s
user    14m36.011s
sys     0m24.367s

real    0m29.803s
user    14m35.188s
sys     0m24.706s
  
real    0m29.858s
user    14m35.515s
sys     0m24.574s

real    0m29.837s
user    14m35.700s
sys     0m24.613s

real    0m29.662s
user    14m31.473s
sys     0m24.144s
```

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
