### PR TITLE
Add function to simplify tests and test recent txs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub fn simulate_transaction<S: StateReader>(
     skip_execute: bool,
     skip_fee_transfer: bool,
     ignore_max_fee: bool,
+    skip_nonce_check: bool,
 ) -> Result<Vec<TransactionExecutionInfo>, TransactionError> {
     let mut cache_state = CachedState::new(Arc::new(state), None, Some(HashMap::new()));
     let mut result = Vec::with_capacity(transactions.len());
@@ -68,6 +69,7 @@ pub fn simulate_transaction<S: StateReader>(
             skip_execute,
             skip_fee_transfer,
             ignore_max_fee,
+            skip_nonce_check,
         );
         let tx_result =
             tx_for_simulation.execute(&mut cache_state, block_context, remaining_gas)?;
@@ -96,7 +98,7 @@ where
         // execute the transaction with the fake state.
 
         // This is important, since we're interested in the fee estimation even if the account does not currently have sufficient funds.
-        let tx_for_simulation = transaction.create_for_simulation(false, false, true, true);
+        let tx_for_simulation = transaction.create_for_simulation(false, false, true, true, false);
 
         let transaction_result =
             tx_for_simulation.execute(&mut cached_state, block_context, 100_000_000)?;
@@ -431,7 +433,7 @@ mod test {
 
         let block_context = BlockContext::default();
         let Transaction::InvokeFunction(simul_invoke) =
-            invoke.create_for_simulation(true, false, false, false) else {
+            invoke.create_for_simulation(true, false, false, false, false) else {
                 unreachable!()
             };
 
@@ -558,6 +560,7 @@ mod test {
             true,
             true,
             false,
+            false,
         )
         .unwrap();
 
@@ -657,6 +660,7 @@ mod test {
             true,
             true,
             false,
+            false,
         )
         .unwrap();
 
@@ -699,6 +703,7 @@ mod test {
             false,
             false,
             false,
+            false,
         )
         .unwrap();
     }
@@ -731,6 +736,7 @@ mod test {
             state,
             block_context,
             100_000_000,
+            false,
             false,
             false,
             false,
@@ -795,6 +801,7 @@ mod test {
             false,
             false,
             false,
+            false,
         )
         .unwrap();
     }
@@ -830,6 +837,7 @@ mod test {
             state,
             block_context,
             100_000_000,
+            false,
             false,
             false,
             false,
@@ -877,6 +885,7 @@ mod test {
             false,
             false,
             true,
+            false,
             false,
         )
         .unwrap();
@@ -942,6 +951,7 @@ mod test {
             false,
             false,
             false, // won't have any effect
+            false,
         )
         .unwrap();
     }
@@ -994,6 +1004,7 @@ mod test {
             state.clone(),
             block_context,
             100_000_000,
+            false,
             false,
             false,
             false,

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -45,6 +45,7 @@ pub struct InvokeFunction {
     skip_validation: bool,
     skip_execute: bool,
     skip_fee_transfer: bool,
+    skip_nonce_check: bool,
 }
 
 impl InvokeFunction {
@@ -115,6 +116,7 @@ impl InvokeFunction {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         })
     }
 
@@ -274,7 +276,9 @@ impl InvokeFunction {
         block_context: &BlockContext,
         remaining_gas: u128,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
-        self.handle_nonce(state)?;
+        if !self.skip_nonce_check {
+            self.handle_nonce(state)?;
+        }
         let mut tx_exec_info = self.apply(state, block_context, remaining_gas)?;
 
         let mut tx_execution_context =
@@ -301,6 +305,7 @@ impl InvokeFunction {
         let contract_address = self.contract_address();
 
         let current_nonce = state.get_nonce_at(contract_address)?;
+        dbg!(&current_nonce);
         match &self.nonce {
             None => {
                 // TODO: Remove this once we have a better way to handle the nonce.
@@ -327,11 +332,13 @@ impl InvokeFunction {
         skip_execute: bool,
         skip_fee_transfer: bool,
         ignore_max_fee: bool,
+        skip_nonce_check: bool,
     ) -> Transaction {
         let tx = InvokeFunction {
             skip_validation,
             skip_execute,
             skip_fee_transfer,
+            skip_nonce_check,
             max_fee: if ignore_max_fee {
                 u128::MAX
             } else {
@@ -424,6 +431,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -492,6 +500,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -556,6 +565,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -614,6 +624,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -678,6 +689,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -752,6 +764,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         let mut state = CachedState::new(Arc::new(state_reader), None, None);
@@ -792,6 +805,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: true,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -849,6 +863,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -911,6 +926,7 @@ mod tests {
             skip_validation: false,
             skip_execute: false,
             skip_fee_transfer: false,
+            skip_nonce_check: false,
         };
 
         // Instantiate CachedState
@@ -1053,6 +1069,7 @@ mod tests {
             skip_validation: true,
             skip_execute: false,
             skip_fee_transfer: true,
+            skip_nonce_check: false,
         };
 
         let mut state_reader = InMemoryStateReader::default();

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -92,6 +92,7 @@ impl Transaction {
         skip_execute: bool,
         skip_fee_transfer: bool,
         ignore_max_fee: bool,
+        skip_nonce_check: bool,
     ) -> Self {
         match self {
             Transaction::Declare(tx) => tx.create_for_simulation(
@@ -120,6 +121,7 @@ impl Transaction {
                 skip_execute,
                 skip_fee_transfer,
                 ignore_max_fee,
+                skip_nonce_check,
             ),
             Transaction::L1Handler(tx) => tx.create_for_simulation(skip_validate, skip_execute),
         }


### PR DESCRIPTION
# TITLE

## Description

This PR adds the `test_tx` function that encapsulates all the logic to run and get the TransactionExecutionInfo of a transaction using the RPC State Reader.

It also adds several new tests.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
