### PR TITLE
Add class hash check for declarev2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(CAIRO_1_CONTRACTS_TEST_DIR)/%.sierra: $(CAIRO_1_CONTRACTS_TEST_DIR)/%.cairo
 	$(STARKNET_COMPILE_CAIRO_1) --allowed-libfuncs-list-name experimental_v0.1.0 $< $@
 
 $(CAIRO_1_CONTRACTS_TEST_DIR)/%.casm: $(CAIRO_1_CONTRACTS_TEST_DIR)/%.sierra
-	$(STARKNET_SIERRA_COMPILE_CAIRO_1) --allowed-libfuncs-list-name experimental_v0.1.0 $< $@
+	$(STARKNET_SIERRA_COMPILE_CAIRO_1) --allowed-libfuncs-list-name experimental_v0.1.0 --add-pythonic-hints $< $@
 
 
 cairo-repo-1-dir = cairo1
@@ -103,7 +103,7 @@ $(CAIRO_2_CONTRACTS_TEST_DIR)/%.sierra: $(CAIRO_2_CONTRACTS_TEST_DIR)/%.cairo
 	$(STARKNET_COMPILE_CAIRO_2) $< $@
 
 $(CAIRO_2_CONTRACTS_TEST_DIR)/%.casm: $(CAIRO_2_CONTRACTS_TEST_DIR)/%.sierra
-	$(STARKNET_SIERRA_COMPILE_CAIRO_2) $< $@
+	$(STARKNET_SIERRA_COMPILE_CAIRO_2) --add-pythonic-hints $< $@
 
 
 cairo-repo-2-dir = cairo2

