### PR TITLE
Fix actual_fee calculation for v0

### DIFF
--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -1,5 +1,5 @@
 use super::error::TransactionError;
-use crate::definitions::constants::FEE_FACTOR;
+use crate::definitions::constants::{FEE_FACTOR, QUERY_VERSION_BASE};
 use crate::execution::execution_entry_point::ExecutionResult;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
 use crate::state::cached_state::CachedState;
@@ -153,7 +153,9 @@ pub fn charge_fee<S: StateReader>(
         block_context,
     )?;
 
-    let actual_fee = if tx_execution_context.version != 0.into() {
+    let actual_fee = if tx_execution_context.version != 0.into()
+        && tx_execution_context.version != *QUERY_VERSION_BASE
+    {
         min(actual_fee, max_fee) * FEE_FACTOR
     } else {
         if actual_fee > max_fee {

--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -152,7 +152,12 @@ pub fn charge_fee<S: StateReader>(
         block_context.starknet_os_config.gas_price,
         block_context,
     )?;
-    let actual_fee = min(actual_fee, max_fee) * FEE_FACTOR;
+
+    let actual_fee = if tx_execution_context.version != 0.into() {
+        min(actual_fee, max_fee) * FEE_FACTOR
+    } else {
+        actual_fee
+    };
 
     let fee_transfer_info = if skip_fee_transfer {
         None

--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -156,6 +156,11 @@ pub fn charge_fee<S: StateReader>(
     let actual_fee = if tx_execution_context.version != 0.into() {
         min(actual_fee, max_fee) * FEE_FACTOR
     } else {
+        if actual_fee > max_fee {
+            return Err(TransactionError::ActualFeeExceedsMaxFee(
+                actual_fee, max_fee,
+            ));
+        }
         actual_fee
     };
 

--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -217,8 +217,10 @@ mod tests {
     #[test]
     fn test_charge_fee_v1_actual_fee_exceeds_max_fee_should_return_max_fee() {
         let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
-        let mut tx_execution_context = TransactionExecutionContext::default();
-        tx_execution_context.version = 1.into();
+        let mut tx_execution_context = TransactionExecutionContext {
+            version: 1.into(),
+            ..Default::default()
+        };
         let mut block_context = BlockContext::default();
         block_context.starknet_os_config.gas_price = 1;
         let resources = HashMap::from([


### PR DESCRIPTION
# Fix actual_fee calculation for v0

## Description

The `min(actual_fee, max_fee) * FEE_FACTOR` shouldn't be calculated for v0