### PR TITLE
ci: split test running into multiple jobs

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -323,14 +323,14 @@ jobs:
         cache-on-failure: true
 
     - name: Cache coverage report
-      id: report-cache
-      uses: actions/cache@v3
+      id: restore-report
+      uses: actions/cache/restore@v3
       with:
         path: lcov.info
         key: coverage-cache-${{ github.sha }}
 
     - name: Fetch programs
-      if: steps.report-cache.outputs.cache-hit != 'true'
+      if: steps.restore-report.outputs.cache-hit != 'true'
       uses: actions/cache/restore@v3
       with:
         path: |
@@ -345,8 +345,15 @@ jobs:
         fail-on-cache-miss: true
 
     - name: Generate coverage report
-      if: steps.report-cache.outputs.cache-hit != 'true'
+      if: steps.restore-report.outputs.cache-hit != 'true'
       run: make coverage-report
+
+    - name: Save coverage report
+      if: steps.restore-report.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: lcov.info
+        key: coverage-cache-${{ github.sha }}
 
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -254,11 +254,12 @@ jobs:
     - name: Run clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
 
-  test:
+  tests:
     strategy:
       fail-fast: false
       matrix:
         target: [ test-cairo-1, test-cairo-2, test-doctests ]
+    name: Run tests
     needs: merge-caches
     runs-on: ubuntu-22.04
     steps:
@@ -299,6 +300,7 @@ jobs:
 
   coverage:
     needs: merge-caches
+    name: Generate and upload coverage report
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -12,28 +12,184 @@ env:
   RUST_TOOLCHAIN: 1.70.0
 
 jobs:
-  build:
+  build-programs:
+    strategy:
+      matrix:
+        # NOTE: we build cairo_proof_programs so clippy can check the benchmarks too
+        program-target: [
+          compile-cairo,
+          compile-starknet,
+          compile-cairo-1-casm,
+          compile-cairo-1-sierra,
+          compile-cairo-2-casm,
+          compile-cairo-2-sierra,
+        ]
+    name: Build Cairo programs
     runs-on: ubuntu-22.04
     steps:
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
-    - uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
-    - name: Deps
-      run: make deps
-    - name: Build
-      run: make build
+        fetch-depth: 0
 
-  format:
+    - name: Fetch from cache
+      uses: actions/cache@v3
+      id: cache-programs
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: ${{ matrix.program-target }}-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        restore-keys: ${{ matrix.program-target }}-cache-
+
+    # This is not pretty, but we need `make` to see the compiled programs are
+    # actually newer than the sources, otherwise it will try to rebuild them
+    - name: Restore timestamps
+      uses: chetan/git-restore-mtime-action@v1
+
+    - name: Python3 Build
+      if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+
+    - name: Install deps
+      if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
+      run: make deps
+
+    - name: Build programs
+      if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
+      run: make -j ${{ matrix.program-target }}
+  
+  merge-caches:
+    name: Merge Cairo programs cache
+    runs-on: ubuntu-22.04
+    needs: build-programs
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Fetch from cache (compile-cairo)
+      uses: actions/cache/restore@v3
+      id: cache-programs
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: compile-cairo-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+    
+    - name: Fetch from cache (compile-starknet)
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: compile-starknet-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+
+    - name: Fetch from cache (compile-cairo-1-casm)
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: compile-cairo-1-casm-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+
+    - name: Fetch from cache (compile-cairo-1-sierra)
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: compile-cairo-1-sierra-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+
+    - name: Fetch from cache (compile-cairo-2-casm)
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: compile-cairo-2-casm-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+
+    - name: Fetch from cache (compile-cairo-2-sierra)
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: compile-cairo-2-sierra-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+
+    - name: Fetch from cache (compile-cairo-2-sierra)
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: compile-cairo-2-sierra-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+    
+    - name: Merge caches
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+
+  build:
+    name: Build with release profile
+    needs: merge-caches
     runs-on: ubuntu-22.04
     steps:
     - name: Install Rust
@@ -46,17 +202,63 @@ jobs:
         cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - name: Fetch programs
+      uses: actions/cache/restore@v3
       with:
-        python-version: '3.9'
-    - name: Deps
-      run: make deps
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+
+    - name: Build
+      run: cargo build --release --workspace
+
+  lint:
+    name: Lint with fmt and clippy
+    needs: merge-caches
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Fetch programs
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+
     - name: Format
       run: cargo fmt --all -- --check
     - name: Run clippy
-      run: make clippy
+      run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ test-cairo-1, test-cairo-2, test-doctests ]
+    needs: merge-caches
     runs-on: ubuntu-22.04
     steps:
     - name: Install Rust
@@ -69,35 +271,61 @@ jobs:
         cache-on-failure: true
     - name: Checkout
       uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-    - name: Deps
-      run: make deps
-    - name: Run tests
-      run: make test
-    - name: Run doctests
-      run: cargo test --workspace --doc
 
