### PR TITLE
Fix storage changes count for transactions with fee transfers

### DIFF
--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -14,13 +14,6 @@ pub(crate) const N_DEFAULT_TOPICS: usize = 1; // Events have one default topic.
 pub(crate) const CONSUMED_MSG_TO_L2_ENCODED_DATA_SIZE: usize =
     (L1_TO_L2_MSG_HEADER_SIZE + 1) - CONSUMED_MSG_TO_L2_N_TOPICS;
 
-/// Sender and sequencer balance updates.
-pub(crate) const FEE_TRANSFER_N_STORAGE_CHANGES: usize = 2;
-
-/// Exclude the sequencer balance update, since it's charged once throught the batch.
-pub(crate) const FEE_TRANSFER_N_STORAGE_CHANGES_TO_CHARGE: usize =
-    FEE_TRANSFER_N_STORAGE_CHANGES - 1;
-
 lazy_static! {
     pub(crate) static ref QUERY_VERSION_BASE: Felt252 =
         felt_str!("340282366920938463463374607431768211456");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ mod test {
         let transaction = Transaction::InvokeFunction(invoke_function);
 
         let estimated_fee = estimate_fee(&[transaction], state, &block_context).unwrap();
-        assert_eq!(estimated_fee[0], (3707, 3672));
+        assert_eq!(estimated_fee[0], (2483, 2448));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,7 @@ mod test {
         block_context.starknet_os_config.gas_price = 1;
 
         let estimated_fee = estimate_message_fee(&l1_handler, state, &block_context).unwrap();
-        assert_eq!(estimated_fee, (19709, 19695));
+        assert_eq!(estimated_fee, (18485, 18471));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1035,7 +1035,7 @@ mod test {
 
         assert_eq!(
             estimate_fee(&[deploy, invoke_tx], state, block_context,).unwrap(),
-            [(0, 3672), (0, 3672)]
+            [(0, 2448), (0, 2448)]
         );
     }
 

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -265,7 +265,6 @@ impl<T: StateReader> State for CachedState<T> {
             self.cache.storage_initial_values.clone(),
         );
 
-        let n_modified_contracts = {
             let storage_unique_updates = storage_updates.keys().map(|k| k.0.clone());
 
             let class_hash_updates: Vec<_> = subtract_mappings(
@@ -289,8 +288,6 @@ impl<T: StateReader> State for CachedState<T> {
             modified_contracts.extend(class_hash_updates);
             modified_contracts.extend(nonce_updates);
 
-            modified_contracts.len()
-        };
 
         // Add fee transfer storage update before actually charging it, as it needs to be included in the
         // calculation of the final fee.
@@ -300,9 +297,10 @@ impl<T: StateReader> State for CachedState<T> {
                 (fee_token_address.clone(), sender_low_key),
                 Felt252::default(),
             );
+            modified_contracts.remove(fee_token_address);
         }
 
-        Ok((n_modified_contracts, storage_updates.len()))
+        Ok((modified_contracts.len(), storage_updates.len()))
     }
 
     fn get_class_hash_at(&mut self, contract_address: &Address) -> Result<ClassHash, StateError> {

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -265,29 +265,28 @@ impl<T: StateReader> State for CachedState<T> {
             self.cache.storage_initial_values.clone(),
         );
 
-            let storage_unique_updates = storage_updates.keys().map(|k| k.0.clone());
+        let storage_unique_updates = storage_updates.keys().map(|k| k.0.clone());
 
-            let class_hash_updates: Vec<_> = subtract_mappings(
-                self.cache.class_hash_writes.clone(),
-                self.cache.class_hash_initial_values.clone(),
-            )
-            .keys()
-            .cloned()
-            .collect();
+        let class_hash_updates: Vec<_> = subtract_mappings(
+            self.cache.class_hash_writes.clone(),
+            self.cache.class_hash_initial_values.clone(),
+        )
+        .keys()
+        .cloned()
+        .collect();
 
-            let nonce_updates: Vec<_> = subtract_mappings(
-                self.cache.nonce_writes.clone(),
-                self.cache.nonce_initial_values.clone(),
-            )
-            .keys()
-            .cloned()
-            .collect();
+        let nonce_updates: Vec<_> = subtract_mappings(
+            self.cache.nonce_writes.clone(),
+            self.cache.nonce_initial_values.clone(),
+        )
+        .keys()
+        .cloned()
+        .collect();
 
-            let mut modified_contracts: HashSet<Address> = HashSet::new();
-            modified_contracts.extend(storage_unique_updates);
-            modified_contracts.extend(class_hash_updates);
-            modified_contracts.extend(nonce_updates);
-
+        let mut modified_contracts: HashSet<Address> = HashSet::new();
+        modified_contracts.extend(storage_unique_updates);
+        modified_contracts.extend(class_hash_updates);
+        modified_contracts.extend(nonce_updates);
 
         // Add fee transfer storage update before actually charging it, as it needs to be included in the
         // calculation of the final fee.

--- a/src/testing/state.rs
+++ b/src/testing/state.rs
@@ -361,7 +361,7 @@ mod tests {
         .unwrap();
 
         let mut actual_resources = HashMap::new();
-        actual_resources.insert("l1_gas_usage".to_string(), 3672);
+        actual_resources.insert("l1_gas_usage".to_string(), 2448);
         actual_resources.insert("n_steps".to_string(), 0);
 
         let transaction_exec_info = TransactionExecutionInfo {
@@ -584,7 +584,7 @@ mod tests {
         .unwrap();
         let actual_resources = HashMap::from([
             ("n_steps".to_string(), 3457),
-            ("l1_gas_usage".to_string(), 3672),
+            ("l1_gas_usage".to_string(), 2448),
             ("range_check_builtin".to_string(), 80),
             ("pedersen_builtin".to_string(), 16),
         ]);

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -438,7 +438,7 @@ mod tests {
 
         let actual_resources = HashMap::from([
             ("n_steps".to_string(), 2715),
-            ("l1_gas_usage".to_string(), 2448),
+            ("l1_gas_usage".to_string(), 1224),
             ("range_check_builtin".to_string(), 63),
             ("pedersen_builtin".to_string(), 15),
         ]);

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -339,7 +339,7 @@ mod test {
                 ("n_steps".to_string(), 1319),
                 ("pedersen_builtin".to_string(), 13),
                 ("range_check_builtin".to_string(), 23),
-                ("l1_gas_usage".to_string(), 19695),
+                ("l1_gas_usage".to_string(), 18471),
             ]),
             tx_type: Some(TransactionType::L1Handler),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,4 @@
 use crate::core::errors::hash_errors::HashError;
-use crate::definitions::constants::FEE_TRANSFER_N_STORAGE_CHANGES_TO_CHARGE;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
 use crate::state::state_api::State;
 use crate::{
@@ -188,7 +187,7 @@ pub fn calculate_tx_resources(
     let l1_gas_usage = calculate_tx_gas_usage(
         l2_to_l1_messages,
         n_modified_contracts,
-        n_storage_changes + FEE_TRANSFER_N_STORAGE_CHANGES_TO_CHARGE,
+        n_storage_changes,
         l1_handler_payload_size,
         n_deployments,
     );

--- a/tests/deploy_account.rs
+++ b/tests/deploy_account.rs
@@ -104,7 +104,7 @@ fn internal_deploy_account() {
                 ("n_steps", 3612),
                 ("pedersen_builtin", 23),
                 ("range_check_builtin", 83),
-                ("l1_gas_usage", 4896)
+                ("l1_gas_usage", 3672)
             ]
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
@@ -264,7 +264,7 @@ fn internal_deploy_account_cairo1() {
                 ("n_steps", n_steps),
                 ("pedersen_builtin", 23),
                 ("range_check_builtin", 87),
-                ("l1_gas_usage", 6120)
+                ("l1_gas_usage", 4896)
             ]
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -1243,7 +1243,7 @@ fn expected_transaction_execution_info(block_context: &BlockContext) -> Transact
     let resources = HashMap::from([
         ("n_steps".to_string(), 4135),
         ("pedersen_builtin".to_string(), 16),
-        ("l1_gas_usage".to_string(), 3672),
+        ("l1_gas_usage".to_string(), 2448),
         ("range_check_builtin".to_string(), 101),
     ]);
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, block_context).unwrap();
@@ -1525,12 +1525,12 @@ fn test_deploy_account() {
         ("n_steps".to_string(), 3625),
         ("range_check_builtin".to_string(), 83),
         ("pedersen_builtin".to_string(), 23),
-        ("l1_gas_usage".to_string(), 6120),
+        ("l1_gas_usage".to_string(), 3672),
     ]);
 
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, &block_context).unwrap();
 
-    assert_eq!(fee, 6157);
+    assert_eq!(fee, 3709);
 
     let expected_execution_info = TransactionExecutionInfo::new(
         expected_validate_call_info.into(),
@@ -1564,7 +1564,7 @@ fn expected_deploy_account_states() -> (
     CachedState<InMemoryStateReader>,
     CachedState<InMemoryStateReader>,
 ) {
-    let fee = Felt252::from(6157);
+    let fee = Felt252::from(3709);
     let mut state_before = CachedState::new(
         Arc::new(InMemoryStateReader::new(
             HashMap::from([

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -937,7 +937,7 @@ fn test_declare_tx() {
         ("n_steps".to_string(), 2715),
         ("range_check_builtin".to_string(), 63),
         ("pedersen_builtin".to_string(), 15),
-        ("l1_gas_usage".to_string(), 3672),
+        ("l1_gas_usage".to_string(), 2448),
     ]);
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, &block_context).unwrap();
 
@@ -1025,7 +1025,7 @@ fn test_declarev2_tx() {
         ("n_steps".to_string(), 2715),
         ("range_check_builtin".to_string(), 63),
         ("pedersen_builtin".to_string(), 15),
-        ("l1_gas_usage".to_string(), 2448),
+        ("l1_gas_usage".to_string(), 1224),
     ]);
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, &block_context).unwrap();
 
@@ -1568,7 +1568,6 @@ fn expected_deploy_account_states() -> (
     let mut state_before = CachedState::new(
         Arc::new(InMemoryStateReader::new(
             HashMap::from([
-                (Address(0x101.into()), felt_to_hash(&0x111.into())),
                 (Address(0x100.into()), felt_to_hash(&0x110.into())),
                 (Address(0x1001.into()), felt_to_hash(&0x1010.into())),
             ]),

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -704,13 +704,13 @@ fn expected_fib_fee_transfer_info(fee: u128) -> CallInfo {
             ],
         }],
         storage_read_values: vec![
-            INITIAL_BALANCE.clone() - Felt252::from(2476),
+            INITIAL_BALANCE.clone() - Felt252::from(1252),
             Felt252::zero(),
-            INITIAL_BALANCE.clone() - Felt252::from(2476),
+            INITIAL_BALANCE.clone() - Felt252::from(1252),
             Felt252::zero(),
-            Felt252::from(2476),
+            Felt252::from(1252),
             Felt252::zero(),
-            Felt252::from(2476),
+            Felt252::from(1252),
             Felt252::zero(),
         ],
         accessed_storage_keys: HashSet::from([
@@ -1272,7 +1272,7 @@ fn expected_fib_transaction_execution_info(
     }
     let resources = HashMap::from([
         ("n_steps".to_string(), n_steps),
-        ("l1_gas_usage".to_string(), 7344),
+        ("l1_gas_usage".to_string(), 4896),
         ("pedersen_builtin".to_string(), 16),
         ("range_check_builtin".to_string(), 104),
     ]);
@@ -1455,7 +1455,7 @@ fn test_invoke_with_declarev2_tx() {
 fn test_deploy_account() {
     let (block_context, mut state) = create_account_tx_test_state().unwrap();
 
-    let expected_fee = 6157;
+    let expected_fee = 3709;
 
     let deploy_account_tx = DeployAccount::new(
         felt_to_hash(&TEST_ACCOUNT_CONTRACT_CLASS_HASH),
@@ -1530,7 +1530,7 @@ fn test_deploy_account() {
 
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, &block_context).unwrap();
 
-    assert_eq!(fee, 3709);
+    assert_eq!(fee, expected_fee);
 
     let expected_execution_info = TransactionExecutionInfo::new(
         expected_validate_call_info.into(),
@@ -1797,7 +1797,7 @@ fn test_state_for_declare_tx() {
     //     ])
     // );
 
-    let fee = Felt252::from(3700);
+    let fee = Felt252::from(2476);
 
     // Check state.cache
     assert_eq!(


### PR DESCRIPTION
Fixes the following bugs:
The storage update related to the fee transfer was counted twice (It was first added in count_actual_storage_changes, and then a + 1 constant was added when calculating the tx resources)
The fee token contract was counted when counting the modified contracts

This fully fixes the fee variations in the first two transactions listed in #1010 
## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
