### PR TITLE
chore: implement `Display` instead of `ToString`

### DIFF
--- a/src/definitions/block_context.rs
+++ b/src/definitions/block_context.rs
@@ -1,5 +1,6 @@
 use crate::{state::BlockInfo, utils::Address};
 use cairo_vm::felt::Felt252;
+use core::fmt;
 use getset::{CopyGetters, Getters, MutGetters};
 use starknet_api::block::Block;
 use std::collections::HashMap;
@@ -17,8 +18,8 @@ pub enum StarknetChainId {
     TestNet2,
 }
 
-impl core::fmt::Display for StarknetChainId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for StarknetChainId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             StarknetChainId::MainNet => write!(f, "SN_MAIN"),
             StarknetChainId::TestNet => write!(f, "SN_GOERLI"),

--- a/src/definitions/block_context.rs
+++ b/src/definitions/block_context.rs
@@ -17,14 +17,13 @@ pub enum StarknetChainId {
     TestNet2,
 }
 
-impl ToString for StarknetChainId {
-    fn to_string(&self) -> String {
+impl core::fmt::Display for StarknetChainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StarknetChainId::MainNet => "SN_MAIN",
-            StarknetChainId::TestNet => "SN_GOERLI",
-            StarknetChainId::TestNet2 => "SN_GOERLI2",
+            StarknetChainId::MainNet => write!(f, "SN_MAIN"),
+            StarknetChainId::TestNet => write!(f, "SN_GOERLI"),
+            StarknetChainId::TestNet2 => write!(f, "SN_GOERLI2"),
         }
-        .to_string()
     }
 }
 


### PR DESCRIPTION
## Description

This PR replaces `StarknetChainId`'s `ToString` impl with a `Display` impl. From the [standard library documentation](https://doc.rust-lang.org/std/string/trait.ToString.html):

> This trait is automatically implemented for any type which implements the `Display` trait. As such, `ToString` shouldn't be implemented directly: `Display` should be implemented instead, and you get the `ToString` implementation for free.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
