### PR TITLE
Add SiR code to new RPC reader for further progress with testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,7 @@ dependencies = [
  "serde_with 3.1.0",
  "starknet",
  "starknet_api 0.4.1",
+ "starknet_in_rust",
  "thiserror",
  "ureq",
 ]

--- a/rpc_state_reader_sn_api/Cargo.toml
+++ b/rpc_state_reader_sn_api/Cargo.toml
@@ -22,3 +22,4 @@ serde_with = "3.0.0"
 dotenv = "0.15.0"
 cairo-vm = "0.8.5"
 blockifier = "0.2.0-rc0"
+starknet_in_rust = { path = "../", version = "0.3.1" }


### PR DESCRIPTION
Adds the code required to execute a transaction with SiR into the RPC SN, which will allow later to easily execute and compare blockifier with SiR
