### PR TITLE
Fix query version bit flag being unsupported in versions other than 0

### DIFF
--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -29,8 +29,14 @@ pub(crate) const N_STEPS_FEE_WEIGHT: f64 = 0.01;
 pub(crate) const L1_HANDLER_VERSION: u64 = 0;
 
 lazy_static! {
-    pub static ref SUPPORTED_VERSIONS: [Felt252; 4] =
-        [0.into(), 1.into(), 2.into(), QUERY_VERSION_BASE.clone()];
+    pub static ref SUPPORTED_VERSIONS: [Felt252; 6] = [
+        0.into(),
+        1.into(),
+        2.into(),
+        &0.into() | &QUERY_VERSION_BASE.clone(),
+        &1.into() | &QUERY_VERSION_BASE.clone(),
+        &2.into() | &QUERY_VERSION_BASE.clone(),
+    ];
 }
 
 lazy_static! {

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -537,13 +537,13 @@ mod tests {
         let path;
         #[cfg(not(feature = "cairo_1_tests"))]
         {
-            version = QUERY_VERSION_BASE.clone();
+            version = &2.into() | &QUERY_VERSION_BASE.clone();
             path = PathBuf::from("starknet_programs/cairo2/fibonacci.sierra");
         }
 
         #[cfg(feature = "cairo_1_tests")]
         {
-            version = QUERY_VERSION_BASE.clone();
+            version = &1.into() | &QUERY_VERSION_BASE.clone();
             path = PathBuf::from("starknet_programs/cairo1/fibonacci.sierra");
         }
 

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -1055,7 +1055,7 @@ mod tests {
     }
 
     #[test]
-    fn invoke_version_one_with_no_nonce_with_query_base() {
+    fn invoke_version_one_with_no_nonce_with_query_base_should_fail() {
         let expected_error = preprocess_invoke_function_fields(
             Felt252::from_str_radix(
                 "112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9",
@@ -1063,8 +1063,8 @@ mod tests {
             )
             .unwrap(),
             None,
-            QUERY_VERSION_BASE.clone(),
+            &1.into() | &QUERY_VERSION_BASE.clone(),
         );
-        assert!(expected_error.is_ok());
+        assert!(expected_error.is_err());
     }
 }

--- a/src/transaction/verify_version.rs
+++ b/src/transaction/verify_version.rs
@@ -31,7 +31,8 @@ pub fn verify_version(
 
 #[cfg(test)]
 mod test {
-    use crate::transaction::error::TransactionError;
+    // TODO: fixture tests would be better here
+    use crate::{definitions::constants::QUERY_VERSION_BASE, transaction::error::TransactionError};
 
     use super::verify_version;
 
@@ -103,5 +104,36 @@ mod test {
         let signature = vec![2.into()];
         let result = verify_version(&version, max_fee, &nonce, &signature).unwrap_err();
         assert_matches!(result, TransactionError::InvalidSignature);
+    }
+
+    #[test]
+    fn version_0_with_max_fee_0_nonce_0_and_empty_signature_and_query_version_set_should_return_ok()
+    {
+        let version = &0.into() | &QUERY_VERSION_BASE.clone();
+        let max_fee = 0;
+        let nonce = 0.into();
+        let signature = vec![];
+        let result = verify_version(&version, max_fee, &nonce, &signature);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn version_1_with_query_version_set_should_return_ok() {
+        let version = &1.into() | &QUERY_VERSION_BASE.clone();
+        let max_fee = 2;
+        let nonce = 3.into();
+        let signature = vec![5.into()];
+        let result = verify_version(&version, max_fee, &nonce, &signature);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn version_2_with_query_version_set_should_return_ok() {
+        let version = &2.into() | &QUERY_VERSION_BASE.clone();
+        let max_fee = 43;
+        let nonce = 4.into();
+        let signature = vec![6.into()];
+        let result = verify_version(&version, max_fee, &nonce, &signature);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
# Fix query version bit flag being unsupported in versions other than 0

## Description

Closes #824. Versions other than 0 using the bit flag were not being supported or taken into account.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