--- a/src/core/contract_address/casm_contract_address.rs
+++ b/src/core/contract_address/casm_contract_address.rs
@@ -1,0 +1,190 @@
+use crate::core::errors::contract_address_errors::ContractAddressError;
+use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
+use cairo_lang_starknet::casm_contract_class::{CasmContractClass, CasmContractEntryPoint};
+use cairo_vm::felt::Felt252;
+use starknet_crypto::{poseidon_hash_many, FieldElement};
+
+const CONTRACT_CLASS_VERSION: &[u8] = b"COMPILED_CLASS_V1";
+
+fn get_contract_entry_points_hashed(
+    contract_class: &CasmContractClass,
+    entry_point_type: &EntryPointType,
+) -> Result<FieldElement, ContractAddressError> {
+    let contract_entry_points = get_contract_entry_points(contract_class, entry_point_type);
+
+    // for each entry_point, we need to store 3 FieldElements: [selector, offset, poseidon_hash_many(builtin_list)].
+    let mut entry_points_flatted = Vec::with_capacity(contract_entry_points.len() * 3);
+
+    for entry_point in contract_entry_points {
+        entry_points_flatted.push(
+            // fix this conversion later
+            FieldElement::from_bytes_be(&Felt252::from(entry_point.selector).to_be_bytes())
+                .map_err(|_err| {
+                    ContractAddressError::Cast("Felt252".to_string(), "FieldElement".to_string())
+                })?,
+        );
+        entry_points_flatted.push(FieldElement::from(entry_point.offset));
+        let mut builtins_flatted = Vec::new();
+        entry_point.builtins.iter().for_each(|builtin| {
+            builtins_flatted.push(FieldElement::from_byte_slice_be(builtin.as_bytes()).unwrap());
+        });
+        entry_points_flatted.push(poseidon_hash_many(&builtins_flatted));
+    }
+
+    Ok(poseidon_hash_many(&entry_points_flatted))
+}
+
+pub fn compute_casm_class_hash(
+    contract_class: &CasmContractClass,
+) -> Result<Felt252, ContractAddressError> {
+    let api_version =
+        FieldElement::from_bytes_be(&Felt252::from_bytes_be(CONTRACT_CLASS_VERSION).to_be_bytes())
+            .map_err(|_err| {
+                ContractAddressError::Cast("Felt252".to_string(), "FieldElement".to_string())
+            })?;
+
+    // Entrypoints by type, hashed.
+    let external_functions =
+        get_contract_entry_points_hashed(contract_class, &EntryPointType::External)?;
+    let l1_handlers = get_contract_entry_points_hashed(contract_class, &EntryPointType::L1Handler)?;
+    let constructors =
+        get_contract_entry_points_hashed(contract_class, &EntryPointType::Constructor)?;
+
+    let mut casm_program_vector = Vec::with_capacity(contract_class.bytecode.len());
+    for number in &contract_class.bytecode {
+        casm_program_vector.push(
+            FieldElement::from_bytes_be(&Felt252::from(number.value.clone()).to_be_bytes())
+                .map_err(|_err| {
+                    ContractAddressError::Cast("Felt252".to_string(), "FieldElement".to_string())
+                })?,
+        );
+    }
+
+    // Hash casm program.
+    let casm_program_ptr = poseidon_hash_many(&casm_program_vector);
+
+    let flatted_contract_class = vec![
+        api_version,
+        external_functions,
+        l1_handlers,
+        constructors,
+        casm_program_ptr,
+    ];
+
+    Ok(Felt252::from_bytes_be(
+        &poseidon_hash_many(&flatted_contract_class).to_bytes_be(),
+    ))
+}
+
+fn get_contract_entry_points(
+    contract_class: &CasmContractClass,
+    entry_point_type: &EntryPointType,
+) -> Vec<CasmContractEntryPoint> {
+    match entry_point_type {
+        EntryPointType::Constructor => contract_class.entry_points_by_type.constructor.clone(),
+        EntryPointType::External => contract_class.entry_points_by_type.external.clone(),
+        EntryPointType::L1Handler => contract_class.entry_points_by_type.l1_handler.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// THE VALUES IN THIS TESTS WERE TAKEN FROM THE CONTRACTS IN THE STARKNET_PROGRAMS FOLDER.
+    /// AND WE USE A [TOOL FOUND IN CAIRO-LANG](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/starknet/cli/compiled_class_hash.py)
+    /// TO GET THE RIGHT HASH VALUE.
+    use std::{fs::File, io::BufReader};
+
+    use super::*;
+    use cairo_vm::felt::felt_str;
+    use coverage_helper::test;
+
+    #[test]
+    fn test_compute_casm_class_hash_contract_a() {
+        // Open the file in read-only mode with buffer.
+        let file = File::open("starknet_programs/cairo1/contract_a.casm").unwrap();
+        let reader = BufReader::new(file);
+
+        // Read the JSON contents of the file as an instance of `User`.
+        let contract_class: CasmContractClass = serde_json::from_reader(reader).unwrap();
+
+        assert_eq!(
+            compute_casm_class_hash(&contract_class).unwrap(),
+            felt_str!(
+                "3a4f00bf75ba3b9230a94f104c7a4605a1901c4bd475beb59eeeeb7aceb9795",
+                16
+            )
+        );
+    }
+
+    #[test]
+    fn test_compute_casm_class_hash_deploy() {
+        // Open the file in read-only mode with buffer.
+        let file = File::open("starknet_programs/cairo1/deploy.casm").unwrap();
+        let reader = BufReader::new(file);
+
+        // Read the JSON contents of the file as an instance of `User`.
+        let contract_class: CasmContractClass = serde_json::from_reader(reader).unwrap();
+
+        assert_eq!(
+            compute_casm_class_hash(&contract_class).unwrap(),
+            felt_str!(
+                "3bd56f1c3c1c595ac2ee6d07bdedc027d09df56235e20374649f0b3535c1f15",
+                16
+            )
+        );
+    }
+
+    #[test]
+    fn test_compute_casm_class_hash_fibonacci() {
+        // Open the file in read-only mode with buffer.
+        let file = File::open("starknet_programs/cairo1/fibonacci.casm").unwrap();
+        let reader = BufReader::new(file);
+
+        // Read the JSON contents of the file as an instance of `User`.
+        let contract_class: CasmContractClass = serde_json::from_reader(reader).unwrap();
+
+        assert_eq!(
+            compute_casm_class_hash(&contract_class).unwrap(),
+            felt_str!(
+                "44f12e6e59232e9909d7428b913b3cc8d9059458e5027740a3ccdbdc4b1ffd2",
+                16
+            )
+        );
+    }
+
+    #[test]
+    fn test_compute_casm_class_hash_factorial() {
+        // Open the file in read-only mode with buffer.
+        let file = File::open("starknet_programs/cairo1/factorial.casm").unwrap();
+        let reader = BufReader::new(file);
+
+        // Read the JSON contents of the file as an instance of `User`.
+        let contract_class: CasmContractClass = serde_json::from_reader(reader).unwrap();
+
+        assert_eq!(
+            compute_casm_class_hash(&contract_class).unwrap(),
+            felt_str!(
+                "189a9b8b852aedbb225aa28dce9cfc3133145dd623e2d2ca5e962b7d4e61e15",
+                16
+            )
+        );
+    }
+
+    #[test]
+    fn test_compute_casm_class_hash_emit_event() {
+        // Open the file in read-only mode with buffer.
+        let file = File::open("starknet_programs/cairo1/emit_event.casm").unwrap();
+        let reader = BufReader::new(file);
+
+        // Read the JSON contents of the file as an instance of `User`.
+        let contract_class: CasmContractClass = serde_json::from_reader(reader).unwrap();
+
+        assert_eq!(
+            compute_casm_class_hash(&contract_class).unwrap(),
+            felt_str!(
+                "3335fe731ceda1116eda8bbc2e282953ce54618309ad474189e627c59328fff",
+                16
+            )
+        );
+    }
+}

--- a/src/core/contract_address/mod.rs
+++ b/src/core/contract_address/mod.rs
@@ -1,6 +1,8 @@
+mod casm_contract_address;
 mod deprecated_contract_address;
 mod sierra_contract_address;
 
+pub use casm_contract_address::compute_casm_class_hash;
 pub use deprecated_contract_address::compute_deprecated_class_hash;
 pub(crate) use deprecated_contract_address::compute_hinted_class_hash;
 pub use sierra_contract_address::compute_sierra_class_hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -836,7 +836,7 @@ mod test {
             tx_type: TransactionType::Declare,
             validate_entry_point_selector: VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone(),
             version: 1.into(),
-            max_fee: 2,
+            max_fee: 100_000_000,
             signature: vec![],
             nonce: 0.into(),
             hash_value: 0.into(),
@@ -997,5 +997,19 @@ mod test {
             estimate_fee(&[deploy, invoke_tx], state, block_context,).unwrap(),
             [(0, 1224), (0, 0)]
         );
+    }
+
+    #[test]
+    fn test_declare_v2_with_invalid_compiled_clas_hash() {
+        let (block_context, mut state) = create_account_tx_test_state().unwrap();
+        let mut declare_v2 = declarev2_tx();
+        declare_v2.compiled_class_hash = Felt252::from(1);
+        let declare_tx = Transaction::DeclareV2(Box::new(declare_v2));
+
+        let err = declare_tx
+            .execute(&mut state, &block_context, 100_000_000)
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Invalid compiled class, expected class hash: \"1948962768849191111780391610229754715773924969841143100991524171924131413970\", but received: \"1\"".to_string());
     }
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -41,7 +41,7 @@ lazy_static! {
     pub static ref TEST_CLASS_HASH: Felt252 = felt_str!("272");
     pub static ref TEST_EMPTY_CONTRACT_CLASS_HASH: Felt252 = felt_str!("274");
     pub static ref TEST_ERC20_CONTRACT_CLASS_HASH: Felt252 = felt_str!("4112");
-    pub static ref TEST_FIB_COMPILED_CONTRACT_CLASS_HASH: Felt252 = felt_str!("27727");
+    pub static ref TEST_FIB_COMPILED_CONTRACT_CLASS_HASH: Felt252 = felt_str!("1948962768849191111780391610229754715773924969841143100991524171924131413970");
 
     // Storage keys.
     pub static ref TEST_ERC20_ACCOUNT_BALANCE_KEY: Felt252 =

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -399,7 +399,7 @@ mod tests {
     use std::{collections::HashMap, fs::File, io::BufReader, path::PathBuf};
 
     use super::DeclareV2;
-    use crate::core::contract_address::compute_sierra_class_hash;
+    use crate::core::contract_address::{compute_casm_class_hash, compute_sierra_class_hash};
     use crate::services::api::contract_classes::compiled_class::CompiledClass;
     use crate::state::state_api::StateReader;
     use crate::{
@@ -407,7 +407,7 @@ mod tests {
         utils::Address,
     };
     use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-    use cairo_vm::felt::{Felt252, felt_str};
+    use cairo_vm::felt::Felt252;
     use num_traits::{One, Zero};
 
     #[test]
@@ -433,13 +433,16 @@ mod tests {
             serde_json::from_reader(reader).unwrap();
         let sierra_class_hash = compute_sierra_class_hash(&sierra_contract_class).unwrap();
         let sender_address = Address(1.into());
+        let casm_class =
+            CasmContractClass::from_contract_class(sierra_contract_class.clone(), true).unwrap();
+        let casm_class_hash = compute_casm_class_hash(&casm_class).unwrap();
 
         // create internal declare v2
 
         let internal_declare = DeclareV2::new_with_tx_hash(
             &sierra_contract_class,
             Some(sierra_class_hash),
-            felt_str!("1948962768849191111780391610229754715773924969841143100991524171924131413970"),
+            casm_class_hash,
             sender_address,
             0,
             version,

--- a/src/transaction/error.rs
+++ b/src/transaction/error.rs
@@ -135,4 +135,6 @@ pub enum TransactionError {
     CallInfoIsNone,
     #[error("Unsupported version {0:?}")]
     UnsupportedVersion(String),
+    #[error("Invalid compiled class, expected class hash: {0:?}, but received: {1:?}")]
+    InvalidCompiledClassHash(String, String),
 }

--- a/starknet_programs/cairo1/fibonacci_dispatcher.cairo
+++ b/starknet_programs/cairo1/fibonacci_dispatcher.cairo
@@ -42,7 +42,8 @@ mod Dispatcher {
         class_hash: felt252, selector: felt252, a: felt252, b: felt252, n: felt252
     ) -> felt252 {
         FibonacciLibraryDispatcher {
-            class_hash: starknet::class_hash_const::<27727>(),
+            // THIS VALUE IS THE HASH OF THE FIBONACCI CASM CLASS HASH. THE SAME AS THE CONSTANT: TEST_FIB_COMPILED_CONTRACT_CLASS_HASH
+            class_hash: starknet::class_hash_const::<1948962768849191111780391610229754715773924969841143100991524171924131413970>(),
             selector
         }.fib(a, b, n)
     }

--- a/starknet_programs/cairo2/fibonacci_dispatcher.cairo
+++ b/starknet_programs/cairo2/fibonacci_dispatcher.cairo
@@ -51,7 +51,8 @@ mod Dispatcher {
             self: @ContractState, class_hash: felt252, selector: felt252, a: felt252, b: felt252, n: felt252
         ) -> felt252 {
             FibonacciLibraryDispatcher {
-                class_hash: starknet::class_hash_const::<27727>(),
+                // THIS VALUE IS THE HASH OF THE FIBONACCI CASM CLASS HASH.
+                class_hash: starknet::class_hash_const::<2889767417435368609058888822622483550637539736178264636938129582300971548553>(),
                 selector
             }.fib(a, b, n)
         }

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -12,7 +12,9 @@ use cairo_vm::vm::{
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Num, One, Zero};
-use starknet_in_rust::core::contract_address::compute_sierra_class_hash;
+use starknet_in_rust::core::contract_address::{
+    compute_casm_class_hash, compute_sierra_class_hash,
+};
 use starknet_in_rust::core::errors::state_errors::StateError;
 use starknet_in_rust::definitions::constants::{
     DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS, VALIDATE_ENTRY_POINT_SELECTOR,
@@ -74,7 +76,8 @@ lazy_static! {
     static ref TEST_CLASS_HASH: Felt252 = felt_str!("272");
     static ref TEST_EMPTY_CONTRACT_CLASS_HASH: Felt252 = felt_str!("274");
     static ref TEST_ERC20_CONTRACT_CLASS_HASH: Felt252 = felt_str!("4112");
-    static ref TEST_FIB_COMPILED_CONTRACT_CLASS_HASH: Felt252 = felt_str!("1948962768849191111780391610229754715773924969841143100991524171924131413970");
+    static ref TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1: Felt252 = felt_str!("1948962768849191111780391610229754715773924969841143100991524171924131413970");
+    static ref TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2: Felt252 = felt_str!("2889767417435368609058888822622483550637539736178264636938129582300971548553");
 
     // Storage keys.
     // NOTE: this key corresponds to the lower 128 bits of an U256
@@ -699,6 +702,9 @@ fn declarev2_tx() -> DeclareV2 {
     let program_data = include_bytes!("../starknet_programs/cairo1/fibonacci.sierra");
     let sierra_contract_class: SierraContractClass = serde_json::from_slice(program_data).unwrap();
     let sierra_class_hash = compute_sierra_class_hash(&sierra_contract_class).unwrap();
+    let casm_class =
+        CasmContractClass::from_contract_class(sierra_contract_class.clone(), true).unwrap();
+    let casm_class_hash = compute_casm_class_hash(&casm_class).unwrap();
 
     DeclareV2 {
         sender_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
@@ -709,10 +715,10 @@ fn declarev2_tx() -> DeclareV2 {
         signature: vec![],
         nonce: 0.into(),
         hash_value: 0.into(),
-        compiled_class_hash: TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone(),
+        compiled_class_hash: casm_class_hash,
         sierra_contract_class,
         sierra_class_hash,
-        casm_class: Default::default(),
+        casm_class: casm_class.into(),
         skip_execute: false,
         skip_fee_transfer: false,
         skip_validate: false,
@@ -720,12 +726,21 @@ fn declarev2_tx() -> DeclareV2 {
 }
 
 fn deploy_fib_syscall() -> Deploy {
+    let contract_hash;
+    #[cfg(not(feature = "cairo_1_tests"))]
+    {
+        contract_hash = felt_to_hash(&TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2.clone())
+    }
+    #[cfg(feature = "cairo_1_tests")]
+    {
+        contract_hash = felt_to_hash(&TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1.clone())
+    }
     Deploy {
         hash_value: 0.into(),
         version: 1.into(),
         contract_address: TEST_FIB_CONTRACT_ADDRESS.clone(),
         contract_address_salt: 0.into(),
-        contract_hash: felt_to_hash(&TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone()),
+        contract_hash,
         constructor_calldata: Vec::new(),
         tx_type: TransactionType::Deploy,
         skip_execute: false,
@@ -862,6 +877,15 @@ fn test_declarev2_tx() {
     ]);
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, &block_context).unwrap();
 
+    let contract_hash;
+    #[cfg(not(feature = "cairo_1_tests"))]
+    {
+        contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2.clone();
+    }
+    #[cfg(feature = "cairo_1_tests")]
+    {
+        contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1.clone();
+    }
     let expected_execution_info = TransactionExecutionInfo::new(
         Some(CallInfo {
             call_type: Some(CallType::Call),
@@ -869,7 +893,7 @@ fn test_declarev2_tx() {
             class_hash: Some(felt_to_hash(&TEST_ACCOUNT_CONTRACT_CLASS_HASH)),
             entry_point_selector: Some(VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone()),
             entry_point_type: Some(EntryPointType::External),
-            calldata: vec![TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone()],
+            calldata: vec![contract_hash],
             execution_resources: ExecutionResources {
                 n_steps: 12,
                 ..Default::default()
@@ -943,6 +967,15 @@ fn expected_execute_call_info() -> CallInfo {
 }
 
 fn expected_fib_execute_call_info() -> CallInfo {
+    let contract_hash;
+    #[cfg(not(feature = "cairo_1_tests"))]
+    {
+        contract_hash = felt_to_hash(&TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2.clone());
+    }
+    #[cfg(feature = "cairo_1_tests")]
+    {
+        contract_hash = felt_to_hash(&TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1.clone());
+    }
     CallInfo {
         caller_address: Address(Felt252::zero()),
         call_type: Some(CallType::Call),
@@ -972,7 +1005,7 @@ fn expected_fib_execute_call_info() -> CallInfo {
         internal_calls: vec![CallInfo {
             caller_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
             call_type: Some(CallType::Call),
-            class_hash: Some(felt_to_hash(&TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone())),
+            class_hash: Some(contract_hash),
             entry_point_selector: Some(Felt252::from_bytes_be(&calculate_sn_keccak(b"fib"))),
             entry_point_type: Some(EntryPointType::External),
             calldata: vec![Felt252::from(42), Felt252::from(0), Felt252::from(0)],
@@ -1760,9 +1793,18 @@ fn test_library_call_with_declare_v2() {
         )
     };
 
+    let casm_contract_hash;
+    #[cfg(not(feature = "cairo_1_tests"))]
+    {
+        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2.clone()
+    }
+    #[cfg(feature = "cairo_1_tests")]
+    {
+        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1.clone()
+    }
     // Create an execution entry point
     let calldata = vec![
-        TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone(),
+        casm_contract_hash,
         Felt252::from_bytes_be(&calculate_sn_keccak(b"fib")),
         1.into(),
         1.into(),
@@ -1798,11 +1840,21 @@ fn test_library_call_with_declare_v2() {
         )
         .unwrap();
 
+    let casm_contract_hash;
+    #[cfg(not(feature = "cairo_1_tests"))]
+    {
+        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2.clone()
+    }
+    #[cfg(feature = "cairo_1_tests")]
+    {
+        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1.clone()
+    }
+
     let expected_internal_call_info = CallInfo {
         caller_address: Address(0.into()),
         call_type: Some(CallType::Delegate),
         contract_address: address.clone(),
-        class_hash: Some(TEST_FIB_COMPILED_CONTRACT_CLASS_HASH.clone().to_be_bytes()),
+        class_hash: Some(casm_contract_hash.to_be_bytes()),
         entry_point_selector: Some(external_entrypoint_selector.into()),
         entry_point_type: Some(EntryPointType::External),
         #[cfg(not(feature = "cairo_1_tests"))]

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -74,7 +74,7 @@ lazy_static! {
     static ref TEST_CLASS_HASH: Felt252 = felt_str!("272");
     static ref TEST_EMPTY_CONTRACT_CLASS_HASH: Felt252 = felt_str!("274");
     static ref TEST_ERC20_CONTRACT_CLASS_HASH: Felt252 = felt_str!("4112");
-    static ref TEST_FIB_COMPILED_CONTRACT_CLASS_HASH: Felt252 = felt_str!("27727");
+    static ref TEST_FIB_COMPILED_CONTRACT_CLASS_HASH: Felt252 = felt_str!("1948962768849191111780391610229754715773924969841143100991524171924131413970");
 
     // Storage keys.
     // NOTE: this key corresponds to the lower 128 bits of an U256


### PR DESCRIPTION
## Description

When compiling the casm class in the DeclareV2 we now check if the received casm_class_hash was correct.

Made on top of #814 (DO NOT MERGE UNTIL GET THAT MERGED)
closes #791 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
