### PR TITLE
use Felt252 for chain ids

### DIFF
--- a/src/bin/invoke_with_cachedstate.rs
+++ b/src/bin/invoke_with_cachedstate.rs
@@ -117,7 +117,11 @@ fn create_initial_state() -> CachedState<InMemoryStateReader> {
 
 pub fn new_starknet_block_context_for_testing() -> BlockContext {
     BlockContext::new(
-        StarknetOsConfig::new(StarknetChainId::TestNet, Address(Felt252::zero()), 0),
+        StarknetOsConfig::new(
+            StarknetChainId::TestNet.to_felt(),
+            Address(Felt252::zero()),
+            0,
+        ),
         0,
         0,
         Default::default(),

--- a/src/definitions/block_context.rs
+++ b/src/definitions/block_context.rs
@@ -68,7 +68,7 @@ impl StarknetChainId {
 pub struct StarknetOsConfig {
     /// ID of the configured chain
     #[getset(get = "pub", get_mut = "pub")]
-    pub(crate) chain_id: StarknetChainId,
+    pub(crate) chain_id: Felt252,
     /// Address of the token used when paying fees
     #[get = "pub"]
     pub(crate) fee_token_address: Address,
@@ -81,10 +81,10 @@ impl StarknetOsConfig {
     ///
     /// # Arguments
     ///
-    /// * `chain_id` - [`StarknetChainId`] of the configured chain.
+    /// * `chain_id` - [`Felt252`] of the configured chain.
     /// * `fee_token_address` - Address of the token used when paying fees.
     /// * `gas_price` - Price of gas.
-    pub fn new(chain_id: StarknetChainId, fee_token_address: Address, gas_price: u128) -> Self {
+    pub fn new(chain_id: Felt252, fee_token_address: Address, gas_price: u128) -> Self {
         StarknetOsConfig {
             chain_id,
             fee_token_address,

--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -62,7 +62,7 @@ lazy_static! {
         16
     ));
     pub static ref DEFAULT_STARKNET_OS_CONFIG: StarknetOsConfig = StarknetOsConfig {
-        chain_id: StarknetChainId::TestNet,
+        chain_id: StarknetChainId::TestNet.to_felt(),
         fee_token_address: Address(felt_str!(
             "4c07059285c2607d528a4c5220ef1f64d8f01273c23cfd9dec68759f61b544",
             16

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -5,10 +5,7 @@ pub mod os_usage;
 use crate::definitions::constants::QUERY_VERSION_BASE;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
 use crate::{
-    definitions::{
-        block_context::StarknetChainId, constants::CONSTRUCTOR_ENTRY_POINT_SELECTOR,
-        transaction_type::TransactionType,
-    },
+    definitions::{constants::CONSTRUCTOR_ENTRY_POINT_SELECTOR, transaction_type::TransactionType},
     state::state_cache::StorageEntry,
     syscalls::syscall_handler_errors::SyscallHandlerError,
     transaction::error::TransactionError,
@@ -370,7 +367,7 @@ impl TxInfoStruct {
     pub(crate) fn new(
         tx: TransactionExecutionContext,
         signature: Relocatable,
-        chain_id: StarknetChainId,
+        chain_id: Felt252,
     ) -> TxInfoStruct {
         TxInfoStruct {
             version: tx.version,
@@ -379,7 +376,7 @@ impl TxInfoStruct {
             signature_len: tx.signature.len(),
             signature,
             transaction_hash: tx.transaction_hash,
-            chain_id: chain_id.to_felt(),
+            chain_id,
             nonce: tx.nonce,
         }
     }

--- a/src/syscalls/business_logic_syscall_handler.rs
+++ b/src/syscalls/business_logic_syscall_handler.rs
@@ -644,7 +644,7 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
         res_segment = (res_segment + 1)?;
         vm.insert_value::<Felt252>(
             res_segment,
-            self.block_context.starknet_os_config.chain_id.to_felt(),
+            self.block_context.starknet_os_config.chain_id.clone(),
         )?;
         res_segment = (res_segment + 1)?;
         vm.insert_value::<Felt252>(res_segment, tx_info.nonce.clone())?;

--- a/src/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -554,7 +554,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
         let tx_info = TxInfoStruct::new(
             tx,
             signature,
-            self.block_context.starknet_os_config.chain_id,
+            self.block_context.starknet_os_config.chain_id.clone(),
         );
 
         let tx_info_ptr_temp = self.allocate_segment(vm, tx_info.to_vec())?;

--- a/src/syscalls/deprecated_syscall_handler.rs
+++ b/src/syscalls/deprecated_syscall_handler.rs
@@ -538,8 +538,7 @@ mod tests {
                 .syscall_handler
                 .block_context
                 .starknet_os_config
-                .chain_id
-                .to_felt());
+                .chain_id);
 
         assert_matches!(
             get_big_int(&vm, relocatable!(4, 7)),

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -64,7 +64,7 @@ lazy_static! {
 pub fn new_starknet_block_context_for_testing() -> BlockContext {
     BlockContext::new(
         StarknetOsConfig::new(
-            StarknetChainId::TestNet,
+            StarknetChainId::TestNet.to_felt(),
             TEST_ERC20_CONTRACT_ADDRESS.clone(),
             1,
         ),

--- a/src/testing/state.rs
+++ b/src/testing/state.rs
@@ -180,7 +180,7 @@ impl StarknetState {
         hash_value: Option<Felt252>,
         remaining_gas: u128,
     ) -> Result<(Address, TransactionExecutionInfo), StarknetStateError> {
-        let chain_id = self.block_context.starknet_os_config.chain_id.to_felt();
+        let chain_id = self.block_context.starknet_os_config.chain_id.clone();
         let deploy = match hash_value {
             None => Deploy::new(
                 contract_address_salt,
@@ -266,7 +266,7 @@ impl StarknetState {
     // ------------------------
 
     fn chain_id(&self) -> Felt252 {
-        self.block_context.starknet_os_config.chain_id.to_felt()
+        self.block_context.starknet_os_config.chain_id.clone()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -102,7 +102,7 @@ lazy_static! {
 pub fn new_starknet_block_context_for_testing() -> BlockContext {
     BlockContext::new(
         StarknetOsConfig::new(
-            StarknetChainId::TestNet,
+            StarknetChainId::TestNet.to_felt(),
             TEST_ERC20_CONTRACT_ADDRESS.clone(),
             *GAS_PRICE,
         ),

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -488,10 +488,10 @@ fn get_tx_info_syscall() {
                max_fee,
                signature: Vec<Felt252>,
                transaction_hash: Felt252,
-               chain_id,
+               chain_id: Felt252,
                execution_resources: ExecutionResources| {
         let mut block_context = BlockContext::default();
-        *block_context.starknet_os_config_mut().chain_id_mut() = chain_id;
+        *block_context.starknet_os_config_mut().chain_id_mut() = chain_id.clone();
 
         let n_steps = block_context.invoke_tx_max_n_steps();
         test_contract(
@@ -527,7 +527,7 @@ fn get_tx_info_syscall() {
                     .reduce(|a, b| a + b)
                     .unwrap_or_default(),
                 transaction_hash,
-                chain_id.to_felt(),
+                chain_id,
             ],
             execution_resources,
         );
@@ -539,7 +539,7 @@ fn get_tx_info_syscall() {
         12,
         vec![],
         0.into(),
-        StarknetChainId::TestNet,
+        StarknetChainId::TestNet.to_felt(),
         ExecutionResources {
             n_steps: 49,
             ..Default::default()
@@ -551,7 +551,7 @@ fn get_tx_info_syscall() {
         12,
         vec![],
         0.into(),
-        StarknetChainId::TestNet,
+        StarknetChainId::TestNet.to_felt(),
         ExecutionResources {
             n_steps: 49,
             ..Default::default()
@@ -563,7 +563,7 @@ fn get_tx_info_syscall() {
         12,
         vec![],
         0.into(),
-        StarknetChainId::TestNet,
+        StarknetChainId::TestNet.to_felt(),
         ExecutionResources {
             n_steps: 49,
             ..Default::default()
@@ -575,7 +575,7 @@ fn get_tx_info_syscall() {
         50,
         vec![],
         0.into(),
-        StarknetChainId::TestNet,
+        StarknetChainId::TestNet.to_felt(),
         ExecutionResources {
             n_steps: 49,
             ..Default::default()
@@ -587,7 +587,7 @@ fn get_tx_info_syscall() {
         50,
         [0x12, 0x34, 0x56, 0x78].map(Felt252::from).to_vec(),
         0.into(),
-        StarknetChainId::TestNet,
+        StarknetChainId::TestNet.to_felt(),
         ExecutionResources {
             n_steps: 77,
             ..Default::default()
@@ -599,7 +599,7 @@ fn get_tx_info_syscall() {
         50,
         [0x12, 0x34, 0x56, 0x78].map(Felt252::from).to_vec(),
         12345678.into(),
-        StarknetChainId::TestNet,
+        StarknetChainId::TestNet.to_felt(),
         ExecutionResources {
             n_steps: 77,
             ..Default::default()
@@ -611,7 +611,7 @@ fn get_tx_info_syscall() {
         50,
         [0x12, 0x34, 0x56, 0x78].map(Felt252::from).to_vec(),
         12345678.into(),
-        StarknetChainId::TestNet2,
+        StarknetChainId::TestNet2.to_felt(),
         ExecutionResources {
             n_steps: 77,
             ..Default::default()


### PR DESCRIPTION
## Description

Change chain_id type to `Felt252`, allowing custom chains.

Closes #844 

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
