### PR TITLE
Remove unused field in BlockInfo

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -32,8 +32,6 @@ pub struct BlockInfo {
     pub gas_price: u64,
     /// The sequencer address of this block.
     pub sequencer_address: Address,
-    /// The version of StarkNet system (e.g. "0.10.3").
-    pub starknet_version: String,
 }
 
 impl BlockInfo {
@@ -43,7 +41,6 @@ impl BlockInfo {
             block_timestamp: 0,
             gas_price: 0,
             sequencer_address,
-            starknet_version: "0.0.0".to_string(),
         }
     }
 
@@ -70,7 +67,6 @@ impl Default for BlockInfo {
             block_timestamp: 0,
             gas_price: 0,
             sequencer_address: Address(0.into()),
-            starknet_version: "0.0.0".to_string(),
         }
     }
 }

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -1518,7 +1518,6 @@ fn run_rabbitx_withdraw() {
     // https://starkscan.co/tx/0x0568988e97ba4be44fd345421a61026b64a2e759bd8a2c6568b6af97d8e91b29
     let mut context = BlockContext::default();
     context.block_info_mut().block_number = 68422;
-    context.block_info_mut().starknet_version = "0.11.2".to_owned();
 
     let class_hash = felt_to_hash(&felt_str!(
         "36e5b6081df2174189fb83800d2a09132286dcd1004ad960a0c8d69364e6e9a",


### PR DESCRIPTION
## Description

Remove `starknet_version` field from `BlockInfo` since it was unused. Checked with `cairo-lang` and it was unused there too.

closes #845 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
