### PR TITLE
ci: run doctests in CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -76,6 +76,8 @@ jobs:
       run: make deps
     - name: Run tests
       run: make test
+    - name: Run doctests
+      run: cargo test --workspace --doc
 
   # 28.06.2023: This job uses unmaintained actions-rs because dtolnay is giving linking errors with nightly
   coverage:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -34,7 +34,7 @@ jobs:
       run: make build
 
   format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -57,7 +57,7 @@ jobs:
       run: make clippy
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -81,7 +81,7 @@ jobs:
 
   # 28.06.2023: This job uses unmaintained actions-rs because dtolnay is giving linking errors with nightly
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,6 @@ test: compile-cairo compile-starknet $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_
 	cargo test --workspace --all-targets --features=cairo_1_tests
 	echo "Cairo2 tests"
 	cargo test --workspace --all-targets
-	echo "doctests"
-	cargo test --workspace --doc
 
 coverage: compile-cairo compile-starknet compile-abi $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_2_COMPILED_CASM_CONTRACTS)
 	cargo +nightly llvm-cov --ignore-filename-regex 'main.rs' --release

--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,11 @@ clippy: compile-cairo compile-starknet $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIR
 
 test: compile-cairo compile-starknet $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_1_COMPILED_SIERRA_CONTRACTS) $(CAIRO_2_COMPILED_CASM_CONTRACTS) $(CAIRO_2_COMPILED_SIERRA_CONTRACTS)
 	echo "Cairo1 tests"
-	cargo test --release --workspace --all-targets --features=cairo_1_tests
+	cargo test --workspace --all-targets --features=cairo_1_tests
 	echo "Cairo2 tests"
-	cargo test --release --workspace --all-targets
+	cargo test --workspace --all-targets
 	echo "doctests"
-	cargo test --release --workspace --doc
+	cargo test --workspace --doc
 
 coverage: compile-cairo compile-starknet compile-abi $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_2_COMPILED_CASM_CONTRACTS)
 	cargo +nightly llvm-cov --ignore-filename-regex 'main.rs' --release

--- a/Makefile
+++ b/Makefile
@@ -129,10 +129,10 @@ $(cairo-repo-2-dir):
 # =================
 
 build: compile-cairo compile-starknet
-	cargo build --release --all
+	cargo build --release --workspace
 
 check: compile-cairo compile-starknet
-	cargo check --all --all-targets
+	cargo check --workspace --all-targets
 
 deps: check-python-version build-cairo-2-compiler build-cairo-1-compiler
 	cargo install flamegraph --version 0.6.2
@@ -163,15 +163,15 @@ clean:
 	-rm -rf cairo-1.1.1.tar
 
 clippy: compile-cairo compile-starknet $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_2_COMPILED_CASM_CONTRACTS)
-	cargo clippy --all --all-targets -- -D warnings
+	cargo clippy --workspace --all-targets -- -D warnings
 
 test: compile-cairo compile-starknet $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_1_COMPILED_SIERRA_CONTRACTS) $(CAIRO_2_COMPILED_CASM_CONTRACTS) $(CAIRO_2_COMPILED_SIERRA_CONTRACTS)
 	echo "Cairo1 tests"
-	cargo test --release --all --all-targets --features=cairo_1_tests
+	cargo test --release --workspace --all-targets --features=cairo_1_tests
 	echo "Cairo2 tests"
-	cargo test --release --all --all-targets
+	cargo test --release --workspace --all-targets
 	echo "doctests"
-	cargo test --release --all --doc
+	cargo test --release --workspace --doc
 
 coverage: compile-cairo compile-starknet compile-abi $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_2_COMPILED_CASM_CONTRACTS)
 	cargo +nightly llvm-cov --ignore-filename-regex 'main.rs' --release

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,8 @@ test: compile-cairo compile-starknet $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_
 	cargo test --release --all --all-targets --features=cairo_1_tests
 	echo "Cairo2 tests"
 	cargo test --release --all --all-targets
+	echo "doctests"
+	cargo test --release --all --doc
 
 coverage: compile-cairo compile-starknet compile-abi $(CAIRO_1_COMPILED_CASM_CONTRACTS) $(CAIRO_2_COMPILED_CASM_CONTRACTS)
 	cargo +nightly llvm-cov --ignore-filename-regex 'main.rs' --release

--- a/src/hash_utils.rs
+++ b/src/hash_utils.rs
@@ -34,7 +34,7 @@ use std::vec;
 /// # Examples
 ///
 /// ```
-/// use starknet_in_rust::{hash_utils::calculate_contract_address, utils::Address, Felt252};
+/// use starknet_in_rust::{hash_utils::calculate_contract_address, utils::Address, felt::Felt252};
 ///
 /// let salt = Felt252::from(123_u16);
 /// let class_hash = Felt252::from(456_u16);
@@ -92,7 +92,7 @@ pub fn calculate_contract_address(
 /// # Examples
 ///
 /// ```
-/// use starknet_in_rust::Felt252;
+/// use starknet_in_rust::felt::Felt252;
 /// use starknet_in_rust::hash_utils::compute_hash_on_elements;
 ///
 /// let input_vec = vec![


### PR DESCRIPTION
## Description

Since we are working on the documentation, I think it's time to add this. Note that the `--all-targets` flag [doesn't include this one](https://github.com/rust-lang/cargo/issues/6669), and so it results in this confusion. As one commenter said:

> Oh god, I think we've been not running doc tests on our CI for a couple of years due to this...

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
