### PR TITLE
Modify errors that are hashing errors to be HashError

### DIFF
--- a/src/core/block_hash/mod.rs
+++ b/src/core/block_hash/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     hash_utils::compute_hash_on_elements, syscalls::syscall_handler_errors::SyscallHandlerError,
 };
+use crate::core::errors::hash_errors::HashError;
 use cairo_vm::felt::Felt252;
 use starknet_crypto::{pedersen_hash, FieldElement};
 use std::iter::zip;
@@ -15,7 +16,7 @@ use std::iter::zip;
 pub fn calculate_tx_hashes_with_signatures(
     tx_hashes: Vec<Felt252>,
     tx_signatures: Vec<Vec<Felt252>>,
-) -> Result<Vec<Felt252>, SyscallHandlerError> {
+) -> Result<Vec<Felt252>, HashError> {
     zip(tx_hashes, tx_signatures)
         .map(|(hash, signature)| calculate_single_tx_hash_with_signature(hash, signature))
         .collect::<Result<Vec<Felt252>, _>>()
@@ -27,14 +28,14 @@ pub fn calculate_tx_hashes_with_signatures(
 pub fn calculate_single_tx_hash_with_signature(
     tx_hash: Felt252,
     tx_signature: Vec<Felt252>,
-) -> Result<Felt252, SyscallHandlerError> {
+) -> Result<Felt252, HashError> {
     let signature_hash = compute_hash_on_elements(&tx_signature)?;
     let signature_str = signature_hash.to_str_radix(10);
     let tx_hash_str = tx_hash.to_str_radix(10);
     let hash = FieldElement::from_dec_str(&tx_hash_str)
-        .map_err(|_| SyscallHandlerError::FailToComputeHash)?;
+        .map_err(|_| HashError::FailToComputeHash)?;
     let signature = FieldElement::from_dec_str(&signature_str)
-        .map_err(|_| SyscallHandlerError::FailToComputeHash)?;
+        .map_err(|_| HashError::FailToComputeHash)?;
     let new_hash = pedersen_hash(&hash, &signature);
     Ok(Felt252::from_bytes_be(&new_hash.to_bytes_be()))
 }
@@ -46,7 +47,7 @@ pub fn calculate_event_hash(
     from_address: Felt252,
     keys: Vec<Felt252>,
     data: Vec<Felt252>,
-) -> Result<Felt252, SyscallHandlerError> {
+) -> Result<Felt252, HashError> {
     let key_hash = compute_hash_on_elements(&keys)?;
     let data_hash = compute_hash_on_elements(&data)?;
     compute_hash_on_elements(&[from_address, key_hash, data_hash])

--- a/src/core/block_hash/starknet_block_hash.rs
+++ b/src/core/block_hash/starknet_block_hash.rs
@@ -1,6 +1,7 @@
 use crate::{
     hash_utils::compute_hash_on_elements, syscalls::syscall_handler_errors::SyscallHandlerError,
 };
+use crate::core::errors::hash_errors::HashError;
 use cairo_vm::felt::Felt252;
 use starknet_crypto::{pedersen_hash, FieldElement};
 use std::iter::zip;
@@ -11,7 +12,7 @@ use std::iter::zip;
 pub fn calculate_tx_hashes_with_signatures(
     tx_hashes: Vec<Felt252>,
     tx_signatures: Vec<Vec<Felt252>>,
-) -> Result<Vec<Felt252>, SyscallHandlerError> {
+) -> Result<Vec<Felt252>, HashError> {
     zip(tx_hashes, tx_signatures)
         .map(|(hash, signature)| calculate_single_tx_hash_with_signature(hash, signature))
         .collect::<Result<Vec<Felt252>, _>>()
@@ -23,14 +24,14 @@ pub fn calculate_tx_hashes_with_signatures(
 pub fn calculate_single_tx_hash_with_signature(
     tx_hash: Felt252,
     tx_signature: Vec<Felt252>,
-) -> Result<Felt252, SyscallHandlerError> {
+) -> Result<Felt252, > {
     let signature_hash = compute_hash_on_elements(&tx_signature)?;
     let signature_str = signature_hash.to_str_radix(10);
     let tx_hash_str = tx_hash.to_str_radix(10);
     let hash = FieldElement::from_dec_str(&tx_hash_str)
-        .map_err(|_| SyscallHandlerError::FailToComputeHash)?;
+        .map_err(|_| HashError::FailToComputeHash)?;
     let signature = FieldElement::from_dec_str(&signature_str)
-        .map_err(|_| SyscallHandlerError::FailToComputeHash)?;
+        .map_err(|_| HashError::FailToComputeHash)?;
     let new_hash = pedersen_hash(&hash, &signature);
     Ok(Felt252::from_bytes_be(&new_hash.to_bytes_be()))
 }
@@ -42,7 +43,7 @@ pub fn calculate_event_hash(
     from_address: Felt252,
     keys: Vec<Felt252>,
     data: Vec<Felt252>,
-) -> Result<Felt252, SyscallHandlerError> {
+) -> Result<Felt252, HashError> {
     let key_hash = compute_hash_on_elements(&keys)?;
     let data_hash = compute_hash_on_elements(&data)?;
     compute_hash_on_elements(&[from_address, key_hash, data_hash])

--- a/src/parser_errors.rs
+++ b/src/parser_errors.rs
@@ -1,6 +1,9 @@
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
 use crate::{
-    core::errors::{contract_address_errors::ContractAddressError, state_errors::StateError},
+    core::errors::{
+        contract_address_errors::ContractAddressError, hash_errors::HashError,
+        state_errors::StateError,
+    },
     syscalls::syscall_handler_errors::SyscallHandlerError,
     transaction::error::TransactionError,
 };
@@ -14,6 +17,8 @@ pub enum ParserError {
     ContractAddress(#[from] ContractAddressError),
     #[error(transparent)]
     Syscall(#[from] SyscallHandlerError),
+    #[error(transparent)]
+    Hashes(#[from] HashError),
     #[error("Failed to convert {0} to Felt")]
     ParseFelt(String),
     #[error("Failed to get entry point for function `{0}`")]

--- a/src/testing/state_error.rs
+++ b/src/testing/state_error.rs
@@ -1,8 +1,8 @@
 use thiserror::Error;
 
 use crate::{
-    core::errors::state_errors::StateError, syscalls::syscall_handler_errors::SyscallHandlerError,
-    transaction::error::TransactionError,
+    core::errors::hash_errors::HashError, core::errors::state_errors::StateError,
+    syscalls::syscall_handler_errors::SyscallHandlerError, transaction::error::TransactionError,
 };
 
 #[derive(Debug, Error)]
@@ -15,4 +15,6 @@ pub enum StarknetStateError {
     State(#[from] StateError),
     #[error(transparent)]
     Transaction(#[from] TransactionError),
+    #[error(transparent)]
+    HashError(#[from] HashError),
 }

--- a/src/transaction/error.rs
+++ b/src/transaction/error.rs
@@ -1,5 +1,8 @@
 use crate::{
-    core::errors::{contract_address_errors::ContractAddressError, state_errors::StateError},
+    core::errors::{
+        contract_address_errors::ContractAddressError, hash_errors::HashError,
+        state_errors::StateError,
+    },
     definitions::transaction_type::TransactionType,
     execution::os_usage::OsResources,
     syscalls::syscall_handler_errors::SyscallHandlerError,
@@ -47,6 +50,8 @@ pub enum TransactionError {
     ContractAddress(#[from] ContractAddressError),
     #[error(transparent)]
     Syscall(#[from] SyscallHandlerError),
+    #[error(transparent)]
+    HashError(#[from] HashError),
     #[error(transparent)]
     State(#[from] StateError),
     #[error("Calling other contracts during validate execution is forbidden")]


### PR DESCRIPTION
# TITLE

## Description

Modify return error when the error is caused by a hash error to be of type HashError 

## Checklist
- [ x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