-  # 28.06.2023: This job uses unmaintained actions-rs because dtolnay is giving linking errors with nightly
+    - name: Fetch programs
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
+    
+    - name: Install testing tools
+      # TODO: remove `if` when nextest adds doctests support
+      if: ${{ matrix.target != 'test-doctests' }}
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+
+    - name: Run tests (${{ matrix.target }})
+      run: make ${{ matrix.target }}
+
   coverage:
+    needs: merge-caches
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-    - name: Deps
-      run: make deps
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
-        override: true
-        components: rustfmt, clippy
-    - name: Coverage
-      run: make coverage
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+    
+    - name: Set nightly as default
+      run: rustup default nightly
+
+    - name: Install testing tools
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest,cargo-llvm-cov
+    
+    - name: Cache coverage report
+      id: report-cache
+      uses: actions/cache@v3
+      with:
+        path: lcov.info
+        key: coverage-cache-${{ github.sha }}
+
+    - name: Generate coverage report
+      if: steps.report-cache.outputs.cache-hit != 'true'
+      run: make coverage-report
+
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -15,7 +15,6 @@ jobs:
   build-programs:
     strategy:
       matrix:
-        # NOTE: we build cairo_proof_programs so clippy can check the benchmarks too
         program-target: [
           compile-cairo,
           compile-starknet,
@@ -66,7 +65,9 @@ jobs:
     - name: Build programs
       if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
       run: make -j ${{ matrix.program-target }}
-  
+
+  # NOTE: used to reduce the amount of cache steps we need in later jobs
+  # TODO: remove this cache once the workflow finishes
   merge-caches:
     name: Merge Cairo programs cache
     runs-on: ubuntu-22.04

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -309,7 +309,7 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
-    
+
     - name: Set nightly as default
       run: rustup default nightly
 
@@ -317,14 +317,18 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-nextest,cargo-llvm-cov
-    
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+
     - name: Cache coverage report
       id: report-cache
       uses: actions/cache@v3
       with:
         path: lcov.info
         key: coverage-cache-${{ github.sha }}
-    
+
     - name: Fetch programs
       if: steps.report-cache.outputs.cache-hit != 'true'
       uses: actions/cache/restore@v3

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -324,6 +324,21 @@ jobs:
       with:
         path: lcov.info
         key: coverage-cache-${{ github.sha }}
+    
+    - name: Fetch programs
+      if: steps.report-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.casm
+          cairo_programs/**/*.sierra
+          cairo_programs/**/*.json
+          starknet_programs/**/*.casm
+          starknet_programs/**/*.sierra
+          starknet_programs/**/*.json
+          !starknet_programs/raw_contract_classes/*
+        key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'starknet_programs/**/*.cairo') }}
+        fail-on-cache-miss: true
 
     - name: Generate coverage report
       if: steps.report-cache.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -185,8 +185,7 @@ coverage: compile-cairo compile-starknet compile-cairo-1-casm compile-cairo-2-ca
 	$(MAKE) coverage-report
 
 coverage-report:
-	cargo +nightly llvm-cov --ignore-filename-regex 'main.rs' --release
-	cargo +nightly llvm-cov report --lcov --ignore-filename-regex 'main.rs' --output-path lcov.info --release
+	cargo +nightly llvm-cov nextest --lcov --ignore-filename-regex 'main.rs' --output-path lcov.info --release
 
 heaptrack:
 	./scripts/heaptrack.sh

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,7 @@ STARKNET_SIERRA_COMPILE_CAIRO_2:=cairo2/bin/starknet-sierra-compile
 #
 
 deps-venv:
-	pip install \
-		fastecdsa \
-		typeguard==2.13.0 \
-		openzeppelin-cairo-contracts==0.6.1 \
-		maturin \
-		cairo-lang==0.11 \
-		"urllib3 <=1.26.15"
+	pip install -r requirements.txt
 
 compile-cairo: $(CAIRO_TARGETS) $(CAIRO_ABI_TARGETS)
 compile-starknet: $(STARKNET_TARGETS) $(STARKNET_ABI_TARGETS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastecdsa
+typeguard==2.13.3
+cairo-lang==0.11
+urllib3<=1.26.15
+openzeppelin-cairo-contracts==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 fastecdsa
-typeguard==2.13.3
 cairo-lang==0.11
-urllib3<=1.26.15
 openzeppelin-cairo-contracts==0.6.1


### PR DESCRIPTION
## Description

This PR updates the `rust-tests` workflow with improvements taken from the _cairo-vm_ repo. As it also splits the tests into multiple jobs, it should fix the disk usage problem we are having.

Some notable changes:
- added `make` targets for cairo 1 and 2 casm and sierra
- moved python dependencies to a `requirements.txt` file
- removed some pinned python dependencies
- changed actions-rs/toolchain for dtolnay's

Note for future PRs: this didn't split test running when generating coverage reports.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
