### PR TITLE
Fix `get_block_info` test.

### DIFF
--- a/rpc_state_reader/src/lib.rs
+++ b/rpc_state_reader/src/lib.rs
@@ -534,7 +534,7 @@ mod tests {
     fn test_get_block_info() {
         let rpc_state = RpcState::new(
             RpcChain::MainNet,
-            BlockValue::Tag(serde_json::to_value("latest").unwrap()),
+            BlockValue::Number(serde_json::to_value(168204).unwrap()),
         );
 
         let gas_price_str = "13563643256";


### PR DESCRIPTION
# Fix `get_block_info` test

## Description

Check out #934.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
