### PR TITLE
Remove redundant `tx_type` field from transactions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,6 @@ mod test {
             EXECUTE_ENTRY_POINT_SELECTOR, VALIDATE_DECLARE_ENTRY_POINT_SELECTOR,
             VALIDATE_ENTRY_POINT_SELECTOR,
         },
-        transaction_type::TransactionType,
     };
     use crate::estimate_fee;
     use crate::estimate_message_fee;
@@ -870,7 +869,6 @@ mod test {
 
         DeclareV2 {
             sender_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
-            tx_type: TransactionType::Declare,
             validate_entry_point_selector: VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone(),
             version: 1.into(),
             max_fee: INITIAL_GAS_COST,

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -39,7 +39,6 @@ use std::sync::Arc;
 pub struct Declare {
     pub class_hash: ClassHash,
     pub sender_address: Address,
-    pub tx_type: TransactionType,
     pub validate_entry_point_selector: Felt252,
     pub version: Felt252,
     pub max_fee: u128,
@@ -83,7 +82,6 @@ impl Declare {
         let internal_declare = Declare {
             class_hash,
             sender_address,
-            tx_type: TransactionType::Declare,
             validate_entry_point_selector,
             version,
             max_fee,
@@ -124,7 +122,6 @@ impl Declare {
         let internal_declare = Declare {
             class_hash,
             sender_address,
-            tx_type: TransactionType::Declare,
             validate_entry_point_selector,
             version,
             max_fee,
@@ -187,7 +184,7 @@ impl Declare {
             None,
             None,
             actual_resources,
-            Some(self.tx_type),
+            Some(TransactionType::Declare),
         ))
     }
 

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -35,7 +35,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct DeclareV2 {
     pub sender_address: Address,
-    pub tx_type: TransactionType,
     pub validate_entry_point_selector: Felt252,
     pub version: Felt252,
     pub max_fee: u128,
@@ -135,7 +134,6 @@ impl DeclareV2 {
             sierra_contract_class: sierra_contract_class.to_owned(),
             sierra_class_hash,
             sender_address,
-            tx_type: TransactionType::Declare,
             validate_entry_point_selector,
             version,
             max_fee,
@@ -327,7 +325,7 @@ impl DeclareV2 {
         let actual_resources = calculate_tx_resources(
             resources_manager,
             &[execution_result.call_info.clone()],
-            self.tx_type,
+            TransactionType::Declare,
             storage_changes,
             None,
             execution_result.n_reverted_steps,
@@ -350,7 +348,7 @@ impl DeclareV2 {
             None,
             None,
             actual_resources,
-            Some(self.tx_type),
+            Some(TransactionType::Declare),
         );
         tx_exec_info.set_fee_info(actual_fee, fee_transfer_info);
 

--- a/src/transaction/deploy.rs
+++ b/src/transaction/deploy.rs
@@ -43,7 +43,6 @@ pub struct Deploy {
     pub contract_hash: ClassHash,
     pub contract_class: CompiledClass,
     pub constructor_calldata: Vec<Felt252>,
-    pub tx_type: TransactionType,
     pub skip_validate: bool,
     pub skip_execute: bool,
     pub skip_fee_transfer: bool,
@@ -84,7 +83,6 @@ impl Deploy {
             contract_hash,
             contract_class: CompiledClass::Deprecated(Arc::new(contract_class)),
             constructor_calldata,
-            tx_type: TransactionType::Deploy,
             skip_validate: false,
             skip_execute: false,
             skip_fee_transfer: false,
@@ -117,7 +115,6 @@ impl Deploy {
             contract_hash,
             constructor_calldata,
             contract_class: CompiledClass::Deprecated(Arc::new(contract_class)),
-            tx_type: TransactionType::Deploy,
             skip_validate: false,
             skip_execute: false,
             skip_fee_transfer: false,
@@ -186,7 +183,7 @@ impl Deploy {
         let actual_resources = calculate_tx_resources(
             resources_manager,
             &[Some(call_info.clone())],
-            self.tx_type,
+            TransactionType::Deploy,
             changes,
             None,
             0,
@@ -197,7 +194,7 @@ impl Deploy {
             Some(call_info),
             None,
             actual_resources,
-            Some(self.tx_type),
+            Some(TransactionType::Deploy),
         ))
     }
 
@@ -249,7 +246,7 @@ impl Deploy {
         let actual_resources = calculate_tx_resources(
             resources_manager,
             &[call_info.clone()],
-            self.tx_type,
+            TransactionType::Deploy,
             changes,
             None,
             n_reverted_steps,
@@ -260,7 +257,7 @@ impl Deploy {
             call_info,
             revert_error,
             actual_resources,
-            Some(self.tx_type),
+            Some(TransactionType::Deploy),
         ))
     }
 

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -739,7 +739,6 @@ fn declare_tx() -> Declare {
         contract_class: ContractClass::from_path(TEST_EMPTY_CONTRACT_PATH).unwrap(),
         class_hash: felt_to_hash(&TEST_EMPTY_CONTRACT_CLASS_HASH),
         sender_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
-        tx_type: TransactionType::Declare,
         validate_entry_point_selector: VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone(),
         version: 1.into(),
         max_fee: 100000,
@@ -765,7 +764,6 @@ fn declarev2_tx() -> DeclareV2 {
 
     DeclareV2 {
         sender_address: TEST_ACCOUNT_CONTRACT_ADDRESS.clone(),
-        tx_type: TransactionType::Declare,
         validate_entry_point_selector: VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone(),
         version: 1.into(),
         max_fee: 50000000,
@@ -808,7 +806,6 @@ fn deploy_fib_syscall() -> Deploy {
         contract_hash,
         contract_class,
         constructor_calldata: Vec::new(),
-        tx_type: TransactionType::Deploy,
         skip_execute: false,
         skip_fee_transfer: false,
         skip_validate: false,


### PR DESCRIPTION
# Remove redundant `tx_type` field from transactions

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
