### PR TITLE
Unify deprecated and casm contract caches.

### DIFF
--- a/bench/internals.rs
+++ b/bench/internals.rs
@@ -17,7 +17,7 @@ use starknet_in_rust::{
     transaction::{declare::Declare, Deploy, DeployAccount, InvokeFunction},
     utils::Address,
 };
-use std::{hint::black_box, sync::Arc};
+use std::{collections::HashMap, hint::black_box, sync::Arc};
 
 lazy_static! {
     // include_str! doesn't seem to work in CI
@@ -61,7 +61,7 @@ fn deploy_account() {
     const RUNS: usize = 500;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, Some(Default::default()), None);
+    let mut state = CachedState::new(state_reader, HashMap::new());
 
     state
         .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
@@ -97,7 +97,7 @@ fn declare() {
     const RUNS: usize = 5;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let state = CachedState::new(state_reader, Some(Default::default()), None);
+    let state = CachedState::new(state_reader, HashMap::new());
 
     let block_context = &Default::default();
 
@@ -129,7 +129,7 @@ fn deploy() {
     const RUNS: usize = 8;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, Some(Default::default()), None);
+    let mut state = CachedState::new(state_reader, HashMap::new());
 
     state
         .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
@@ -164,7 +164,7 @@ fn invoke() {
     const RUNS: usize = 100;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, Some(Default::default()), None);
+    let mut state = CachedState::new(state_reader, HashMap::new());
 
     state
         .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)

--- a/bench/internals.rs
+++ b/bench/internals.rs
@@ -11,7 +11,9 @@ use starknet_in_rust::{
         constants::{TRANSACTION_VERSION, VALIDATE_ENTRY_POINT_SELECTOR},
     },
     hash_utils::calculate_contract_address,
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::in_memory_state_reader::InMemoryStateReader,
     state::{cached_state::CachedState, state_api::State},
     transaction::{declare::Declare, Deploy, DeployAccount, InvokeFunction},
@@ -64,7 +66,10 @@ fn deploy_account() {
     let mut state = CachedState::new(state_reader, HashMap::new());
 
     state
-        .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
+        .set_contract_class(
+            &CLASS_HASH_BYTES,
+            &CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+        )
         .unwrap();
 
     let block_context = &Default::default();
@@ -132,7 +137,10 @@ fn deploy() {
     let mut state = CachedState::new(state_reader, HashMap::new());
 
     state
-        .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
+        .set_contract_class(
+            &CLASS_HASH_BYTES,
+            &CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+        )
         .unwrap();
 
     let block_context = &Default::default();
@@ -167,7 +175,10 @@ fn invoke() {
     let mut state = CachedState::new(state_reader, HashMap::new());
 
     state
-        .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
+        .set_contract_class(
+            &CLASS_HASH_BYTES,
+            &CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+        )
         .unwrap();
 
     let block_context = &Default::default();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,7 +23,9 @@ use starknet_in_rust::{
     hash_utils::calculate_contract_address,
     parser_errors::ParserError,
     serde_structs::read_abi,
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::{cached_state::CachedState, state_api::State},
     state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
     transaction::{error::TransactionError, InvokeFunction},
@@ -110,7 +112,10 @@ fn declare_parser(
     let contract_class =
         ContractClass::from_path(&args.contract).map_err(ContractAddressError::Program)?;
     let class_hash = compute_deprecated_class_hash(&contract_class)?;
-    cached_state.set_contract_class(&felt_to_hash(&class_hash), &contract_class)?;
+    cached_state.set_contract_class(
+        &felt_to_hash(&class_hash),
+        &CompiledClass::Deprecated(Arc::new(contract_class.clone())),
+    )?;
 
     let tx_hash = calculate_declare_transaction_hash(
         &contract_class,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -313,8 +313,7 @@ pub async fn start_devnet(port: u16) -> Result<(), std::io::Error> {
     let cached_state = web::Data::new(AppState {
         cached_state: Mutex::new(CachedState::<InMemoryStateReader>::new(
             Arc::new(InMemoryStateReader::default()),
-            Some(HashMap::new()),
-            None,
+            HashMap::new(),
         )),
     });
 

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -25,6 +25,7 @@ use std::{
     path::PathBuf,
 };
 
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use std::fs;
 use std::process::Command;
 use std::thread;
@@ -44,11 +45,11 @@ fn main() {
             let file_content1 = "
             %lang starknet
             from starkware.cairo.common.cairo_builtins import HashBuiltin
-            
+
             @storage_var
             func _counter() -> (res: felt) {
             }
-            
+
             @external
             func write_and_read{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res:felt) {
                 _counter.write('";
@@ -116,7 +117,10 @@ fn main() {
             let address = Address(1111.into());
             let class_hash = [1; 32];
 
-            contract_class_cache.insert(class_hash, contract_class);
+            contract_class_cache.insert(
+                class_hash,
+                CompiledClass::Deprecated(Arc::new(contract_class)),
+            );
             let mut state_reader = InMemoryStateReader::default();
             state_reader
                 .address_to_class_hash_mut()
@@ -126,8 +130,7 @@ fn main() {
             //*    Create state with previous data
             //* ---------------------------------------
 
-            let mut state =
-                CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+            let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
             //* ------------------------------------
             //*    Create execution entry point

--- a/rpc_state_reader/src/lib.rs
+++ b/rpc_state_reader/src/lib.rs
@@ -741,7 +741,7 @@ mod transaction_tests {
         felt::felt_str,
         state::cached_state::CachedState,
     };
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
     fn test_tx(
         tx_hash: &str,
@@ -754,7 +754,7 @@ mod transaction_tests {
         // Instantiate the RPC StateReader and the CachedState
         let block = BlockValue::Number(serde_json::to_value(block_number).unwrap());
         let rpc_state = Arc::new(RpcState::new(network, block));
-        let mut state = CachedState::new(rpc_state.clone(), None, None);
+        let mut state = CachedState::new(rpc_state.clone(), HashMap::new());
 
         let fee_token_address = Address(felt_str!(
             "049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",

--- a/src/bin/fibonacci.rs
+++ b/src/bin/fibonacci.rs
@@ -5,9 +5,13 @@ use num_traits::Zero;
 
 use lazy_static::lazy_static;
 use starknet_in_rust::{
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::cached_state::CachedState, state::in_memory_state_reader::InMemoryStateReader,
-    testing::state::StarknetState, utils::Address,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::cached_state::CachedState,
+    state::in_memory_state_reader::InMemoryStateReader,
+    testing::state::StarknetState,
+    utils::Address,
 };
 
 #[cfg(feature = "with_mimalloc")]
@@ -78,17 +82,17 @@ fn create_initial_state() -> CachedState<InMemoryStateReader> {
             state_reader
                 .address_to_nonce_mut()
                 .insert(CONTRACT_ADDRESS.clone(), Felt252::zero());
-            state_reader
-                .class_hash_to_contract_class_mut()
-                .insert(*CONTRACT_CLASS_HASH, CONTRACT_CLASS.clone());
+            state_reader.class_hash_to_compiled_class_mut().insert(
+                *CONTRACT_CLASS_HASH,
+                CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+            );
 
             state_reader
                 .address_to_storage_mut()
                 .insert((CONTRACT_ADDRESS.clone(), [0; 32]), Felt252::zero());
             Arc::new(state_reader)
         },
-        Some(HashMap::new()),
-        None,
+        HashMap::new(),
     );
 
     cached_state

--- a/src/bin/invoke.rs
+++ b/src/bin/invoke.rs
@@ -4,9 +4,13 @@ use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::Zero;
 
 use starknet_in_rust::{
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::cached_state::CachedState, state::in_memory_state_reader::InMemoryStateReader,
-    testing::state::StarknetState, utils::Address,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::cached_state::CachedState,
+    state::in_memory_state_reader::InMemoryStateReader,
+    testing::state::StarknetState,
+    utils::Address,
 };
 
 use lazy_static::lazy_static;
@@ -92,17 +96,17 @@ fn create_initial_state() -> CachedState<InMemoryStateReader> {
             state_reader
                 .address_to_nonce_mut()
                 .insert(CONTRACT_ADDRESS.clone(), Felt252::zero());
-            state_reader
-                .class_hash_to_contract_class_mut()
-                .insert(*CONTRACT_CLASS_HASH, CONTRACT_CLASS.clone());
+            state_reader.class_hash_to_compiled_class_mut().insert(
+                *CONTRACT_CLASS_HASH,
+                CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+            );
 
             state_reader
                 .address_to_storage_mut()
                 .insert((CONTRACT_ADDRESS.clone(), [0; 32]), Felt252::zero());
             Arc::new(state_reader)
         },
-        Some(HashMap::new()),
-        None,
+        HashMap::new(),
     );
 
     cached_state

--- a/src/bin/invoke_with_cachedstate.rs
+++ b/src/bin/invoke_with_cachedstate.rs
@@ -8,7 +8,9 @@ use starknet_in_rust::{
         block_context::{BlockContext, StarknetChainId, StarknetOsConfig},
         constants::TRANSACTION_VERSION,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::in_memory_state_reader::InMemoryStateReader,
     state::{cached_state::CachedState, BlockInfo},
     transaction::InvokeFunction,
@@ -99,17 +101,17 @@ fn create_initial_state() -> CachedState<InMemoryStateReader> {
             state_reader
                 .address_to_nonce_mut()
                 .insert(CONTRACT_ADDRESS.clone(), Felt252::zero());
-            state_reader
-                .class_hash_to_contract_class_mut()
-                .insert(*CONTRACT_CLASS_HASH, CONTRACT_CLASS.clone());
+            state_reader.class_hash_to_compiled_class_mut().insert(
+                *CONTRACT_CLASS_HASH,
+                CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+            );
 
             state_reader
                 .address_to_storage_mut()
                 .insert((CONTRACT_ADDRESS.clone(), [0; 32]), Felt252::zero());
             Arc::new(state_reader)
         },
-        Some(HashMap::new()),
-        None,
+        HashMap::new(),
     );
 
     cached_state

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -131,7 +131,6 @@ impl ExecutionEntryPoint {
                 let mut tmp_state = CachedState::new(
                     state.state_reader.clone(),
                     state.contract_classes.clone(),
-                    state.casm_contract_classes.clone(),
                 );
                 tmp_state.cache = state.cache.clone();
 

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -128,10 +128,8 @@ impl ExecutionEntryPoint {
                 })
             }
             CompiledClass::Casm(contract_class) => {
-                let mut tmp_state = CachedState::new(
-                    state.state_reader.clone(),
-                    state.contract_classes.clone(),
-                );
+                let mut tmp_state =
+                    CachedState::new(state.state_reader.clone(), state.contract_classes.clone());
                 tmp_state.cache = state.cache.clone();
 
                 match self._execute(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,7 +684,10 @@ mod test {
         let mut state = CachedState::new(state_reader, HashMap::new());
 
         state
-            .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
+            .set_contract_class(
+                &CLASS_HASH_BYTES,
+                &CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+            )
             .unwrap();
 
         let block_context = &Default::default();
@@ -760,7 +763,10 @@ mod test {
         let mut state = CachedState::new(state_reader, HashMap::new());
 
         state
-            .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
+            .set_contract_class(
+                &CLASS_HASH_BYTES,
+                &CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+            )
             .unwrap();
 
         let block_context = Default::default();
@@ -821,7 +827,10 @@ mod test {
         let mut state = CachedState::new(state_reader, HashMap::new());
 
         state
-            .set_contract_class(&CLASS_HASH_BYTES, &CONTRACT_CLASS)
+            .set_contract_class(
+                &CLASS_HASH_BYTES,
+                &CompiledClass::Deprecated(Arc::new(CONTRACT_CLASS.clone())),
+            )
             .unwrap();
 
         let block_context = &Default::default();
@@ -945,7 +954,10 @@ mod test {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let mut block_context = BlockContext::default();

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -16,6 +16,8 @@ use std::{
     sync::Arc,
 };
 
+pub type ContractClassCache = HashMap<ClassHash, CompiledClass>;
+
 pub const UNINITIALIZED_CLASS_HASH: &ClassHash = &[0u8; 32];
 
 /// Represents a cached state of contract classes with optional caches.
@@ -25,12 +27,12 @@ pub struct CachedState<T: StateReader> {
     #[getset(get = "pub", get_mut = "pub")]
     pub(crate) cache: StateCache,
     #[get = "pub"]
-    pub(crate) contract_classes: HashMap<ClassHash, CompiledClass>,
+    pub(crate) contract_classes: ContractClassCache,
 }
 
 impl<T: StateReader> CachedState<T> {
     /// Constructor, creates a new cached state.
-    pub fn new(state_reader: Arc<T>, contract_classes: HashMap<ClassHash, CompiledClass>) -> Self {
+    pub fn new(state_reader: Arc<T>, contract_classes: ContractClassCache) -> Self {
         Self {
             cache: StateCache::default(),
             state_reader,
@@ -42,7 +44,7 @@ impl<T: StateReader> CachedState<T> {
     pub fn new_for_testing(
         state_reader: Arc<T>,
         cache: StateCache,
-        contract_classes: HashMap<ClassHash, CompiledClass>,
+        contract_classes: ContractClassCache,
     ) -> Self {
         Self {
             cache,
@@ -54,7 +56,7 @@ impl<T: StateReader> CachedState<T> {
     /// Sets the contract classes cache.
     pub fn set_contract_classes(
         &mut self,
-        contract_classes: HashMap<ClassHash, CompiledClass>,
+        contract_classes: ContractClassCache,
     ) -> Result<(), StateError> {
         if !self.contract_classes.is_empty() {
             return Err(StateError::AssignedContractClassCache);

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -65,14 +65,6 @@ impl<T: StateReader> CachedState<T> {
         self.contract_classes = contract_classes;
         Ok(())
     }
-
-    // /// Returns the casm classes.
-    // #[allow(dead_code)]
-    // pub(crate) fn get_casm_classes(&mut self) -> Result<&CasmClassCache, StateError> {
-    //     self.casm_contract_classes
-    //         .as_ref()
-    //         .ok_or(StateError::MissingCasmClassCache)
-    // }
 }
 
 impl<T: StateReader> StateReader for CachedState<T> {

--- a/src/state/in_memory_state_reader.rs
+++ b/src/state/in_memory_state_reader.rs
@@ -1,19 +1,15 @@
 use crate::{
     core::errors::state_errors::StateError,
-    services::api::contract_classes::{
-        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
-    },
+    services::api::contract_classes::compiled_class::CompiledClass,
     state::{
-        cached_state::{CasmClassCache, UNINITIALIZED_CLASS_HASH},
-        state_api::StateReader,
-        state_cache::StorageEntry,
+        cached_state::UNINITIALIZED_CLASS_HASH, state_api::StateReader, state_cache::StorageEntry,
     },
     utils::{Address, ClassHash, CompiledClassHash},
 };
 use cairo_vm::felt::Felt252;
 use getset::{Getters, MutGetters};
 use num_traits::Zero;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 /// A [StateReader] that holds all the data in memory.
 ///
@@ -28,9 +24,7 @@ pub struct InMemoryStateReader {
     #[getset(get_mut = "pub")]
     pub address_to_storage: HashMap<StorageEntry, Felt252>,
     #[getset(get_mut = "pub")]
-    pub class_hash_to_contract_class: HashMap<ClassHash, ContractClass>,
-    #[getset(get_mut = "pub")]
-    pub(crate) casm_contract_classes: CasmClassCache,
+    pub class_hash_to_compiled_class: HashMap<ClassHash, CompiledClass>,
     #[getset(get_mut = "pub")]
     pub(crate) class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
 }
@@ -49,16 +43,14 @@ impl InMemoryStateReader {
         address_to_class_hash: HashMap<Address, ClassHash>,
         address_to_nonce: HashMap<Address, Felt252>,
         address_to_storage: HashMap<StorageEntry, Felt252>,
-        class_hash_to_contract_class: HashMap<ClassHash, ContractClass>,
-        casm_contract_classes: CasmClassCache,
+        class_hash_to_compiled_class: HashMap<ClassHash, CompiledClass>,
         class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
     ) -> Self {
         Self {
             address_to_class_hash,
             address_to_nonce,
             address_to_storage,
-            class_hash_to_contract_class,
-            casm_contract_classes,
+            class_hash_to_compiled_class,
             class_hash_to_compiled_class_hash,
         }
     }
@@ -79,13 +71,10 @@ impl InMemoryStateReader {
         &self,
         compiled_class_hash: &CompiledClassHash,
     ) -> Result<CompiledClass, StateError> {
-        if let Some(compiled_class) = self.casm_contract_classes.get(compiled_class_hash) {
-            return Ok(CompiledClass::Casm(Arc::new(compiled_class.clone())));
+        match self.class_hash_to_compiled_class.get(compiled_class_hash) {
+            Some(compiled_class) => Ok(compiled_class.clone()),
+            None => Err(StateError::NoneCompiledClass(*compiled_class_hash)),
         }
-        if let Some(compiled_class) = self.class_hash_to_contract_class.get(compiled_class_hash) {
-            return Ok(CompiledClass::Deprecated(Arc::new(compiled_class.clone())));
-        }
-        Err(StateError::NoneCompiledClass(*compiled_class_hash))
     }
 }
 
@@ -127,9 +116,10 @@ impl StateReader for InMemoryStateReader {
 
     fn get_contract_class(&self, class_hash: &ClassHash) -> Result<CompiledClass, StateError> {
         // Deprecated contract classes dont have a compiled_class_hash, we dont need to fetch it
-        if let Some(compiled_class) = self.class_hash_to_contract_class.get(class_hash) {
-            return Ok(CompiledClass::Deprecated(Arc::new(compiled_class.clone())));
+        if let Some(compiled_class) = self.class_hash_to_compiled_class.get(class_hash) {
+            return Ok(compiled_class.clone());
         }
+
         let compiled_class_hash = self.get_compiled_class_hash(class_hash)?;
         if compiled_class_hash != *UNINITIALIZED_CLASS_HASH {
             let compiled_class = self.get_compiled_class(&compiled_class_hash)?;
@@ -143,11 +133,12 @@ impl StateReader for InMemoryStateReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::api::contract_classes::deprecated_contract_class::ContractClass;
+    use std::sync::Arc;
 
     #[test]
     fn get_contract_state_test() {
         let mut state_reader = InMemoryStateReader::new(
-            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
             HashMap::new(),
@@ -190,7 +181,6 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             HashMap::new(),
-            HashMap::new(),
         );
 
         let contract_class_key = [0; 32];
@@ -198,9 +188,10 @@ mod tests {
             ContractClass::from_path("starknet_programs/raw_contract_classes/class_with_abi.json")
                 .unwrap();
 
-        state_reader
-            .class_hash_to_contract_class
-            .insert([0; 32], contract_class.clone());
+        state_reader.class_hash_to_compiled_class.insert(
+            [0; 32],
+            CompiledClass::Deprecated(Arc::new(contract_class.clone())),
+        );
         assert_eq!(
             state_reader
                 .get_contract_class(&contract_class_key)

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -166,7 +166,7 @@ impl StateDiff {
     where
         T: StateReader + Clone,
     {
-        let mut cache_state = CachedState::new(state_reader, None, None);
+        let mut cache_state = CachedState::new(state_reader, HashMap::new());
         let cache_storage_mapping = to_cache_state_storage_mapping(&self.storage_updates);
 
         cache_state.cache_mut().set_initial_values(
@@ -240,7 +240,7 @@ mod test {
     use crate::{
         state::in_memory_state_reader::InMemoryStateReader,
         state::{
-            cached_state::{CachedState, ContractClassCache},
+            cached_state::CachedState,
             state_api::StateReader,
             state_cache::{StateCache, StorageEntry},
         },
@@ -263,7 +263,7 @@ mod test {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let cached_state = CachedState::new(Arc::new(state_reader), None, None);
+        let cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         let diff = StateDiff::from_cached_state(cached_state).unwrap();
 
@@ -323,7 +323,8 @@ mod test {
             .address_to_nonce
             .insert(contract_address.clone(), nonce);
 
-        let cached_state_original = CachedState::new(Arc::new(state_reader.clone()), None, None);
+        let cached_state_original =
+            CachedState::new(Arc::new(state_reader.clone()), HashMap::new());
 
         let diff = StateDiff::from_cached_state(cached_state_original.clone()).unwrap();
 
@@ -370,12 +371,8 @@ mod test {
             storage_writes,
             HashMap::new(),
         );
-        let cached_state = CachedState::new_for_testing(
-            Arc::new(state_reader),
-            Some(ContractClassCache::new()),
-            cache,
-            None,
-        );
+        let cached_state =
+            CachedState::new_for_testing(Arc::new(state_reader), cache, HashMap::new());
 
         let mut diff = StateDiff::from_cached_state(cached_state).unwrap();
 

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -1,13 +1,10 @@
 use super::state_cache::StorageEntry;
 use crate::{
     core::errors::state_errors::StateError,
-    services::api::contract_classes::{
-        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
-    },
+    services::api::contract_classes::compiled_class::CompiledClass,
     state::StateDiff,
     utils::{Address, ClassHash, CompiledClassHash},
 };
-use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_vm::felt::Felt252;
 
 pub trait StateReader {
@@ -30,7 +27,7 @@ pub trait State {
     fn set_contract_class(
         &mut self,
         class_hash: &ClassHash,
-        contract_class: &ContractClass,
+        contract_class: &CompiledClass,
     ) -> Result<(), StateError>;
 
     fn deploy_contract(
@@ -47,12 +44,6 @@ pub trait State {
         &mut self,
         contract_address: Address,
         class_hash: ClassHash,
-    ) -> Result<(), StateError>;
-
-    fn set_compiled_class(
-        &mut self,
-        compiled_class_hash: &Felt252,
-        casm_class: CasmContractClass,
     ) -> Result<(), StateError>;
 
     fn set_compiled_class_hash(

--- a/src/syscalls/deprecated_syscall_handler.rs
+++ b/src/syscalls/deprecated_syscall_handler.rs
@@ -227,6 +227,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::services::api::contract_classes::compiled_class::CompiledClass;
     use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
     use crate::{
         add_segments, allocate_selector, any_box,
@@ -1034,7 +1035,10 @@ mod tests {
             .syscall_handler
             .starknet_storage_state
             .state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         // Execute Deploy hint
@@ -1133,7 +1137,10 @@ mod tests {
             .syscall_handler
             .starknet_storage_state
             .state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         // Execute Deploy hint

--- a/src/syscalls/deprecated_syscall_handler.rs
+++ b/src/syscalls/deprecated_syscall_handler.rs
@@ -730,7 +730,7 @@ mod tests {
             ]
         );
 
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -766,7 +766,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_CONTRACT_ADDRESS.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -808,7 +808,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_TX_SIGNATURE.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -847,7 +847,7 @@ mod tests {
         );
     }
 
-    /// Tests the correct behavior of a storage read operation within a blockchain.  
+    /// Tests the correct behavior of a storage read operation within a blockchain.
     #[test]
     fn test_bl_storage_read_hint_ok() {
         let mut vm = vm!();
@@ -876,7 +876,7 @@ mod tests {
 
         let hint_data = HintProcessorData::new_default(STORAGE_READ.to_string(), ids_data);
 
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -911,7 +911,7 @@ mod tests {
         assert_matches!(get_big_int(&vm, relocatable!(2, 2)), Ok(response) if response == storage_value );
     }
 
-    /// Tests the correct behavior of a storage write operation within a blockchain.  
+    /// Tests the correct behavior of a storage write operation within a blockchain.
     #[test]
     fn test_bl_storage_write_hint_ok() {
         let mut vm = vm!();
@@ -941,7 +941,7 @@ mod tests {
 
         let hint_data = HintProcessorData::new_default(STORAGE_WRITE.to_string(), ids_data);
 
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -980,7 +980,7 @@ mod tests {
         assert_eq!(write, Felt252::new(45));
     }
 
-    /// Tests the correct behavior of a deploy operation within a blockchain.  
+    /// Tests the correct behavior of a deploy operation within a blockchain.
     #[test]
     fn test_bl_deploy_ok() {
         let mut vm = vm!();
@@ -1015,7 +1015,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(DEPLOY.to_string(), ids_data);
 
         // Create SyscallHintProcessor
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -1071,7 +1071,7 @@ mod tests {
         );
     }
 
-    /// Tests the correct behavior of a storage deploy and invoke operations within a blockchain.  
+    /// Tests the correct behavior of a storage deploy and invoke operations within a blockchain.
     #[test]
     fn test_deploy_and_invoke() {
         /*
@@ -1113,7 +1113,7 @@ mod tests {
         );
 
         // Create SyscallHintProcessor
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),

--- a/src/syscalls/deprecated_syscall_response.rs
+++ b/src/syscalls/deprecated_syscall_response.rs
@@ -309,7 +309,7 @@ impl DeprecatedWriteSyscallResponse for DeprecatedStorageReadResponse {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
     use super::*;
     use crate::{
@@ -330,7 +330,7 @@ mod tests {
     #[test]
     fn write_get_caller_address_response() {
         // Initialize a VM and syscall handler
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
 

--- a/src/testing/erc20.rs
+++ b/src/testing/erc20.rs
@@ -142,7 +142,10 @@ fn test_erc20_cairo2() {
         serde_json::from_slice(program_data_account).unwrap();
 
     state
-        .set_compiled_class(&felt_str!("1"), contract_class_account)
+        .set_contract_class(
+            &felt_str!("1").to_be_bytes(),
+            &CompiledClass::Casm(Arc::new(contract_class_account)),
+        )
         .unwrap();
 
     let contract_address_salt =
@@ -181,7 +184,10 @@ fn test_erc20_cairo2() {
         serde_json::from_slice(program_data_account).unwrap();
 
     state
-        .set_compiled_class(&felt_str!("1"), contract_class_account)
+        .set_contract_class(
+            &felt_str!("1").to_be_bytes(),
+            &CompiledClass::Casm(Arc::new(contract_class_account)),
+        )
         .unwrap();
 
     let contract_address_salt = felt_str!("123123123123123");

--- a/src/testing/erc20.rs
+++ b/src/testing/erc20.rs
@@ -10,7 +10,9 @@ use crate::{
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::{
         cached_state::CachedState,
         in_memory_state_reader::InMemoryStateReader,
@@ -58,8 +60,11 @@ fn test_erc20_cairo2() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
-    contract_class_cache.insert(erc20_class_hash, test_contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+    contract_class_cache.insert(
+        erc20_class_hash,
+        CompiledClass::Casm(Arc::new(test_contract_class)),
+    );
 
     let mut state_reader = InMemoryStateReader::default();
     state_reader
@@ -70,7 +75,7 @@ fn test_erc20_cairo2() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let name_ = Felt252::from_bytes_be(b"some-token");
     let symbol_ = Felt252::from_bytes_be(b"my-super-awesome-token");

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -14,7 +14,9 @@ use crate::{
         block_context::{BlockContext, StarknetChainId, StarknetOsConfig},
         constants::DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::{
         cached_state::CachedState, in_memory_state_reader::InMemoryStateReader,
         state_cache::StorageEntry, BlockInfo,
@@ -149,14 +151,14 @@ pub fn create_account_tx_test_state(
                 state_reader.address_to_storage_mut().extend(stored);
             }
             for (class_hash, contract_class) in class_hash_to_class {
-                state_reader
-                    .class_hash_to_contract_class_mut()
-                    .insert(class_hash, contract_class);
+                state_reader.class_hash_to_compiled_class_mut().insert(
+                    class_hash,
+                    CompiledClass::Deprecated(Arc::new(contract_class)),
+                );
             }
             Arc::new(state_reader)
         },
-        Some(HashMap::new()),
-        Some(HashMap::new()),
+        HashMap::new(),
     );
 
     Ok((block_context, cached_state))

--- a/src/testing/state.rs
+++ b/src/testing/state.rs
@@ -40,7 +40,7 @@ impl StarknetState {
         let block_context = context.unwrap_or_default();
         let state_reader = Arc::new(InMemoryStateReader::default());
 
-        let state = CachedState::new(state_reader, Some(HashMap::new()), Some(HashMap::new()));
+        let state = CachedState::new(state_reader, HashMap::new());
 
         let l2_to_l1_messages = HashMap::new();
         let l2_to_l1_messages_log = Vec::new();
@@ -330,6 +330,7 @@ mod tests {
         },
         execution::{CallType, OrderedL2ToL1Message},
         hash_utils::calculate_contract_address,
+        services::api::contract_classes::compiled_class::CompiledClass,
         state::state_cache::StorageEntry,
         utils::{calculate_sn_keccak, felt_to_hash},
     };
@@ -399,11 +400,10 @@ mod tests {
             starknet_state
                 .state
                 .contract_classes
-                .unwrap()
                 .get(&class_hash)
                 .unwrap()
                 .to_owned(),
-            contract_class
+            CompiledClass::Deprecated(Arc::new(contract_class))
         );
     }
 
@@ -419,7 +419,10 @@ mod tests {
         // hack store account contract
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
-        contract_class_cache.insert(class_hash, contract_class.clone());
+        contract_class_cache.insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class.clone())),
+        );
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -440,11 +443,12 @@ mod tests {
         state_reader
             .address_to_storage_mut()
             .insert(storage_entry.clone(), storage.clone());
-        state_reader
-            .class_hash_to_contract_class_mut()
-            .insert(class_hash, contract_class.clone());
+        state_reader.class_hash_to_compiled_class_mut().insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class.clone())),
+        );
 
-        let state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+        let state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
         //* --------------------------------------------
         //*    Create starknet state with previous data

--- a/src/testing/state.rs
+++ b/src/testing/state.rs
@@ -1,5 +1,6 @@
 use super::{state_error::StarknetStateError, type_utils::ExecutionInfo};
 use crate::execution::execution_entry_point::ExecutionResult;
+use crate::services::api::contract_classes::compiled_class::CompiledClass;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
 use crate::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
@@ -201,8 +202,10 @@ impl StarknetState {
         let contract_hash = deploy.contract_hash;
         let mut tx = Transaction::Deploy(deploy);
 
-        self.state
-            .set_contract_class(&contract_hash, &contract_class)?;
+        self.state.set_contract_class(
+            &contract_hash,
+            &CompiledClass::Deprecated(Arc::new(contract_class)),
+        )?;
 
         let tx_execution_info = self.execute_tx(&mut tx, remaining_gas)?;
         Ok((contract_address, tx_execution_info))
@@ -472,7 +475,10 @@ mod tests {
 
         starknet_state
             .state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         // --------------------------------------------

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -332,7 +332,9 @@ mod tests {
             transaction_type::TransactionType,
         },
         execution::CallType,
-        services::api::contract_classes::deprecated_contract_class::ContractClass,
+        services::api::contract_classes::{
+            compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+        },
         state::cached_state::CachedState,
         state::in_memory_state_reader::InMemoryStateReader,
         utils::{felt_to_hash, Address},
@@ -353,7 +355,10 @@ mod tests {
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = hash.to_be_bytes();
 
-        contract_class_cache.insert(class_hash, contract_class.clone());
+        contract_class_cache.insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class.clone())),
+        );
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -369,7 +374,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::new(1));
 
-        let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -510,7 +515,10 @@ mod tests {
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class);
+        contract_class_cache.insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class)),
+        );
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -526,7 +534,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::new(1));
 
-        let _state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+        let _state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -573,7 +581,10 @@ mod tests {
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class);
+        contract_class_cache.insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class)),
+        );
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -589,7 +600,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::new(1));
 
-        let _state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+        let _state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -635,7 +646,10 @@ mod tests {
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class);
+        contract_class_cache.insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class)),
+        );
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -651,7 +665,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::zero());
 
-        let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -711,7 +725,10 @@ mod tests {
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class);
+        contract_class_cache.insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class)),
+        );
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -727,7 +744,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::zero());
 
-        let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -774,7 +791,7 @@ mod tests {
 
         let state_reader = Arc::new(InMemoryStateReader::default());
 
-        let mut state = CachedState::new(state_reader, Some(contract_class_cache), None);
+        let mut state = CachedState::new(state_reader, contract_class_cache);
 
         // There are no account contracts in the state, so the transaction should fail
         let fib_contract_class =
@@ -815,7 +832,10 @@ mod tests {
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class);
+        contract_class_cache.insert(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class)),
+        );
 
         // store sender_address
         let sender_address = Address(1.into());
@@ -831,7 +851,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::zero());
 
-        let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
         //* ---------------------------------------
         //*    Test declare with previous data

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -29,6 +29,8 @@ use num_traits::Zero;
 
 use super::fee::charge_fee;
 use super::{verify_version, Transaction};
+use crate::services::api::contract_classes::compiled_class::CompiledClass;
+use std::sync::Arc;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ///  Represents an internal transaction in the StarkNet network that is a declaration of a Cairo
@@ -281,7 +283,10 @@ impl Declare {
             self.skip_fee_transfer,
         )?;
 
-        state.set_contract_class(&self.class_hash, &self.contract_class)?;
+        state.set_contract_class(
+            &self.class_hash,
+            &CompiledClass::Deprecated(Arc::new(self.contract_class.clone())),
+        )?;
 
         tx_exec_info.set_fee_info(actual_fee, fee_transfer_info);
 

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -510,7 +510,7 @@ mod tests {
         // crate state to store casm contract class
         let casm_contract_class_cache = HashMap::new();
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, None, Some(casm_contract_class_cache));
+        let mut state = CachedState::new(state_reader, casm_contract_class_cache);
 
         // call compile and store
         assert!(internal_declare
@@ -579,7 +579,7 @@ mod tests {
         // crate state to store casm contract class
         let casm_contract_class_cache = HashMap::new();
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, None, Some(casm_contract_class_cache));
+        let mut state = CachedState::new(state_reader, casm_contract_class_cache);
 
         // call compile and store
         assert!(internal_declare
@@ -650,7 +650,7 @@ mod tests {
         // crate state to store casm contract class
         let casm_contract_class_cache = HashMap::new();
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, None, Some(casm_contract_class_cache));
+        let mut state = CachedState::new(state_reader, casm_contract_class_cache);
 
         // call compile and store
         assert!(internal_declare
@@ -719,7 +719,7 @@ mod tests {
         // crate state to store casm contract class
         let casm_contract_class_cache = HashMap::new();
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, None, Some(casm_contract_class_cache));
+        let mut state = CachedState::new(state_reader, casm_contract_class_cache);
 
         // call compile and store
         assert!(internal_declare
@@ -789,7 +789,7 @@ mod tests {
         // crate state to store casm contract class
         let casm_contract_class_cache = HashMap::new();
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, None, Some(casm_contract_class_cache));
+        let mut state = CachedState::new(state_reader, casm_contract_class_cache);
 
         let expected_err = format!(
             "Invalid compiled class, expected class hash: {}, but received: {}",

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -5,6 +5,7 @@ use crate::definitions::constants::QUERY_VERSION_BASE;
 use crate::execution::execution_entry_point::ExecutionResult;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
 
+use crate::services::api::contract_classes::compiled_class::CompiledClass;
 use crate::state::cached_state::CachedState;
 use crate::{
     core::transaction_hash::calculate_declare_v2_transaction_hash,
@@ -26,6 +27,7 @@ use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
 use cairo_vm::felt::Felt252;
 use num_traits::Zero;
+use std::sync::Arc;
 
 /// Represents a declare transaction in the starknet network.
 /// Declare creates a blueprint of a contract class that is used to deploy instances of the contract
@@ -372,7 +374,10 @@ impl DeclareV2 {
             ));
         }
         state.set_compiled_class_hash(&self.sierra_class_hash, &self.compiled_class_hash)?;
-        state.set_compiled_class(&self.compiled_class_hash, casm_class)?;
+        state.set_contract_class(
+            &self.compiled_class_hash.to_be_bytes(),
+            &CompiledClass::Casm(Arc::new(casm_class)),
+        )?;
 
         Ok(())
     }

--- a/src/transaction/deploy.rs
+++ b/src/transaction/deploy.rs
@@ -328,7 +328,7 @@ mod tests {
     fn invoke_constructor_test() {
         // Instantiate CachedState
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, Some(Default::default()), None);
+        let mut state = CachedState::new(state_reader, HashMap::new());
 
         // Set contract_class
         let contract_class =
@@ -376,7 +376,7 @@ mod tests {
     fn invoke_constructor_no_calldata_should_fail() {
         // Instantiate CachedState
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, Some(Default::default()), None);
+        let mut state = CachedState::new(state_reader, HashMap::new());
 
         let contract_class =
             ContractClass::from_path("starknet_programs/constructor.json").unwrap();
@@ -402,7 +402,7 @@ mod tests {
     fn deploy_contract_without_constructor_should_fail() {
         // Instantiate CachedState
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, Some(Default::default()), None);
+        let mut state = CachedState::new(state_reader, HashMap::new());
 
         let contract_path = "starknet_programs/amm.json";
         let contract_class = ContractClass::from_path(contract_path).unwrap();

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -385,7 +385,7 @@ impl DeployAccount {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc};
+    use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
     use super::*;
     use crate::{
@@ -406,11 +406,7 @@ mod tests {
         let class_hash = felt_to_hash(&hash);
 
         let block_context = BlockContext::default();
-        let mut _state = CachedState::new(
-            Arc::new(InMemoryStateReader::default()),
-            Some(Default::default()),
-            None,
-        );
+        let mut _state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
         let internal_deploy = DeployAccount::new(
             class_hash,
@@ -442,11 +438,7 @@ mod tests {
         let class_hash = felt_to_hash(&hash);
 
         let block_context = BlockContext::default();
-        let mut state = CachedState::new(
-            Arc::new(InMemoryStateReader::default()),
-            Some(Default::default()),
-            None,
-        );
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
         let internal_deploy = DeployAccount::new(
             class_hash,
@@ -494,11 +486,7 @@ mod tests {
         let class_hash = felt_to_hash(&hash);
 
         let block_context = BlockContext::default();
-        let mut state = CachedState::new(
-            Arc::new(InMemoryStateReader::default()),
-            Some(Default::default()),
-            None,
-        );
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
         let internal_deploy = DeployAccount::new(
             class_hash,

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -465,7 +465,9 @@ mod tests {
         .unwrap();
 
         let class_hash = internal_deploy.class_hash();
-        state.set_contract_class(class_hash, &contract).unwrap();
+        state
+            .set_contract_class(class_hash, &CompiledClass::Deprecated(Arc::new(contract)))
+            .unwrap();
         internal_deploy.execute(&mut state, &block_context).unwrap();
         assert_matches!(
             internal_deploy_error
@@ -501,7 +503,9 @@ mod tests {
         .unwrap();
 
         let class_hash = internal_deploy.class_hash();
-        state.set_contract_class(class_hash, &contract).unwrap();
+        state
+            .set_contract_class(class_hash, &CompiledClass::Deprecated(Arc::new(contract)))
+            .unwrap();
         internal_deploy.execute(&mut state, &block_context).unwrap();
     }
 }

--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_charge_fee_v0_actual_fee_exceeds_max_fee_should_return_error() {
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut tx_execution_context = TransactionExecutionContext::default();
         let mut block_context = BlockContext::default();
         block_context.starknet_os_config.gas_price = 1;
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_charge_fee_v1_actual_fee_exceeds_max_fee_should_return_error() {
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), None, None);
+        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
         let mut tx_execution_context = TransactionExecutionContext {
             version: 1.into(),
             ..Default::default()

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -401,8 +401,11 @@ pub(crate) fn preprocess_invoke_function_fields(
 mod tests {
     use super::*;
     use crate::{
-        services::api::contract_classes::deprecated_contract_class::ContractClass,
-        state::cached_state::CachedState, state::in_memory_state_reader::InMemoryStateReader,
+        services::api::contract_classes::{
+            compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+        },
+        state::cached_state::CachedState,
+        state::in_memory_state_reader::InMemoryStateReader,
         utils::calculate_sn_keccak,
     };
     use cairo_lang_starknet::casm_contract_class::CasmContractClass;
@@ -449,7 +452,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -518,7 +521,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -583,7 +586,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -642,7 +645,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -707,7 +710,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -766,7 +769,7 @@ mod tests {
             skip_nonce_check: false,
         };
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -823,7 +826,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -881,7 +884,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -944,7 +947,7 @@ mod tests {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();
@@ -1087,13 +1090,9 @@ mod tests {
 
         let mut casm_contract_class_cache = HashMap::new();
 
-        casm_contract_class_cache.insert(class_hash, contract_class);
+        casm_contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
 
-        let mut state = CachedState::new(
-            Arc::new(state_reader),
-            None,
-            Some(casm_contract_class_cache),
-        );
+        let mut state = CachedState::new(Arc::new(state_reader), casm_contract_class_cache);
 
         let state_before_execution = state.clone();
 

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -458,7 +458,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let result = internal_invoke_function
@@ -527,7 +530,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let result = internal_invoke_function
@@ -592,7 +598,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let expected_error =
@@ -651,7 +660,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let result = internal_invoke_function
@@ -716,7 +728,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let expected_error =
@@ -775,7 +790,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let block_context = BlockContext::default();
@@ -832,7 +850,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let mut block_context = BlockContext::default();
@@ -890,7 +911,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         internal_invoke_function
@@ -953,7 +977,10 @@ mod tests {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let expected_error =

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -211,7 +211,9 @@ mod test {
         sync::Arc,
     };
 
-    use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
+    use crate::services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::EntryPointType,
+    };
     use cairo_vm::{
         felt::{felt_str, Felt252},
         vm::runners::cairo_runner::ExecutionResources,
@@ -272,7 +274,10 @@ mod test {
         state.set_contract_classes(HashMap::new()).unwrap();
 
         state
-            .set_contract_class(&class_hash, &contract_class)
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class)),
+            )
             .unwrap();
 
         let mut block_context = BlockContext::default();

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -266,7 +266,7 @@ mod test {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), None, None);
+        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
 
         // Initialize state.contract_classes
         state.set_contract_classes(HashMap::new()).unwrap();

--- a/tests/cairo_1_syscalls.rs
+++ b/tests/cairo_1_syscalls.rs
@@ -65,7 +65,7 @@ fn storage_write_read() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -75,7 +75,7 @@ fn storage_write_read() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let block_context = BlockContext::default();
     let mut tx_execution_context = TransactionExecutionContext::new(
@@ -204,7 +204,7 @@ fn library_call() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -226,7 +226,10 @@ fn library_call() {
     let lib_class_hash: ClassHash = [2; 32];
     let lib_nonce = Felt252::zero();
 
-    contract_class_cache.insert(lib_class_hash, lib_contract_class);
+    contract_class_cache.insert(
+        lib_class_hash,
+        CompiledClass::Casm(Arc::new(lib_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(lib_address.clone(), lib_class_hash);
@@ -235,7 +238,7 @@ fn library_call() {
         .insert(lib_address, lib_nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [25.into(), Felt252::from_bytes_be(&lib_class_hash)].to_vec();
@@ -361,7 +364,7 @@ fn call_contract_storage_write_read() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -392,7 +395,10 @@ fn call_contract_storage_write_read() {
     let simple_wallet_class_hash: ClassHash = [2; 32];
     let simple_wallet_nonce = Felt252::zero();
 
-    contract_class_cache.insert(simple_wallet_class_hash, simple_wallet_contract_class);
+    contract_class_cache.insert(
+        simple_wallet_class_hash,
+        CompiledClass::Casm(Arc::new(simple_wallet_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(simple_wallet_address.clone(), simple_wallet_class_hash);
@@ -401,7 +407,7 @@ fn call_contract_storage_write_read() {
         .insert(simple_wallet_address.clone(), simple_wallet_nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let block_context = BlockContext::default();
     let mut tx_execution_context = TransactionExecutionContext::new(
@@ -547,7 +553,7 @@ fn emit_event() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -557,7 +563,7 @@ fn emit_event() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [].to_vec();
@@ -659,8 +665,11 @@ fn deploy_cairo1_from_cairo1() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
-    contract_class_cache.insert(test_class_hash, test_contract_class.clone());
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+    contract_class_cache.insert(
+        test_class_hash,
+        CompiledClass::Casm(Arc::new(test_contract_class.clone())),
+    );
 
     let mut state_reader = InMemoryStateReader::default();
     state_reader
@@ -671,7 +680,7 @@ fn deploy_cairo1_from_cairo1() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // arguments of deploy contract
     let calldata: Vec<_> = [test_felt_hash, salt].to_vec();
@@ -750,15 +759,17 @@ fn deploy_cairo0_from_cairo1_without_constructor() {
     let entrypoint_selector = &entrypoints.external.get(0).unwrap().selector;
 
     // Create state reader with class hash data
-    let mut casm_contract_class_cache = HashMap::new();
     let mut contract_class_cache = HashMap::new();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    casm_contract_class_cache.insert(class_hash, contract_class);
-    contract_class_cache.insert(test_class_hash, test_contract_class.clone());
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+    contract_class_cache.insert(
+        test_class_hash,
+        CompiledClass::Deprecated(Arc::new(test_contract_class.clone())),
+    );
 
     let mut state_reader = InMemoryStateReader::default();
     state_reader
@@ -769,11 +780,7 @@ fn deploy_cairo0_from_cairo1_without_constructor() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        Some(contract_class_cache),
-        Some(casm_contract_class_cache),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // arguments of deploy contract
     let calldata: Vec<_> = [test_felt_hash, salt].to_vec();
@@ -850,7 +857,6 @@ fn deploy_cairo0_from_cairo1_with_constructor() {
     let entrypoint_selector = &entrypoints.external.get(0).unwrap().selector;
 
     // Create state reader with class hash data
-    let mut casm_contract_class_cache = HashMap::new();
     let mut contract_class_cache = HashMap::new();
 
     let address = Address(1111.into());
@@ -858,8 +864,11 @@ fn deploy_cairo0_from_cairo1_with_constructor() {
     let nonce = Felt252::zero();
 
     // simulate contract declare
-    casm_contract_class_cache.insert(class_hash, contract_class);
-    contract_class_cache.insert(test_class_hash, test_contract_class.clone());
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+    contract_class_cache.insert(
+        test_class_hash,
+        CompiledClass::Deprecated(Arc::new(test_contract_class.clone())),
+    );
 
     let mut state_reader = InMemoryStateReader::default();
     state_reader
@@ -870,11 +879,7 @@ fn deploy_cairo0_from_cairo1_with_constructor() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        Some(contract_class_cache),
-        Some(casm_contract_class_cache),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // arguments of deploy contract
     let calldata: Vec<_> = [test_felt_hash, salt, address.0.clone(), Felt252::zero()].to_vec();
@@ -953,15 +958,17 @@ fn deploy_cairo0_and_invoke() {
     let entrypoint_selector = &entrypoints.external.get(0).unwrap().selector;
 
     // Create state reader with class hash data
-    let mut casm_contract_class_cache = HashMap::new();
     let mut contract_class_cache = HashMap::new();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    casm_contract_class_cache.insert(class_hash, contract_class);
-    contract_class_cache.insert(test_class_hash, test_contract_class.clone());
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+    contract_class_cache.insert(
+        test_class_hash,
+        CompiledClass::Deprecated(Arc::new(test_contract_class.clone())),
+    );
 
     let mut state_reader = InMemoryStateReader::default();
     state_reader
@@ -972,11 +979,7 @@ fn deploy_cairo0_and_invoke() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state: CachedState<_> = CachedState::new(
-        Arc::new(state_reader),
-        Some(contract_class_cache),
-        Some(casm_contract_class_cache),
-    );
+    let mut state: CachedState<_> = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // arguments of deploy contract
     let calldata: Vec<_> = [test_felt_hash, salt].to_vec();
@@ -1085,7 +1088,7 @@ fn test_send_message_to_l1_syscall() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
 
     let mut state_reader = InMemoryStateReader::default();
     state_reader
@@ -1096,7 +1099,7 @@ fn test_send_message_to_l1_syscall() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // RUN SEND_MSG
     // Create an execution entry point
@@ -1179,7 +1182,7 @@ fn test_get_execution_info() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -1189,7 +1192,7 @@ fn test_get_execution_info() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let block_context = BlockContext::default();
     let mut tx_execution_context = TransactionExecutionContext::new(
@@ -1274,7 +1277,10 @@ fn replace_class_internal() {
     let class_hash_a: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash_a, contract_class_a);
+    contract_class_cache.insert(
+        class_hash_a,
+        CompiledClass::Casm(Arc::new(contract_class_a)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -1292,10 +1298,13 @@ fn replace_class_internal() {
 
     let class_hash_b: ClassHash = [2; 32];
 
-    contract_class_cache.insert(class_hash_b, contract_class_b.clone());
+    contract_class_cache.insert(
+        class_hash_b,
+        CompiledClass::Casm(Arc::new(contract_class_b.clone())),
+    );
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Run upgrade entrypoint and check that the storage was updated with the new contract class
     // Create an execution entry point
@@ -1370,7 +1379,10 @@ fn replace_class_contract_call() {
     let class_hash_a: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash_a, contract_class_a);
+    contract_class_cache.insert(
+        class_hash_a,
+        CompiledClass::Casm(Arc::new(contract_class_a)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -1391,7 +1403,10 @@ fn replace_class_contract_call() {
 
     let class_hash_b: ClassHash = [2; 32];
 
-    contract_class_cache.insert(class_hash_b, contract_class_b);
+    contract_class_cache.insert(
+        class_hash_b,
+        CompiledClass::Casm(Arc::new(contract_class_b)),
+    );
 
     // SET GET_NUMBER_WRAPPER
 
@@ -1408,7 +1423,10 @@ fn replace_class_contract_call() {
     let wrapper_address = Address(Felt252::from(2));
     let wrapper_class_hash: ClassHash = [3; 32];
 
-    contract_class_cache.insert(wrapper_class_hash, wrapper_contract_class);
+    contract_class_cache.insert(
+        wrapper_class_hash,
+        CompiledClass::Casm(Arc::new(wrapper_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(wrapper_address.clone(), wrapper_class_hash);
@@ -1417,7 +1435,7 @@ fn replace_class_contract_call() {
         .insert(wrapper_address, nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
@@ -1537,7 +1555,10 @@ fn replace_class_contract_call_same_transaction() {
     let class_hash_a: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash_a, contract_class_a);
+    contract_class_cache.insert(
+        class_hash_a,
+        CompiledClass::Casm(Arc::new(contract_class_a)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -1558,7 +1579,10 @@ fn replace_class_contract_call_same_transaction() {
 
     let class_hash_b: ClassHash = [2; 32];
 
-    contract_class_cache.insert(class_hash_b, contract_class_b);
+    contract_class_cache.insert(
+        class_hash_b,
+        CompiledClass::Casm(Arc::new(contract_class_b)),
+    );
 
     // SET GET_NUMBER_WRAPPER
 
@@ -1574,7 +1598,10 @@ fn replace_class_contract_call_same_transaction() {
     let wrapper_address = Address(Felt252::from(2));
     let wrapper_class_hash: ClassHash = [3; 32];
 
-    contract_class_cache.insert(wrapper_class_hash, wrapper_contract_class);
+    contract_class_cache.insert(
+        wrapper_class_hash,
+        CompiledClass::Casm(Arc::new(wrapper_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(wrapper_address.clone(), wrapper_class_hash);
@@ -1583,7 +1610,7 @@ fn replace_class_contract_call_same_transaction() {
         .insert(wrapper_address, nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
@@ -1645,14 +1672,16 @@ fn call_contract_upgrade_cairo_0_to_cairo_1_same_transaction() {
     let contract_class_c = ContractClass::from_path("starknet_programs/get_number_c.json").unwrap();
 
     // Create state reader with class hash data
-    let mut casm_contract_class_cache = HashMap::new();
-    let mut deprecated_contract_class_cache = HashMap::new();
+    let mut contract_class_cache = HashMap::new();
 
     let address = Address(Felt252::one());
     let class_hash_c: ClassHash = Felt252::one().to_be_bytes();
     let nonce = Felt252::zero();
 
-    deprecated_contract_class_cache.insert(class_hash_c, contract_class_c);
+    contract_class_cache.insert(
+        class_hash_c,
+        CompiledClass::Deprecated(Arc::new(contract_class_c)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -1673,7 +1702,10 @@ fn call_contract_upgrade_cairo_0_to_cairo_1_same_transaction() {
 
     let class_hash_b: ClassHash = Felt252::from(2).to_be_bytes();
 
-    casm_contract_class_cache.insert(class_hash_b, contract_class_b);
+    contract_class_cache.insert(
+        class_hash_b,
+        CompiledClass::Casm(Arc::new(contract_class_b)),
+    );
 
     // SET GET_NUMBER_WRAPPER
 
@@ -1689,7 +1721,10 @@ fn call_contract_upgrade_cairo_0_to_cairo_1_same_transaction() {
     let wrapper_address = Address(Felt252::from(2));
     let wrapper_class_hash: ClassHash = [3; 32];
 
-    casm_contract_class_cache.insert(wrapper_class_hash, wrapper_contract_class);
+    contract_class_cache.insert(
+        wrapper_class_hash,
+        CompiledClass::Casm(Arc::new(wrapper_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(wrapper_address.clone(), wrapper_class_hash);
@@ -1698,11 +1733,7 @@ fn call_contract_upgrade_cairo_0_to_cairo_1_same_transaction() {
         .insert(wrapper_address, nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        Some(deprecated_contract_class_cache),
-        Some(casm_contract_class_cache),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
@@ -1762,14 +1793,16 @@ fn call_contract_downgrade_cairo_1_to_cairo_0_same_transaction() {
     let contract_class_c = ContractClass::from_path("starknet_programs/get_number_c.json").unwrap();
 
     // Create state reader with class hash data
-    let mut casm_contract_class_cache = HashMap::new();
-    let mut deprecated_contract_class_cache = HashMap::new();
+    let mut contract_class_cache = HashMap::new();
 
     let address = Address(Felt252::one());
     let class_hash_c: ClassHash = Felt252::one().to_be_bytes();
     let nonce = Felt252::zero();
 
-    deprecated_contract_class_cache.insert(class_hash_c, contract_class_c);
+    contract_class_cache.insert(
+        class_hash_c,
+        CompiledClass::Deprecated(Arc::new(contract_class_c)),
+    );
 
     // SET GET_NUMBER_B
 
@@ -1783,7 +1816,10 @@ fn call_contract_downgrade_cairo_1_to_cairo_0_same_transaction() {
 
     let class_hash_b: ClassHash = Felt252::from(2).to_be_bytes();
 
-    casm_contract_class_cache.insert(class_hash_b, contract_class_b);
+    contract_class_cache.insert(
+        class_hash_b,
+        CompiledClass::Casm(Arc::new(contract_class_b)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -1806,7 +1842,10 @@ fn call_contract_downgrade_cairo_1_to_cairo_0_same_transaction() {
     let wrapper_address = Address(Felt252::from(2));
     let wrapper_class_hash: ClassHash = [3; 32];
 
-    casm_contract_class_cache.insert(wrapper_class_hash, wrapper_contract_class);
+    contract_class_cache.insert(
+        wrapper_class_hash,
+        CompiledClass::Casm(Arc::new(wrapper_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(wrapper_address.clone(), wrapper_class_hash);
@@ -1815,11 +1854,7 @@ fn call_contract_downgrade_cairo_1_to_cairo_0_same_transaction() {
         .insert(wrapper_address, nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        Some(deprecated_contract_class_cache),
-        Some(casm_contract_class_cache),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
@@ -1879,14 +1914,16 @@ fn call_contract_replace_class_cairo_0() {
     let contract_class_c = ContractClass::from_path("starknet_programs/get_number_c.json").unwrap();
 
     // Create state reader with class hash data
-    let mut casm_contract_class_cache = HashMap::new();
-    let mut deprecated_contract_class_cache = HashMap::new();
+    let mut contract_class_cache = HashMap::new();
 
     let address = Address(Felt252::one());
     let class_hash_c: ClassHash = Felt252::one().to_be_bytes();
     let nonce = Felt252::zero();
 
-    deprecated_contract_class_cache.insert(class_hash_c, contract_class_c);
+    contract_class_cache.insert(
+        class_hash_c,
+        CompiledClass::Deprecated(Arc::new(contract_class_c)),
+    );
 
     // SET GET_NUMBER_B
 
@@ -1896,7 +1933,10 @@ fn call_contract_replace_class_cairo_0() {
 
     let class_hash_d: ClassHash = Felt252::from(2).to_be_bytes();
 
-    deprecated_contract_class_cache.insert(class_hash_d, contract_class_d);
+    contract_class_cache.insert(
+        class_hash_d,
+        CompiledClass::Deprecated(Arc::new(contract_class_d)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -1919,7 +1959,10 @@ fn call_contract_replace_class_cairo_0() {
     let wrapper_address = Address(Felt252::from(2));
     let wrapper_class_hash: ClassHash = [3; 32];
 
-    casm_contract_class_cache.insert(wrapper_class_hash, wrapper_contract_class);
+    contract_class_cache.insert(
+        wrapper_class_hash,
+        CompiledClass::Casm(Arc::new(wrapper_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(wrapper_address.clone(), wrapper_class_hash);
@@ -1928,11 +1971,7 @@ fn call_contract_replace_class_cairo_0() {
         .insert(wrapper_address, nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        Some(deprecated_contract_class_cache),
-        Some(casm_contract_class_cache),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // INITIALIZE STARKNET CONFIG
     let block_context = BlockContext::default();
@@ -1998,7 +2037,7 @@ fn test_out_of_gas_failure() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2008,7 +2047,7 @@ fn test_out_of_gas_failure() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [].to_vec();
@@ -2075,7 +2114,7 @@ fn deploy_syscall_failure_uninitialized_class_hash() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2085,7 +2124,7 @@ fn deploy_syscall_failure_uninitialized_class_hash() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [Felt252::zero()].to_vec();
@@ -2151,7 +2190,7 @@ fn deploy_syscall_failure_in_constructor() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2167,10 +2206,13 @@ fn deploy_syscall_failure_in_constructor() {
     let f_c_program_data = include_bytes!("../starknet_programs/cairo1/failing_constructor.casm");
     let f_c_contract_class: CasmContractClass = serde_json::from_slice(f_c_program_data).unwrap();
     let f_c_class_hash = Felt252::one();
-    contract_class_cache.insert(f_c_class_hash.to_be_bytes(), f_c_contract_class);
+    contract_class_cache.insert(
+        f_c_class_hash.to_be_bytes(),
+        CompiledClass::Casm(Arc::new(f_c_contract_class)),
+    );
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [f_c_class_hash].to_vec();
@@ -2238,7 +2280,7 @@ fn storage_read_no_value() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2248,7 +2290,7 @@ fn storage_read_no_value() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let block_context = BlockContext::default();
     let mut tx_execution_context = TransactionExecutionContext::new(
@@ -2309,7 +2351,7 @@ fn storage_read_unavailable_address_domain() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2319,7 +2361,7 @@ fn storage_read_unavailable_address_domain() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let block_context = BlockContext::default();
     let mut tx_execution_context = TransactionExecutionContext::new(
@@ -2383,7 +2425,7 @@ fn storage_write_unavailable_address_domain() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2393,7 +2435,7 @@ fn storage_write_unavailable_address_domain() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let block_context = BlockContext::default();
     let mut tx_execution_context = TransactionExecutionContext::new(
@@ -2455,7 +2497,7 @@ fn library_call_failure() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2476,7 +2518,10 @@ fn library_call_failure() {
     let lib_class_hash: ClassHash = [2; 32];
     let lib_nonce = Felt252::zero();
 
-    contract_class_cache.insert(lib_class_hash, lib_contract_class);
+    contract_class_cache.insert(
+        lib_class_hash,
+        CompiledClass::Casm(Arc::new(lib_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(lib_address.clone(), lib_class_hash);
@@ -2485,7 +2530,7 @@ fn library_call_failure() {
         .insert(lib_address, lib_nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [25.into(), Felt252::from_bytes_be(&lib_class_hash)].to_vec();
@@ -2564,7 +2609,7 @@ fn send_messages_to_l1_different_contract_calls() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2585,7 +2630,10 @@ fn send_messages_to_l1_different_contract_calls() {
     let send_msg_class_hash: ClassHash = [2; 32];
     let send_msg_nonce = Felt252::zero();
 
-    contract_class_cache.insert(send_msg_class_hash, send_msg_contract_class);
+    contract_class_cache.insert(
+        send_msg_class_hash,
+        CompiledClass::Casm(Arc::new(send_msg_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(send_msg_address.clone(), send_msg_class_hash);
@@ -2594,7 +2642,7 @@ fn send_messages_to_l1_different_contract_calls() {
         .insert(send_msg_address, send_msg_nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [25.into(), 50.into(), 75.into()].to_vec();
@@ -2679,13 +2727,12 @@ fn send_messages_to_l1_different_contract_calls_cairo1_to_cairo0() {
 
     // Create state reader with class hash data
     let mut contract_class_cache = HashMap::new();
-    let mut deprecated_contract_class_cache = HashMap::new();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2703,7 +2750,10 @@ fn send_messages_to_l1_different_contract_calls_cairo1_to_cairo0() {
     let send_msg_class_hash: ClassHash = [2; 32];
     let send_msg_nonce = Felt252::zero();
 
-    deprecated_contract_class_cache.insert(send_msg_class_hash, send_msg_contract_class);
+    contract_class_cache.insert(
+        send_msg_class_hash,
+        CompiledClass::Deprecated(Arc::new(send_msg_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(send_msg_address.clone(), send_msg_class_hash);
@@ -2712,11 +2762,7 @@ fn send_messages_to_l1_different_contract_calls_cairo1_to_cairo0() {
         .insert(send_msg_address, send_msg_nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        Some(deprecated_contract_class_cache),
-        Some(contract_class_cache),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [25.into(), 50.into(), 75.into()].to_vec();
@@ -2796,13 +2842,15 @@ fn send_messages_to_l1_different_contract_calls_cairo0_to_cairo1() {
 
     // Create state reader with class hash data
     let mut contract_class_cache = HashMap::new();
-    let mut deprecated_contract_class_cache = HashMap::new();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    deprecated_contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2823,7 +2871,10 @@ fn send_messages_to_l1_different_contract_calls_cairo0_to_cairo1() {
     let send_msg_class_hash: ClassHash = [2; 32];
     let send_msg_nonce = Felt252::zero();
 
-    contract_class_cache.insert(send_msg_class_hash, send_msg_contract_class);
+    contract_class_cache.insert(
+        send_msg_class_hash,
+        CompiledClass::Casm(Arc::new(send_msg_contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(send_msg_address.clone(), send_msg_class_hash);
@@ -2832,11 +2883,7 @@ fn send_messages_to_l1_different_contract_calls_cairo0_to_cairo1() {
         .insert(send_msg_address, send_msg_nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        Some(deprecated_contract_class_cache),
-        Some(contract_class_cache),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [25.into(), 50.into(), 75.into()].to_vec();
@@ -2920,7 +2967,7 @@ fn keccak_syscall() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -2930,7 +2977,7 @@ fn keccak_syscall() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     let block_context = BlockContext::default();
     let mut tx_execution_context = TransactionExecutionContext::new(

--- a/tests/complex_contracts/amm_contracts/amm.rs
+++ b/tests/complex_contracts/amm_contracts/amm.rs
@@ -54,11 +54,7 @@ fn swap(calldata: &[Felt252], call_config: &mut CallConfig) -> Result<CallInfo, 
 #[test]
 fn amm_init_pool_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -124,11 +120,7 @@ fn amm_init_pool_test() {
 #[test]
 fn amm_add_demo_tokens_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -203,11 +195,7 @@ fn amm_add_demo_tokens_test() {
 #[test]
 fn amm_get_pool_token_balance() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -279,11 +267,7 @@ fn amm_get_pool_token_balance() {
 #[test]
 fn amm_swap_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -381,11 +365,7 @@ fn amm_swap_test() {
 #[test]
 fn amm_init_pool_should_fail_with_amount_out_of_bounds() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -421,11 +401,7 @@ fn amm_init_pool_should_fail_with_amount_out_of_bounds() {
 #[test]
 fn amm_swap_should_fail_with_unexistent_token() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -461,11 +437,7 @@ fn amm_swap_should_fail_with_unexistent_token() {
 #[test]
 fn amm_swap_should_fail_with_amount_out_of_bounds() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -501,11 +473,7 @@ fn amm_swap_should_fail_with_amount_out_of_bounds() {
 #[test]
 fn amm_swap_should_fail_when_user_does_not_have_enough_funds() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -544,11 +512,7 @@ fn amm_swap_should_fail_when_user_does_not_have_enough_funds() {
 #[test]
 fn amm_get_account_token_balance_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,

--- a/tests/complex_contracts/amm_contracts/amm_proxy.rs
+++ b/tests/complex_contracts/amm_contracts/amm_proxy.rs
@@ -17,11 +17,7 @@ use std::sync::Arc;
 #[test]
 fn amm_proxy_init_pool_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -118,11 +114,7 @@ fn amm_proxy_init_pool_test() {
 #[test]
 fn amm_proxy_get_pool_token_balance_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -226,11 +218,7 @@ fn amm_proxy_get_pool_token_balance_test() {
 #[test]
 fn amm_proxy_add_demo_token_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -340,11 +328,7 @@ fn amm_proxy_add_demo_token_test() {
 #[test]
 fn amm_proxy_get_account_token_balance() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -467,11 +451,7 @@ fn amm_proxy_get_account_token_balance() {
 #[test]
 fn amm_proxy_swap() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,

--- a/tests/complex_contracts/nft/erc721.rs
+++ b/tests/complex_contracts/nft/erc721.rs
@@ -24,11 +24,7 @@ use crate::complex_contracts::utils::*;
 #[test]
 fn erc721_constructor_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be(b"some-nft");
     let collection_symbol = Felt252::from(555);
@@ -71,11 +67,7 @@ fn erc721_constructor_test() {
 #[test]
 fn erc721_balance_of_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -162,11 +154,7 @@ fn erc721_balance_of_test() {
 #[test]
 fn erc721_test_owner_of() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -245,11 +233,7 @@ fn erc721_test_owner_of() {
 #[test]
 fn erc721_test_get_approved() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -345,11 +329,7 @@ fn erc721_test_get_approved() {
 #[test]
 fn erc721_test_is_approved_for_all() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -448,11 +428,7 @@ fn erc721_test_is_approved_for_all() {
 #[test]
 fn erc721_test_approve() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -553,11 +529,7 @@ fn erc721_test_approve() {
 #[test]
 fn erc721_set_approval_for_all() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -652,11 +624,7 @@ fn erc721_set_approval_for_all() {
 #[test]
 fn erc721_transfer_from_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -793,11 +761,7 @@ fn erc721_transfer_from_test() {
 #[test]
 fn erc721_transfer_from_and_get_owner_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -885,11 +849,7 @@ fn erc721_transfer_from_and_get_owner_test() {
 #[test]
 fn erc721_safe_transfer_from_should_fail_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -953,11 +913,7 @@ fn erc721_safe_transfer_from_should_fail_test() {
 #[test]
 fn erc721_calling_constructor_twice_should_fail_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -1003,11 +959,7 @@ fn erc721_calling_constructor_twice_should_fail_test() {
 #[test]
 fn erc721_constructor_should_fail_with_to_equal_zero() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -1031,11 +983,7 @@ fn erc721_constructor_should_fail_with_to_equal_zero() {
 #[test]
 fn erc721_transfer_fail_to_zero_address() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -1086,11 +1034,7 @@ fn erc721_transfer_fail_to_zero_address() {
 #[test]
 fn erc721_transfer_fail_not_owner() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(
-        Arc::new(InMemoryStateReader::default()),
-        Some(Default::default()),
-        None,
-    );
+    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);

--- a/tests/complex_contracts/utils.rs
+++ b/tests/complex_contracts/utils.rs
@@ -12,14 +12,19 @@ use starknet_in_rust::{
         execution_entry_point::{ExecutionEntryPoint, ExecutionResult},
         CallInfo, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::{cached_state::CachedState, state_api::State},
     state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
     transaction::{error::TransactionError, Deploy},
     utils::{calculate_sn_keccak, Address},
 };
 use starknet_in_rust::{ContractEntryPoint, EntryPointType};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 pub struct CallConfig<'a> {
     pub state: &'a mut CachedState<InMemoryStateReader>,
@@ -156,7 +161,10 @@ pub fn deploy(
         )?,
     };
     let class_hash = internal_deploy.class_hash();
-    state.set_contract_class(&class_hash, &contract_class)?;
+    state.set_contract_class(
+        &class_hash,
+        &CompiledClass::Deprecated(Arc::new(contract_class)),
+    )?;
 
     let tx_execution_info = internal_deploy.apply(state, block_context)?;
 

--- a/tests/delegate_call.rs
+++ b/tests/delegate_call.rs
@@ -2,6 +2,7 @@
 
 use cairo_vm::felt::Felt252;
 use num_traits::{One, Zero};
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
@@ -33,7 +34,10 @@ fn delegate_call() {
     let address = Address(Felt252::one()); // const CONTRACT_ADDRESS = 1;
     let class_hash = [2; 32];
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -64,7 +68,10 @@ fn delegate_call() {
     let address = Address(1111.into());
     let class_hash = [1; 32];
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(address.clone(), class_hash);
@@ -76,7 +83,7 @@ fn delegate_call() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     //* ------------------------------------
     //*    Create execution entry point

--- a/tests/delegate_l1_handler.rs
+++ b/tests/delegate_l1_handler.rs
@@ -2,6 +2,7 @@
 
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::{One, Zero};
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
@@ -34,7 +35,10 @@ fn delegate_l1_handler() {
     let address = Address(Felt252::one()); // const CONTRACT_ADDRESS = 1;
     let class_hash = [2; 32];
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -59,7 +63,10 @@ fn delegate_l1_handler() {
     let address = Address(1111.into());
     let class_hash = [1; 32];
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     state_reader
         .address_to_class_hash_mut()
         .insert(address.clone(), class_hash);
@@ -71,7 +78,7 @@ fn delegate_l1_handler() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     //* ------------------------------------
     //*    Create execution entry point

--- a/tests/deploy_account.rs
+++ b/tests/deploy_account.rs
@@ -20,7 +20,10 @@ use starknet_in_rust::{
     utils::Address,
     CasmContractClass,
 };
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 lazy_static! {
     static ref TEST_ACCOUNT_COMPILED_CONTRACT_CLASS_HASH: Felt252 = felt_str!("1");
@@ -29,7 +32,7 @@ lazy_static! {
 #[test]
 fn internal_deploy_account() {
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, None, None);
+    let mut state = CachedState::new(state_reader, HashMap::new());
 
     state.set_contract_classes(Default::default()).unwrap();
 
@@ -109,7 +112,7 @@ fn internal_deploy_account() {
 #[test]
 fn internal_deploy_account_cairo1() {
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, None, Some(Default::default()));
+    let mut state = CachedState::new(state_reader, HashMap::default());
 
     state.set_contract_classes(Default::default()).unwrap();
 

--- a/tests/deploy_account.rs
+++ b/tests/deploy_account.rs
@@ -4,7 +4,6 @@ use cairo_vm::{
 };
 use lazy_static::lazy_static;
 use num_traits::Zero;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     core::contract_address::compute_deprecated_class_hash,
     definitions::{
@@ -19,6 +18,9 @@ use starknet_in_rust::{
     transaction::DeployAccount,
     utils::Address,
     CasmContractClass,
+};
+use starknet_in_rust::{
+    services::api::contract_classes::compiled_class::CompiledClass, EntryPointType,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -43,7 +45,10 @@ fn internal_deploy_account() {
     let class_hash_bytes = class_hash.to_be_bytes();
 
     state
-        .set_contract_class(&class_hash_bytes, &contract_class)
+        .set_contract_class(
+            &class_hash_bytes,
+            &CompiledClass::Deprecated(Arc::new(contract_class)),
+        )
         .unwrap();
 
     let contract_address_salt =
@@ -123,9 +128,9 @@ fn internal_deploy_account_cairo1() {
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
 
     state
-        .set_compiled_class(
-            &TEST_ACCOUNT_COMPILED_CONTRACT_CLASS_HASH.clone(),
-            contract_class,
+        .set_contract_class(
+            &TEST_ACCOUNT_COMPILED_CONTRACT_CLASS_HASH.to_be_bytes(),
+            &CompiledClass::Casm(Arc::new(contract_class)),
         )
         .unwrap();
 

--- a/tests/fibonacci.rs
+++ b/tests/fibonacci.rs
@@ -6,6 +6,7 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use cairo_vm::{felt::Felt252, vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME};
 use num_traits::Zero;
 use starknet_in_rust::definitions::block_context::BlockContext;
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::constants::TRANSACTION_VERSION,
@@ -50,7 +51,10 @@ fn integration_test() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -63,7 +67,7 @@ fn integration_test() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     //* ------------------------------------
     //*    Create execution entry point
@@ -151,7 +155,7 @@ fn integration_test_cairo1() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -161,7 +165,7 @@ fn integration_test_cairo1() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), None, Some(contract_class_cache));
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     // Create an execution entry point
     let calldata = [0.into(), 1.into(), 12.into()].to_vec();

--- a/tests/increase_balance.rs
+++ b/tests/increase_balance.rs
@@ -3,6 +3,7 @@
 use cairo_vm::felt::Felt252;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_traits::Zero;
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
@@ -53,7 +54,10 @@ fn hello_starknet_increase_balance() {
     let storage_entry: StorageEntry = (address.clone(), [1; 32]);
     let storage = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -69,7 +73,7 @@ fn hello_starknet_increase_balance() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     //* ------------------------------------
     //*    Create execution entry point

--- a/tests/internal_calls.rs
+++ b/tests/internal_calls.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use cairo_vm::felt::Felt252;
 use num_traits::Zero;
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
@@ -15,6 +16,7 @@ use starknet_in_rust::{
     state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
     utils::{calculate_sn_keccak, Address, ClassHash},
 };
+use std::collections::HashMap;
 
 #[test]
 fn test_internal_calls() {
@@ -47,8 +49,10 @@ fn test_internal_calls() {
 
     let mut state = CachedState::new(
         Arc::new(state_reader),
-        Some([([0x01; 32], contract_class)].into_iter().collect()),
-        None,
+        HashMap::from([(
+            [0x01; 32],
+            CompiledClass::Deprecated(Arc::new(contract_class)),
+        )]),
     );
 
     let entry_point_selector = Felt252::from_bytes_be(&calculate_sn_keccak(b"a"));

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -1688,13 +1688,17 @@ fn expected_deploy_account_states() -> (
     state_after
         .set_contract_class(
             &felt_to_hash(&0x1010.into()),
-            &ContractClass::from_path(ERC20_CONTRACT_PATH).unwrap(),
+            &CompiledClass::Deprecated(Arc::new(
+                ContractClass::from_path(ERC20_CONTRACT_PATH).unwrap(),
+            )),
         )
         .unwrap();
     state_after
         .set_contract_class(
             &felt_to_hash(&0x111.into()),
-            &ContractClass::from_path(ACCOUNT_CONTRACT_PATH).unwrap(),
+            &CompiledClass::Deprecated(Arc::new(
+                ContractClass::from_path(ACCOUNT_CONTRACT_PATH).unwrap(),
+            )),
         )
         .unwrap();
 
@@ -2010,7 +2014,7 @@ fn test_library_call_with_declare_v2() {
         .insert(address.clone(), nonce);
 
     state
-        .set_compiled_class(&Felt252::from_bytes_be(&class_hash), contract_class)
+        .set_contract_class(&class_hash, &CompiledClass::Casm(Arc::new(contract_class)))
         .unwrap();
 
     let create_execute_extrypoint = |selector: &BigUint,

--- a/tests/multi_syscall_test.rs
+++ b/tests/multi_syscall_test.rs
@@ -1,6 +1,7 @@
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_vm::felt::Felt252;
 use num_traits::{Num, Zero};
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::utils::calculate_sn_keccak;
 use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
@@ -28,7 +29,7 @@ fn test_multiple_syscall() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -38,11 +39,7 @@ fn test_multiple_syscall() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(
-        Arc::new(state_reader),
-        None,
-        Some(contract_class_cache.clone()),
-    );
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache.clone());
 
     // Create an execution entry point
     let calldata = [].to_vec();

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -1,6 +1,7 @@
 use cairo_vm::felt::Felt252;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_traits::Zero;
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
@@ -50,7 +51,10 @@ fn integration_storage_test() {
     let storage_entry = (address.clone(), [90; 32]);
     let storage_value = Felt252::new(10902);
 
-    contract_class_cache.insert(class_hash, contract_class);
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Deprecated(Arc::new(contract_class)),
+    );
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -66,7 +70,7 @@ fn integration_storage_test() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), Some(contract_class_cache), None);
+    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
 
     //* ------------------------------------
     //*    Create execution entry point


### PR DESCRIPTION
# Unify deprecated and casm contract caches

## Description

Check out the issue #876 for a description.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
