### PR TITLE
chore: remove `mimalloc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [features]
 default = ["with_mimalloc"]
-with_mimalloc = ["mimalloc"]
+with_mimalloc = ["dep:mimalloc"]
 cairo_1_tests = []
 
 [workspace]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [features]
 default = ["with_mimalloc"]
-with_mimalloc = ["mimalloc"]
+with_mimalloc = ["dep:mimalloc"]
 
 [dependencies]
 starknet_in_rust = { path = "../", version = "0.3.0" }
 num-traits = "0.2.15"
 serde = { version = "1.0.152", features = ["derive"] }
-cairo-vm = { workspace=true, features = ["cairo-1-hints"]}
+cairo-vm = { workspace = true, features = ["cairo-1-hints"] }
 clap = { version = "4.1.8", features = ["derive"] }
 actix-web = "4.3.1"
 awc = "3.1.1"


### PR DESCRIPTION
## Description

This PR removes the feature `mimalloc` that was created because of marking the dependency as _optional_. Note this doesn't remove the `with_mimalloc` feature.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
