### PR TITLE
perf: less CallInfo struct clones and other small improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
  "hashbrown 0.14.0",
 ]
@@ -3862,7 +3862,7 @@ dependencies = [
  "hex",
  "keccak",
  "lazy_static",
- "lru 0.11.0",
+ "lru 0.11.1",
  "mimalloc",
  "num-bigint",
  "num-integer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
+dependencies = [
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,7 +2647,7 @@ checksum = "5f4e3bc495f6e95bc15a6c0c55ac00421504a5a43d09e3cc455d1fea7015581d"
 dependencies = [
  "bitvec",
  "either",
- "lru",
+ "lru 0.7.8",
  "num-bigint",
  "num-integer",
  "num-modular",
@@ -3853,6 +3862,7 @@ dependencies = [
  "hex",
  "keccak",
  "lazy_static",
+ "lru 0.11.0",
  "mimalloc",
  "num-bigint",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde_json_pythonic = "0.1.2"
 [dev-dependencies]
 assert_matches = "1.5.0"
 coverage-helper = "0.2.0"
+lru = "0.11.0"
 pretty_assertions_sorted = "1.2.3"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -114,20 +114,44 @@ You can find an example on how to use the CLI [here](/docs/CLI_USAGE_EXAMPLE.md)
 
 #### Contract class cache behavior
 
-`starknet_in_rust` supports caching contracts in memory. The project provides two builtin cache
-policies: null and permanent. The null cache behaves as if there was no cache at all. The permanent
-cache caches everything in memory forever.
+`starknet_in_rust` supports caching contracts in memory. Caching the contracts is useful for
+avoiding excessive RPC API usage and keeping the contract class deserialization overhead to the
+minimum. The project provides two builtin cache policies: null and permanent. The null cache behaves
+as if there was no cache at all. The permanent cache caches everything in memory forever.
+
+In addition to those two, an example is provided that implements and uses an LRU cache policy.
+Long-running applications should ideally implement a cache algorithm suited to their needs or
+alternatively use our example's implementation to avoid spamming the API when using the null cache
+or blowing the memory usage when running with the permanent cache.
+
+Customized cache policies may be used by implementing the `ContractClassCache` trait. Check out our
+[LRU cache example](examples/lru_cache/main.rs) for more details. Updating the cache requires
+manually merging the local state cache into the shared cache manually. This can be done by calling
+the `drain_private_contract_class_cache` on the `CachedState` instance.
 
 ```rs
 // To use the null cache (aka. no cache at all), create the state as follows:
-let state = StarknetState::new(None, Arc::new(NullContractClassCache::default()));
+let cache = Arc::new(NullContractClassCache::default());
+let state1 = CachedState::new(state_reader.clone(), cache.clone());
+let state2 = CachedState::new(state_reader.clone(), cache.clone()); // Cache is reused.
 
-// If the permanent cache is preferred, then use `PermanentContractClassCache` instead:
-let state = StarknetState::new(None, Arc::new(PermanentContractClassCache::default()));
+// Insert state usage here.
+
+// The null cache doesn't have any method to extend it since it has no data.
 ```
 
-Custom cache policies are also supported by implementing a single trait. An example may be found
-[here](examples/lru_cache/main.rs).
+```rs
+// If the permanent cache is preferred, then use `PermanentContractClassCache` instead:
+let cache = Arc::new(PermanentContractClassCache::default());
+let state1 = CachedState::new(state_reader.clone(), cache.clone());
+let state2 = CachedState::new(state_reader.clone(), cache.clone()); // Cache is reused.
+
+// Insert state usage here.
+
+// Extend the shared cache with the states' contracts after using them.
+cache.extend(state1.state.drain_private_contract_class_cache());
+cache.extend(state2.state.drain_private_contract_class_cache());
+```
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It makes use of [cairo-vm](https://github.com/lambdaclass/cairo-vm), the Rust im
 ### Dependencies
 - Rust 1.70
 - A working installation of cairo-lang 0.12 (for compiling the cairo files)
-- [Optional, for testing purposes] Heaptrack 
+- [Optional, for testing purposes] Heaptrack
 
 ### Installation
 
@@ -109,6 +109,26 @@ You can find a tutorial on running contracts [here](/examples/contract_execution
 ### Using the CLI
 You can find an example on how to use the CLI [here](/docs/CLI_USAGE_EXAMPLE.md)
 
+
+### Customization
+
+#### Contract class cache behavior
+
+`starknet_in_rust` supports caching contracts in memory. The project provides two builtin cache
+policies: null and permanent. The null cache behaves as if there was no cache at all. The permanent
+cache caches everything in memory forever.
+
+```rs
+// To use the null cache (aka. no cache at all), create the state as follows:
+let state = StarknetState::new(None, Arc::new(NullContractClassCache::default()));
+
+// If the permanent cache is preferred, then use `PermanentContractClassCache` instead:
+let state = StarknetState::new(None, Arc::new(PermanentContractClassCache::default()));
+```
+
+Custom cache policies are also supported by implementing a single trait. An example may be found
+[here](examples/lru_cache/main.rs).
+
 ### Testing
 
 [Add an Infura API key.](#rpc-state-reader)
@@ -138,7 +158,7 @@ $ make benchmark
 
 ## 🛠 Contributing
 
-The open source community is a fantastic place for learning, inspiration, and creation, and this is all thanks to contributions from people like you. Your contributions are **greatly appreciated**. 
+The open source community is a fantastic place for learning, inspiration, and creation, and this is all thanks to contributions from people like you. Your contributions are **greatly appreciated**.
 
 If you have any suggestions for how to improve the project, please feel free to fork the repo and create a pull request, or [open an issue](https://github.com/lambdaclass/starknet_in_rust/issues/new?labels=enhancement&title=feat%3A+) with the tag 'enhancement'.
 

--- a/bench/internals.rs
+++ b/bench/internals.rs
@@ -14,12 +14,15 @@ use starknet_in_rust::{
     services::api::contract_classes::{
         compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
     },
-    state::in_memory_state_reader::InMemoryStateReader,
     state::{cached_state::CachedState, state_api::State},
+    state::{
+        contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader,
+    },
     transaction::{declare::Declare, Deploy, DeployAccount, InvokeFunction},
     utils::Address,
 };
-use std::{collections::HashMap, hint::black_box, sync::Arc};
+use std::{hint::black_box, sync::Arc};
 
 lazy_static! {
     // include_str! doesn't seem to work in CI
@@ -63,7 +66,10 @@ fn deploy_account() {
     const RUNS: usize = 500;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, HashMap::new());
+    let mut state = CachedState::new(
+        state_reader,
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     state
         .set_contract_class(
@@ -102,7 +108,10 @@ fn declare() {
     const RUNS: usize = 5;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let state = CachedState::new(state_reader, HashMap::new());
+    let state = CachedState::new(
+        state_reader,
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let block_context = &Default::default();
 
@@ -134,7 +143,10 @@ fn deploy() {
     const RUNS: usize = 8;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, HashMap::new());
+    let mut state = CachedState::new(
+        state_reader,
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     state
         .set_contract_class(
@@ -172,7 +184,10 @@ fn invoke() {
     const RUNS: usize = 100;
 
     let state_reader = Arc::new(InMemoryStateReader::default());
-    let mut state = CachedState::new(state_reader, HashMap::new());
+    let mut state = CachedState::new(
+        state_reader,
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     state
         .set_contract_class(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,12 +27,14 @@ use starknet_in_rust::{
         compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
     },
     state::{cached_state::CachedState, state_api::State},
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager, StateDiff},
+    state::{
+        contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager, StateDiff,
+    },
     transaction::{error::TransactionError, InvokeFunction},
     utils::{felt_to_hash, string_to_hash, Address},
 };
 use std::{
-    collections::HashMap,
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -102,11 +104,11 @@ struct DevnetArgs {
 }
 
 struct AppState {
-    cached_state: Mutex<CachedState<InMemoryStateReader>>,
+    cached_state: Mutex<CachedState<InMemoryStateReader, PermanentContractClassCache>>,
 }
 
 fn declare_parser(
-    cached_state: &mut CachedState<InMemoryStateReader>,
+    cached_state: &mut CachedState<InMemoryStateReader, PermanentContractClassCache>,
     args: &DeclareArgs,
 ) -> Result<(Felt252, Felt252), ParserError> {
     let contract_class =
@@ -129,7 +131,7 @@ fn declare_parser(
 }
 
 fn deploy_parser(
-    cached_state: &mut CachedState<InMemoryStateReader>,
+    cached_state: &mut CachedState<InMemoryStateReader, PermanentContractClassCache>,
     args: &DeployArgs,
 ) -> Result<(Felt252, Felt252), ParserError> {
     let constructor_calldata = match &args.inputs {
@@ -155,7 +157,7 @@ fn deploy_parser(
 }
 
 fn invoke_parser(
-    cached_state: &mut CachedState<InMemoryStateReader>,
+    cached_state: &mut CachedState<InMemoryStateReader, PermanentContractClassCache>,
     args: &InvokeArgs,
 ) -> Result<(Felt252, Felt252), ParserError> {
     let contract_address = Address(
@@ -219,7 +221,7 @@ fn invoke_parser(
 }
 
 fn call_parser(
-    cached_state: &mut CachedState<InMemoryStateReader>,
+    cached_state: &mut CachedState<InMemoryStateReader, PermanentContractClassCache>,
     args: &CallArgs,
 ) -> Result<Vec<Felt252>, ParserError> {
     let contract_address = Address(
@@ -318,9 +320,9 @@ async fn call_req(data: web::Data<AppState>, args: web::Json<CallArgs>) -> HttpR
 
 pub async fn start_devnet(port: u16) -> Result<(), std::io::Error> {
     let cached_state = web::Data::new(AppState {
-        cached_state: Mutex::new(CachedState::<InMemoryStateReader>::new(
+        cached_state: Mutex::new(CachedState::new(
             Arc::new(InMemoryStateReader::default()),
-            HashMap::new(),
+            Arc::new(PermanentContractClassCache::default()),
         )),
     });
 

--- a/examples/contract_execution/main.rs
+++ b/examples/contract_execution/main.rs
@@ -12,10 +12,11 @@
 use cairo_vm::felt::Felt252;
 use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
+    state::contract_class_cache::PermanentContractClassCache,
     testing::state::StarknetState,
     utils::{calculate_sn_keccak, Address},
 };
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 fn main() {
     // replace this with the path to your compiled contract
@@ -25,7 +26,7 @@ fn main() {
     let entry_point: &str = "factorial";
 
     // replace this with the arguments for the entrypoint
-    let calldata: Vec<Felt252> = [1.into(), 1.into(), 10.into()].to_vec();
+    let calldata: Vec<Felt252> = [10.into()].to_vec();
 
     let retdata = test_contract(contract_path, entry_point, calldata);
 
@@ -47,7 +48,7 @@ fn test_contract(
     //* --------------------------------------------
     //*             Initialize state
     //* --------------------------------------------
-    let mut state = StarknetState::new(None);
+    let mut state = StarknetState::new(None, Arc::new(PermanentContractClassCache::default()));
 
     //* --------------------------------------------
     //*          Read contract from file

--- a/examples/lru_cache/main.rs
+++ b/examples/lru_cache/main.rs
@@ -1,0 +1,95 @@
+#![deny(warnings)]
+
+use cairo_vm::felt::Felt252;
+use lru::LruCache;
+use starknet_in_rust::{
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::contract_class_cache::ContractClassCache,
+    testing::state::StarknetState,
+    utils::{calculate_sn_keccak, Address, ClassHash},
+};
+use std::{
+    num::NonZeroUsize,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+fn main() {
+    let shared_cache = Arc::new(LruContractCache::new(NonZeroUsize::new(64).unwrap()));
+
+    let ret_data = run_contract(
+        "starknet_programs/factorial.json",
+        "factorial",
+        [10.into()],
+        shared_cache,
+    );
+
+    println!("{ret_data:?}");
+}
+
+fn run_contract<C>(
+    contract_path: impl AsRef<Path>,
+    entry_point: impl AsRef<str>,
+    calldata: impl Into<Vec<Felt252>>,
+    contract_cache: Arc<C>,
+) -> Vec<Felt252>
+where
+    C: ContractClassCache,
+{
+    let mut state = StarknetState::new(None, contract_cache);
+
+    let contract_class = ContractClass::from_path(contract_path.as_ref()).unwrap();
+    state.declare(contract_class.clone()).unwrap();
+
+    let (contract_address, _) = state
+        .deploy(contract_class, vec![], Felt252::default(), None, 0)
+        .unwrap();
+
+    let entry_point_selector =
+        Felt252::from_bytes_be(&calculate_sn_keccak(entry_point.as_ref().as_bytes()));
+    let caller_address = Address::default();
+
+    let call_info = state
+        .execute_entry_point_raw(
+            contract_address,
+            entry_point_selector,
+            calldata.into(),
+            caller_address,
+        )
+        .unwrap();
+
+    call_info.retdata
+}
+
+pub struct LruContractCache {
+    storage: Mutex<LruCache<ClassHash, CompiledClass>>,
+}
+
+impl LruContractCache {
+    pub fn new(cap: NonZeroUsize) -> Self {
+        Self {
+            storage: Mutex::new(LruCache::new(cap)),
+        }
+    }
+
+    pub fn extend<I>(&self, other: I)
+    where
+        I: IntoIterator<Item = (ClassHash, CompiledClass)>,
+    {
+        other.into_iter().for_each(|(k, v)| {
+            self.storage.lock().unwrap().put(k, v);
+        });
+    }
+}
+
+impl ContractClassCache for LruContractCache {
+    fn get_contract_class(&self, class_hash: ClassHash) -> Option<CompiledClass> {
+        self.storage.lock().unwrap().get(&class_hash).cloned()
+    }
+
+    fn set_contract_class(&self, class_hash: ClassHash, compiled_class: CompiledClass) {
+        self.storage.lock().unwrap().put(class_hash, compiled_class);
+    }
+}

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -3,33 +3,29 @@
 #[macro_use]
 extern crate honggfuzz;
 
-use cairo_vm::felt::Felt252;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use cairo_vm::{felt::Felt252, vm::runners::cairo_runner::ExecutionResources};
 use num_traits::Zero;
-use starknet_in_rust::execution::execution_entry_point::ExecutionResult;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
-        execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, TransactionExecutionContext,
+        execution_entry_point::{ExecutionEntryPoint, ExecutionResult},
+        CallInfo, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::cached_state::CachedState,
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        ExecutionResourcesManager,
+    },
     utils::{calculate_sn_keccak, Address},
+    EntryPointType,
 };
-
-use std::sync::Arc;
 use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
+    collections::HashSet, fs, path::PathBuf, process::Command, sync::Arc, thread, time::Duration,
 };
-
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use std::fs;
-use std::process::Command;
-use std::thread;
-use std::time::Duration;
 
 fn main() {
     println!("Starting fuzzer");
@@ -110,14 +106,14 @@ fn main() {
             //*    Create state reader with class hash data
             //* --------------------------------------------
 
-            let mut contract_class_cache = HashMap::new();
+            let contract_class_cache = PermanentContractClassCache::default();
 
             //  ------------ contract data --------------------
 
             let address = Address(1111.into());
             let class_hash = [1; 32];
 
-            contract_class_cache.insert(
+            contract_class_cache.set_contract_class(
                 class_hash,
                 CompiledClass::Deprecated(Arc::new(contract_class)),
             );
@@ -130,7 +126,8 @@ fn main() {
             //*    Create state with previous data
             //* ---------------------------------------
 
-            let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+            let mut state =
+                CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
             //* ------------------------------------
             //*    Create execution entry point

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -23,10 +23,8 @@ use starknet_in_rust::{
     execution::{CallInfo, TransactionExecutionInfo},
     services::api::contract_classes::compiled_class::CompiledClass,
     state::{
-        cached_state::{CachedState, ContractClassCache},
-        state_api::StateReader,
-        state_cache::StorageEntry,
-        BlockInfo,
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+        state_api::StateReader, state_cache::StorageEntry, BlockInfo,
     },
     transaction::{InvokeFunction, Transaction},
     utils::{Address, ClassHash},
@@ -146,7 +144,7 @@ pub fn execute_tx(
     let trace = rpc_reader.0.get_transaction_trace(&tx_hash);
     let receipt = rpc_reader.0.get_transaction_receipt(&tx_hash);
 
-    let class_cache = ContractClassCache::default();
+    let class_cache = Arc::new(PermanentContractClassCache::default());
     let mut state = CachedState::new(Arc::new(rpc_reader), class_cache);
 
     let block_context = BlockContext::new(

--- a/src/bin/deploy.rs
+++ b/src/bin/deploy.rs
@@ -1,11 +1,12 @@
 use lazy_static::lazy_static;
 use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
-    testing::state::StarknetState,
+    state::contract_class_cache::PermanentContractClassCache, testing::state::StarknetState,
 };
 
 #[cfg(feature = "with_mimalloc")]
 use mimalloc::MiMalloc;
+use std::sync::Arc;
 
 #[cfg(feature = "with_mimalloc")]
 #[global_allocator]
@@ -20,7 +21,8 @@ lazy_static! {
 
 fn main() {
     const RUNS: usize = 100;
-    let mut starknet_state = StarknetState::new(None);
+    let mut starknet_state =
+        StarknetState::new(None, Arc::new(PermanentContractClassCache::default()));
 
     for n in 0..RUNS {
         let contract_address_salt = n.into();

--- a/src/bin/deploy_invoke.rs
+++ b/src/bin/deploy_invoke.rs
@@ -1,11 +1,12 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::Zero;
 
 use starknet_in_rust::{
     services::api::contract_classes::deprecated_contract_class::ContractClass,
-    testing::state::StarknetState, utils::Address,
+    state::contract_class_cache::PermanentContractClassCache, testing::state::StarknetState,
+    utils::Address,
 };
 
 use lazy_static::lazy_static;
@@ -36,7 +37,8 @@ lazy_static! {
 
 fn main() {
     const RUNS: usize = 10000;
-    let mut starknet_state = StarknetState::new(None);
+    let mut starknet_state =
+        StarknetState::new(None, Arc::new(PermanentContractClassCache::default()));
     let contract_address_salt = 1.into();
 
     let (contract_address, _exec_info) = starknet_state

--- a/src/bin/fibonacci.rs
+++ b/src/bin/fibonacci.rs
@@ -1,18 +1,18 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
-
 use cairo_vm::felt::{felt_str, Felt252};
-use num_traits::Zero;
-
 use lazy_static::lazy_static;
+use num_traits::Zero;
 use starknet_in_rust::{
     services::api::contract_classes::{
         compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
     },
-    state::cached_state::CachedState,
-    state::in_memory_state_reader::InMemoryStateReader,
+    state::{
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader,
+    },
     testing::state::StarknetState,
     utils::Address,
 };
+use std::{path::PathBuf, sync::Arc};
 
 #[cfg(feature = "with_mimalloc")]
 use mimalloc::MiMalloc;
@@ -71,7 +71,7 @@ fn main() {
     }
 }
 
-fn create_initial_state() -> CachedState<InMemoryStateReader> {
+fn create_initial_state() -> CachedState<InMemoryStateReader, PermanentContractClassCache> {
     let cached_state = CachedState::new(
         {
             let mut state_reader = InMemoryStateReader::default();
@@ -92,7 +92,7 @@ fn create_initial_state() -> CachedState<InMemoryStateReader> {
                 .insert((CONTRACT_ADDRESS.clone(), [0; 32]), Felt252::zero());
             Arc::new(state_reader)
         },
-        HashMap::new(),
+        Arc::new(PermanentContractClassCache::default()),
     );
 
     cached_state

--- a/src/bin/invoke.rs
+++ b/src/bin/invoke.rs
@@ -1,19 +1,19 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
-
 use cairo_vm::felt::{felt_str, Felt252};
+use lazy_static::lazy_static;
 use num_traits::Zero;
-
 use starknet_in_rust::{
     services::api::contract_classes::{
         compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
     },
     state::cached_state::CachedState,
-    state::in_memory_state_reader::InMemoryStateReader,
+    state::{
+        contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader,
+    },
     testing::state::StarknetState,
     utils::Address,
 };
-
-use lazy_static::lazy_static;
+use std::{path::PathBuf, sync::Arc};
 
 #[cfg(feature = "with_mimalloc")]
 use mimalloc::MiMalloc;
@@ -85,7 +85,7 @@ fn main() {
     }
 }
 
-fn create_initial_state() -> CachedState<InMemoryStateReader> {
+fn create_initial_state() -> CachedState<InMemoryStateReader, PermanentContractClassCache> {
     let cached_state = CachedState::new(
         {
             let mut state_reader = InMemoryStateReader::default();
@@ -106,7 +106,7 @@ fn create_initial_state() -> CachedState<InMemoryStateReader> {
                 .insert((CONTRACT_ADDRESS.clone(), [0; 32]), Felt252::zero());
             Arc::new(state_reader)
         },
-        HashMap::new(),
+        Arc::new(PermanentContractClassCache::default()),
     );
 
     cached_state

--- a/src/bin/invoke_with_cachedstate.rs
+++ b/src/bin/invoke_with_cachedstate.rs
@@ -1,8 +1,6 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
-
 use cairo_vm::felt::{felt_str, Felt252};
+use lazy_static::lazy_static;
 use num_traits::Zero;
-
 use starknet_in_rust::{
     definitions::{
         block_context::{BlockContext, StarknetChainId, StarknetOsConfig},
@@ -12,12 +10,13 @@ use starknet_in_rust::{
         compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
     },
     state::in_memory_state_reader::InMemoryStateReader,
-    state::{cached_state::CachedState, BlockInfo},
+    state::{
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache, BlockInfo,
+    },
     transaction::InvokeFunction,
     utils::Address,
 };
-
-use lazy_static::lazy_static;
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 #[cfg(feature = "with_mimalloc")]
 use mimalloc::MiMalloc;
@@ -90,7 +89,7 @@ fn main() {
     }
 }
 
-fn create_initial_state() -> CachedState<InMemoryStateReader> {
+fn create_initial_state() -> CachedState<InMemoryStateReader, PermanentContractClassCache> {
     let cached_state = CachedState::new(
         {
             let mut state_reader = InMemoryStateReader::default();
@@ -111,7 +110,7 @@ fn create_initial_state() -> CachedState<InMemoryStateReader> {
                 .insert((CONTRACT_ADDRESS.clone(), [0; 32]), Felt252::zero());
             Arc::new(state_reader)
         },
-        HashMap::new(),
+        Arc::new(PermanentContractClassCache::default()),
     );
 
     cached_state

--- a/src/core/errors/state_errors.rs
+++ b/src/core/errors/state_errors.rs
@@ -8,21 +8,17 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum StateError {
-    #[error("Missing ContractClassCache")]
-    MissingContractClassCache,
-    #[error("ContractClassCache must be None")]
-    AssignedContractClassCache,
     #[error("Missing key in StorageUpdate Map")]
     EmptyKeyInStorage,
     #[error("Try to create a CarriedState from a None parent")]
     ParentCarriedStateIsNone,
     #[error("Cache already initialized")]
     StateCacheAlreadyInitialized,
-    #[error("No contract state assigned for contact address: {0:?}")]
+    #[error("No contract state assigned for contract address: {0:?}")]
     NoneContractState(Address),
-    #[error("No class hash assigned for contact address: {0:?}")]
+    #[error("No class hash assigned for contract address: {0:?}")]
     NoneClassHash(Address),
-    #[error("No nonce assigned for contact address: {0:?}")]
+    #[error("No nonce assigned for contract address: {0:?}")]
     NoneNonce(Address),
     #[error("No storage value assigned for entry: {0:?}")]
     NoneStorage(StorageEntry),
@@ -34,20 +30,16 @@ pub enum StateError {
     ContractAddressUnavailable(Address),
     #[error(transparent)]
     ContractClass(#[from] ContractClassError),
-    #[error("Missing CasmClassCache")]
-    MissingCasmClassCache,
     #[error("Constructor calldata is empty")]
-    ConstructorCalldataEmpty(),
+    ConstructorCalldataEmpty,
     #[error("Error in ExecutionEntryPoint")]
-    ExecutionEntryPoint(),
+    ExecutionEntryPoint,
     #[error("No compiled class found for compiled_class_hash {0:?}")]
     NoneCompiledClass(ClassHash),
     #[error("No compiled class hash found for class_hash {0:?}")]
     NoneCompiledHash(ClassHash),
     #[error("Missing casm class for hash {0:?}")]
     MissingCasmClass(ClassHash),
-    #[error("No class hash declared in class_hash_to_contract_class")]
-    MissingClassHash(),
     #[error("Uninitializes class_hash")]
     UninitiaizedClassHash,
     #[error(transparent)]

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -1,18 +1,20 @@
-use std::sync::Arc;
-
-use crate::services::api::contract_classes::deprecated_contract_class::{
-    ContractEntryPoint, EntryPointType,
+use super::{
+    CallInfo, CallResult, CallType, OrderedEvent, OrderedL2ToL1Message, TransactionExecutionContext,
 };
-use crate::state::cached_state::CachedState;
 use crate::{
     definitions::{block_context::BlockContext, constants::DEFAULT_ENTRY_POINT_SELECTOR},
     runner::StarknetRunner,
     services::api::contract_classes::{
-        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+        compiled_class::CompiledClass,
+        deprecated_contract_class::{ContractClass, ContractEntryPoint, EntryPointType},
     },
-    state::state_api::State,
-    state::ExecutionResourcesManager,
-    state::{contract_storage_state::ContractStorageState, state_api::StateReader},
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::ContractClassCache,
+        contract_storage_state::ContractStorageState,
+        state_api::{State, StateReader},
+        ExecutionResourcesManager,
+    },
     syscalls::{
         business_logic_syscall_handler::BusinessLogicSyscallHandler,
         deprecated_business_logic_syscall_handler::DeprecatedBLSyscallHandler,
@@ -37,10 +39,7 @@ use cairo_vm::{
         vm_core::VirtualMachine,
     },
 };
-
-use super::{
-    CallInfo, CallResult, CallType, OrderedEvent, OrderedL2ToL1Message, TransactionExecutionContext,
-};
+use std::sync::Arc;
 
 #[derive(Debug, Default)]
 pub struct ExecutionResult {
@@ -93,9 +92,9 @@ impl ExecutionEntryPoint {
     /// The information collected from this run (number of steps required, modifications to the
     /// contract storage, etc.) is saved on the resources manager.
     /// Returns a CallInfo object that represents the execution.
-    pub fn execute<T>(
+    pub fn execute<T, C>(
         &self,
-        state: &mut CachedState<T>,
+        state: &mut CachedState<T, C>,
         block_context: &BlockContext,
         resources_manager: &mut ExecutionResourcesManager,
         tx_execution_context: &mut TransactionExecutionContext,
@@ -104,6 +103,7 @@ impl ExecutionEntryPoint {
     ) -> Result<ExecutionResult, TransactionError>
     where
         T: StateReader,
+        C: ContractClassCache,
     {
         // lookup the compiled class from the state.
         let class_hash = self.get_code_class_hash(state)?;
@@ -223,11 +223,11 @@ impl ExecutionEntryPoint {
             .ok_or(TransactionError::EntryPointNotFound)
     }
 
-    fn build_call_info_deprecated<S: StateReader>(
+    fn build_call_info_deprecated<S: StateReader, C: ContractClassCache>(
         &self,
         previous_cairo_usage: ExecutionResources,
         resources_manager: &ExecutionResourcesManager,
-        starknet_storage_state: ContractStorageState<S>,
+        starknet_storage_state: ContractStorageState<S, C>,
         events: Vec<OrderedEvent>,
         l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
         internal_calls: Vec<CallInfo>,
@@ -256,11 +256,11 @@ impl ExecutionEntryPoint {
         })
     }
 
-    fn build_call_info<S: StateReader>(
+    fn build_call_info<S: StateReader, C: ContractClassCache>(
         &self,
         previous_cairo_usage: ExecutionResources,
         resources_manager: &ExecutionResourcesManager,
-        starknet_storage_state: ContractStorageState<S>,
+        starknet_storage_state: ContractStorageState<S, C>,
         events: Vec<OrderedEvent>,
         l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
         internal_calls: Vec<CallInfo>,
@@ -296,10 +296,10 @@ impl ExecutionEntryPoint {
     /// Returns the hash of the executed contract class.
     fn get_code_class_hash<S: State>(&self, state: &mut S) -> Result<[u8; 32], TransactionError> {
         if self.class_hash.is_some() {
-            match self.call_type {
-                CallType::Delegate => return Ok(self.class_hash.unwrap()),
-                _ => return Err(TransactionError::CallTypeIsNotDelegate),
-            }
+            return match self.call_type {
+                CallType::Delegate => Ok(self.class_hash.unwrap()),
+                _ => Err(TransactionError::CallTypeIsNotDelegate),
+            };
         }
         let code_address = match self.call_type {
             CallType::Call => Some(self.contract_address.clone()),
@@ -315,9 +315,9 @@ impl ExecutionEntryPoint {
         get_deployed_address_class_hash_at_address(state, &code_address.unwrap())
     }
 
-    fn _execute_version0_class<S: StateReader>(
+    fn _execute_version0_class<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         resources_manager: &mut ExecutionResourcesManager,
         block_context: &BlockContext,
         tx_execution_context: &mut TransactionExecutionContext,
@@ -338,7 +338,7 @@ impl ExecutionEntryPoint {
         // prepare OS context
         //let os_context = runner.prepare_os_context();
         let os_context =
-            StarknetRunner::<DeprecatedSyscallHintProcessor<S>>::prepare_os_context_cairo0(
+            StarknetRunner::<DeprecatedSyscallHintProcessor<S, C>>::prepare_os_context_cairo0(
                 &cairo_runner,
                 &mut vm,
             );
@@ -409,7 +409,7 @@ impl ExecutionEntryPoint {
 
         let retdata = runner.get_return_values()?;
 
-        self.build_call_info_deprecated::<S>(
+        self.build_call_info_deprecated::<S, C>(
             previous_cairo_usage,
             resources_manager,
             runner.hint_processor.syscall_handler.starknet_storage_state,
@@ -420,9 +420,9 @@ impl ExecutionEntryPoint {
         )
     }
 
-    fn _execute<S: StateReader>(
+    fn _execute<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         resources_manager: &mut ExecutionResourcesManager,
         block_context: &BlockContext,
         tx_execution_context: &mut TransactionExecutionContext,
@@ -448,7 +448,7 @@ impl ExecutionEntryPoint {
         )?;
         validate_contract_deployed(state, &self.contract_address)?;
         // prepare OS context
-        let os_context = StarknetRunner::<SyscallHintProcessor<S>>::prepare_os_context_cairo1(
+        let os_context = StarknetRunner::<SyscallHintProcessor<S, C>>::prepare_os_context_cairo1(
             &cairo_runner,
             &mut vm,
             self.initial_gas.into(),
@@ -559,7 +559,7 @@ impl ExecutionEntryPoint {
         resources_manager.cairo_usage += &runner.get_execution_resources()?;
 
         let call_result = runner.get_call_result(self.initial_gas)?;
-        self.build_call_info::<S>(
+        self.build_call_info::<S, C>(
             previous_cairo_usage,
             resources_manager,
             runner.hint_processor.syscall_handler.starknet_storage_state,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,26 +2,24 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
+    definitions::block_context::BlockContext,
     execution::{
-        execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,
-        TransactionExecutionInfo,
+        execution_entry_point::{ExecutionEntryPoint, ExecutionResult},
+        CallType, TransactionExecutionContext, TransactionExecutionInfo,
     },
     state::{
+        cached_state::CachedState,
+        contract_class_cache::ContractClassCache,
         state_api::{State, StateReader},
         ExecutionResourcesManager,
     },
-    transaction::{error::TransactionError, Transaction},
+    transaction::{error::TransactionError, fee::calculate_tx_fee, L1Handler, Transaction},
+    utils::Address,
 };
-
 use cairo_vm::felt::Felt252;
-use definitions::block_context::BlockContext;
-use execution::execution_entry_point::ExecutionResult;
-use state::cached_state::CachedState;
-use transaction::{fee::calculate_tx_fee, L1Handler};
-use utils::Address;
 
 #[cfg(test)]
 #[macro_use]
@@ -31,9 +29,10 @@ extern crate assert_matches;
 pub use crate::services::api::contract_classes::deprecated_contract_class::{
     ContractEntryPoint, EntryPointType,
 };
-pub use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-pub use cairo_lang_starknet::contract_class::ContractClass;
-pub use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
+pub use cairo_lang_starknet::{
+    casm_contract_class::CasmContractClass, contract_class::ContractClass,
+    contract_class::ContractClass as SierraContractClass,
+};
 pub use cairo_vm::felt;
 
 pub mod core;
@@ -51,9 +50,10 @@ pub mod transaction;
 pub mod utils;
 
 #[allow(clippy::too_many_arguments)]
-pub fn simulate_transaction<S: StateReader>(
+pub fn simulate_transaction<S: StateReader, C: ContractClassCache>(
     transactions: &[&Transaction],
     state: S,
+    contract_class_cache: Arc<C>,
     block_context: &BlockContext,
     remaining_gas: u128,
     skip_validate: bool,
@@ -62,7 +62,7 @@ pub fn simulate_transaction<S: StateReader>(
     ignore_max_fee: bool,
     skip_nonce_check: bool,
 ) -> Result<Vec<TransactionExecutionInfo>, TransactionError> {
-    let mut cache_state = CachedState::new(Arc::new(state), HashMap::new());
+    let mut cache_state = CachedState::new(Arc::new(state), contract_class_cache);
     let mut result = Vec::with_capacity(transactions.len());
     for transaction in transactions {
         let tx_for_simulation = transaction.create_for_simulation(
@@ -81,13 +81,14 @@ pub fn simulate_transaction<S: StateReader>(
 }
 
 /// Estimate the fee associated with transaction
-pub fn estimate_fee<T>(
+pub fn estimate_fee<T, C>(
     transactions: &[Transaction],
-    mut cached_state: CachedState<T>,
+    mut cached_state: CachedState<T, C>,
     block_context: &BlockContext,
 ) -> Result<Vec<(u128, usize)>, TransactionError>
 where
     T: StateReader,
+    C: ContractClassCache,
 {
     let mut result = Vec::with_capacity(transactions.len());
     for transaction in transactions {
@@ -112,11 +113,11 @@ where
     Ok(result)
 }
 
-pub fn call_contract<T: StateReader>(
+pub fn call_contract<T: StateReader, C: ContractClassCache>(
     contract_address: Felt252,
     entrypoint_selector: Felt252,
     calldata: Vec<Felt252>,
-    state: &mut CachedState<T>,
+    state: &mut CachedState<T, C>,
     block_context: BlockContext,
     caller_address: Address,
 ) -> Result<Vec<Felt252>, TransactionError> {
@@ -166,17 +167,15 @@ pub fn call_contract<T: StateReader>(
 }
 
 /// Estimate the fee associated with L1Handler
-pub fn estimate_message_fee<T>(
+pub fn estimate_message_fee<T, C>(
     l1_handler: &L1Handler,
-    state: T,
+    mut cached_state: CachedState<T, C>,
     block_context: &BlockContext,
 ) -> Result<(u128, usize), TransactionError>
 where
     T: StateReader,
+    C: ContractClassCache,
 {
-    // This is used as a copy of the original state, we can update this cached state freely.
-    let mut cached_state = CachedState::<T>::new(Arc::new(state), HashMap::new());
-
     // Check if the contract is deployed.
     cached_state.get_class_hash_at(l1_handler.contract_address())?;
 
@@ -194,9 +193,9 @@ where
     }
 }
 
-pub fn execute_transaction<S: StateReader>(
+pub fn execute_transaction<S: StateReader, C: ContractClassCache>(
     tx: Transaction,
-    state: &mut CachedState<S>,
+    state: &mut CachedState<S, C>,
     block_context: BlockContext,
     remaining_gas: u128,
 ) -> Result<TransactionExecutionInfo, TransactionError> {
@@ -205,52 +204,48 @@ pub fn execute_transaction<S: StateReader>(
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-    use std::sync::Arc;
-
-    use crate::core::contract_address::{compute_deprecated_class_hash, compute_sierra_class_hash};
-    use crate::definitions::constants::INITIAL_GAS_COST;
-    use crate::definitions::{
-        block_context::StarknetChainId,
-        constants::{
-            EXECUTE_ENTRY_POINT_SELECTOR, VALIDATE_DECLARE_ENTRY_POINT_SELECTOR,
-            VALIDATE_ENTRY_POINT_SELECTOR,
-        },
-    };
-    use crate::estimate_fee;
-    use crate::estimate_message_fee;
-    use crate::hash_utils::calculate_contract_address;
-    use crate::services::api::contract_classes::deprecated_contract_class::ContractClass;
-    use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
-    use crate::state::state_api::State;
-    use crate::testing::{
-        create_account_tx_test_state, TEST_ACCOUNT_CONTRACT_ADDRESS, TEST_CONTRACT_ADDRESS,
-        TEST_CONTRACT_PATH, TEST_FIB_COMPILED_CONTRACT_CLASS_HASH,
-    };
-    use crate::transaction::{
-        Declare, DeclareV2, Deploy, DeployAccount, InvokeFunction, L1Handler, Transaction,
-    };
-    use crate::utils::felt_to_hash;
-    use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-    use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
-    use cairo_vm::felt::{felt_str, Felt252};
-    use num_traits::{Num, One, Zero};
-
     use crate::{
         call_contract,
-        definitions::block_context::BlockContext,
+        core::contract_address::{compute_deprecated_class_hash, compute_sierra_class_hash},
+        definitions::{
+            block_context::{BlockContext, StarknetChainId},
+            constants::{
+                EXECUTE_ENTRY_POINT_SELECTOR, INITIAL_GAS_COST,
+                VALIDATE_DECLARE_ENTRY_POINT_SELECTOR, VALIDATE_ENTRY_POINT_SELECTOR,
+            },
+        },
+        estimate_fee, estimate_message_fee,
+        hash_utils::calculate_contract_address,
+        services::api::contract_classes::{
+            compiled_class::CompiledClass,
+            deprecated_contract_class::{ContractClass, EntryPointType},
+        },
         simulate_transaction,
         state::{
-            cached_state::CachedState, in_memory_state_reader::InMemoryStateReader,
+            cached_state::CachedState,
+            contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+            in_memory_state_reader::InMemoryStateReader,
+            state_api::State,
             ExecutionResourcesManager,
         },
-        utils::{Address, ClassHash},
+        testing::{
+            create_account_tx_test_state, TEST_ACCOUNT_CONTRACT_ADDRESS, TEST_CONTRACT_ADDRESS,
+            TEST_CONTRACT_PATH, TEST_FIB_COMPILED_CONTRACT_CLASS_HASH,
+        },
+        transaction::{
+            Declare, DeclareV2, Deploy, DeployAccount, InvokeFunction, L1Handler, Transaction,
+        },
+        utils::{felt_to_hash, Address, ClassHash},
     };
-
-    use crate::services::api::contract_classes::compiled_class::CompiledClass;
+    use cairo_lang_starknet::{
+        casm_contract_class::CasmContractClass,
+        contract_class::ContractClass as SierraContractClass,
+    };
+    use cairo_vm::felt::{felt_str, Felt252};
     use lazy_static::lazy_static;
+    use num_traits::{Num, One, Zero};
     use pretty_assertions_sorted::assert_eq;
+    use std::{path::PathBuf, sync::Arc};
 
     lazy_static! {
         // include_str! doesn't seem to work in CI
@@ -310,13 +305,14 @@ mod test {
         let entrypoints = contract_class.clone().entry_points_by_type;
         let entrypoint_selector = &entrypoints.external.get(0).unwrap().selector;
 
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         let address = Address(1111.into());
         let class_hash: ClassHash = [1; 32];
         let nonce = Felt252::zero();
 
-        contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+        contract_class_cache
+            .set_contract_class(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
         let mut state_reader = InMemoryStateReader::default();
         state_reader
             .address_to_class_hash_mut()
@@ -325,7 +321,7 @@ mod test {
             .address_to_nonce_mut()
             .insert(address.clone(), nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
         let calldata = [1.into(), 1.into(), 10.into()].to_vec();
 
         let retdata = call_contract(
@@ -366,7 +362,7 @@ mod test {
         // Set contract_class
         let class_hash = [1; 32];
         let contract_class = ContractClass::from_path("starknet_programs/l1l2.json").unwrap();
-        // Set contact_state
+        // Set contract_state
         let contract_address = Address(0.into());
         let nonce = Felt252::zero();
 
@@ -377,14 +373,16 @@ mod test {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         // Initialize state.contract_classes
-        let contract_classes = HashMap::from([(
+        state.contract_class_cache().set_contract_class(
             class_hash,
             CompiledClass::Deprecated(Arc::new(contract_class)),
-        )]);
-        state.set_contract_classes(contract_classes).unwrap();
+        );
 
         let mut block_context = BlockContext::default();
         block_context.starknet_os_config.gas_price = 1;
@@ -403,13 +401,14 @@ mod test {
         let entrypoints = contract_class.clone().entry_points_by_type;
         let entrypoint_selector = &entrypoints.external.get(0).unwrap().selector;
 
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         let address = Address(1111.into());
         let class_hash: ClassHash = [1; 32];
         let nonce = Felt252::zero();
 
-        contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+        contract_class_cache
+            .set_contract_class(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
 
         let mut state_reader = InMemoryStateReader::default();
         state_reader
@@ -419,7 +418,7 @@ mod test {
             .address_to_nonce_mut()
             .insert(address.clone(), nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
         let calldata = [1.into(), 1.into(), 10.into()].to_vec();
 
         let invoke = InvokeFunction::new(
@@ -559,6 +558,7 @@ mod test {
         let context = simulate_transaction(
             &[&invoke_1, &invoke_2, &invoke_3],
             state_reader,
+            Arc::new(PermanentContractClassCache::default()),
             &block_context,
             1000,
             false,
@@ -661,6 +661,7 @@ mod test {
         let context = simulate_transaction(
             &[&invoke],
             state_reader,
+            Arc::new(PermanentContractClassCache::default()),
             &block_context,
             1000,
             true,
@@ -679,7 +680,10 @@ mod test {
     #[test]
     fn test_simulate_deploy() {
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, HashMap::new());
+        let mut state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         state
             .set_contract_class(
@@ -706,7 +710,8 @@ mod test {
 
         simulate_transaction(
             &[&internal_deploy],
-            state,
+            state.clone(),
+            state.contract_class_cache().clone(),
             block_context,
             100_000_000,
             false,
@@ -721,7 +726,10 @@ mod test {
     #[test]
     fn test_simulate_declare() {
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let state = CachedState::new(state_reader, HashMap::new());
+        let state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let block_context = &Default::default();
 
@@ -743,7 +751,8 @@ mod test {
 
         simulate_transaction(
             &[&declare_tx],
-            state,
+            state.clone(),
+            state.contract_class_cache().clone(),
             block_context,
             100_000_000,
             false,
@@ -758,7 +767,10 @@ mod test {
     #[test]
     fn test_simulate_invoke() {
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, HashMap::new());
+        let mut state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         state
             .set_contract_class(
@@ -807,7 +819,8 @@ mod test {
 
         simulate_transaction(
             &[&invoke_tx],
-            state,
+            state.clone(),
+            state.contract_class_cache().clone(),
             &block_context,
             100_000_000,
             false,
@@ -822,7 +835,10 @@ mod test {
     #[test]
     fn test_simulate_deploy_account() {
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, HashMap::new());
+        let mut state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         state
             .set_contract_class(
@@ -850,7 +866,8 @@ mod test {
 
         simulate_transaction(
             &[&deploy_account_tx],
-            state,
+            state.clone(),
+            state.contract_class_cache().clone(),
             block_context,
             100_000_000,
             false,
@@ -894,7 +911,8 @@ mod test {
 
         simulate_transaction(
             &[&declare_tx],
-            state,
+            state.clone(),
+            state.contract_class_cache().clone(),
             &block_context,
             100_000_000,
             false,
@@ -934,7 +952,7 @@ mod test {
         // Set contract_class
         let class_hash = [1; 32];
         let contract_class = ContractClass::from_path("starknet_programs/l1l2.json").unwrap();
-        // Set contact_state
+        // Set contract_state
         let contract_address = Address(0.into());
         let nonce = Felt252::zero();
 
@@ -945,10 +963,10 @@ mod test {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
-
-        // Initialize state.contract_classes
-        state.set_contract_classes(HashMap::new()).unwrap();
+        let mut state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         state
             .set_contract_class(
@@ -962,7 +980,8 @@ mod test {
 
         simulate_transaction(
             &[&l1_handler_tx],
-            state,
+            state.clone(),
+            state.contract_class_cache().clone(),
             &block_context,
             100_000_000,
             false,
@@ -977,7 +996,10 @@ mod test {
     #[test]
     fn test_deploy_and_invoke_simulation() {
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let state = CachedState::new(state_reader, HashMap::new());
+        let state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let block_context = &Default::default();
 
@@ -1020,6 +1042,7 @@ mod test {
         simulate_transaction(
             &[&deploy, &invoke_tx],
             state.clone(),
+            state.contract_class_cache().clone(),
             block_context,
             100_000_000,
             false,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -426,7 +426,10 @@ mod test {
     use super::StarknetRunner;
     use crate::{
         state::cached_state::CachedState,
-        state::in_memory_state_reader::InMemoryStateReader,
+        state::{
+            contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader,
+        },
         syscalls::{
             deprecated_business_logic_syscall_handler::DeprecatedBLSyscallHandler,
             deprecated_syscall_handler::DeprecatedSyscallHintProcessor,
@@ -448,7 +451,12 @@ mod test {
         let cairo_runner = CairoRunner::new(&program, "starknet", false).unwrap();
         let mut vm = VirtualMachine::new(true);
 
-        let os_context = StarknetRunner::<SyscallHintProcessor<CachedState::<InMemoryStateReader>>>::prepare_os_context_cairo0(&cairo_runner, &mut vm);
+        let os_context = StarknetRunner::<
+            SyscallHintProcessor<
+                CachedState<InMemoryStateReader, PermanentContractClassCache>,
+                PermanentContractClassCache,
+            >,
+        >::prepare_os_context_cairo0(&cairo_runner, &mut vm);
 
         // is expected to return a pointer to the first segment as there is nothing more in the vm
         let expected = Vec::from([MaybeRelocatable::from((0, 0))]);
@@ -462,7 +470,7 @@ mod test {
         let cairo_runner = CairoRunner::new(&program, "starknet", false).unwrap();
         let vm = VirtualMachine::new(true);
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let hint_processor = DeprecatedSyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -478,7 +486,7 @@ mod test {
         let cairo_runner = CairoRunner::new(&program, "starknet", false).unwrap();
         let vm = VirtualMachine::new(true);
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let hint_processor = DeprecatedSyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -497,7 +505,7 @@ mod test {
         let cairo_runner = CairoRunner::new(&program, "starknet", false).unwrap();
         let vm = VirtualMachine::new(true);
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let hint_processor = DeprecatedSyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -519,7 +527,7 @@ mod test {
         let cairo_runner = CairoRunner::new(&program, "starknet", false).unwrap();
         let vm = VirtualMachine::new(true);
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let hint_processor = DeprecatedSyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -541,7 +549,7 @@ mod test {
         let cairo_runner = CairoRunner::new(&program, "starknet", false).unwrap();
         let vm = VirtualMachine::new(true);
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let hint_processor = DeprecatedSyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -563,7 +571,7 @@ mod test {
         vm.add_memory_segment();
         vm.compute_segments_effective_sizes();
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let hint_processor = DeprecatedSyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -586,7 +594,7 @@ mod test {
         vm.add_memory_segment();
         vm.compute_segments_effective_sizes();
 
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let hint_processor = DeprecatedSyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -115,7 +115,9 @@ impl<T: StateReader, C: ContractClassCache> CachedState<T, C> {
             state_reader,
             cache: self.cache.clone(),
             contract_class_cache: self.contract_class_cache.clone(),
-            contract_class_cache_private: RefCell::new(HashMap::default()),
+            contract_class_cache_private: RefCell::new(
+                self.contract_class_cache_private.borrow().clone(),
+            ),
             #[cfg(feature = "metrics")]
             cache_hits: 0,
             #[cfg(feature = "metrics")]

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -1,4 +1,5 @@
 use super::{
+    contract_class_cache::ContractClassCache,
     state_api::{State, StateReader},
     state_cache::{StateCache, StorageEntry},
 };
@@ -15,28 +16,32 @@ use cairo_vm::felt::Felt252;
 use getset::{Getters, MutGetters};
 use num_traits::Zero;
 use std::{
+    cell::RefCell,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
 
-pub type ContractClassCache = HashMap<ClassHash, CompiledClass>;
-
 pub const UNINITIALIZED_CLASS_HASH: &ClassHash = &[0u8; 32];
 
 /// Represents a cached state of contract classes with optional caches.
-#[derive(Default, Clone, Debug, Eq, Getters, MutGetters, PartialEq)]
-pub struct CachedState<T: StateReader> {
+#[derive(Default, Clone, Debug, Getters, MutGetters)]
+pub struct CachedState<T: StateReader, C: ContractClassCache> {
     pub state_reader: Arc<T>,
     #[getset(get = "pub", get_mut = "pub")]
     pub(crate) cache: StateCache,
-    #[get = "pub"]
-    pub(crate) contract_classes: ContractClassCache,
+
+    #[getset(get = "pub", get_mut = "pub")]
+    pub(crate) contract_class_cache: Arc<C>,
+    pub(crate) contract_class_cache_private: RefCell<HashMap<ClassHash, CompiledClass>>,
+
+    #[cfg(feature = "metrics")]
     cache_hits: usize,
+    #[cfg(feature = "metrics")]
     cache_misses: usize,
 }
 
 #[cfg(feature = "metrics")]
-impl<T: StateReader> CachedState<T> {
+impl<T: StateReader, C: ContractClassCache> CachedState<T, C> {
     #[inline(always)]
     pub fn add_hit(&mut self) {
         self.cache_hits += 1;
@@ -49,7 +54,7 @@ impl<T: StateReader> CachedState<T> {
 }
 
 #[cfg(not(feature = "metrics"))]
-impl<T: StateReader> CachedState<T> {
+impl<T: StateReader, C: ContractClassCache> CachedState<T, C> {
     #[inline(always)]
     pub fn add_hit(&mut self) {
         // does nothing
@@ -61,14 +66,18 @@ impl<T: StateReader> CachedState<T> {
     }
 }
 
-impl<T: StateReader> CachedState<T> {
+impl<T: StateReader, C: ContractClassCache> CachedState<T, C> {
     /// Constructor, creates a new cached state.
-    pub fn new(state_reader: Arc<T>, contract_classes: ContractClassCache) -> Self {
+    pub fn new(state_reader: Arc<T>, contract_classes: Arc<C>) -> Self {
         Self {
             cache: StateCache::default(),
             state_reader,
-            contract_classes,
+            contract_class_cache: contract_classes,
+            contract_class_cache_private: RefCell::new(HashMap::new()),
+
+            #[cfg(feature = "metrics")]
             cache_hits: 0,
+            #[cfg(feature = "metrics")]
             cache_misses: 0,
         }
     }
@@ -77,44 +86,45 @@ impl<T: StateReader> CachedState<T> {
     pub fn new_for_testing(
         state_reader: Arc<T>,
         cache: StateCache,
-        contract_classes: ContractClassCache,
+        contract_classes: Arc<C>,
     ) -> Self {
         Self {
             cache,
-            contract_classes,
             state_reader,
+            contract_class_cache: contract_classes,
+            contract_class_cache_private: RefCell::new(HashMap::new()),
+
+            #[cfg(feature = "metrics")]
             cache_hits: 0,
+            #[cfg(feature = "metrics")]
             cache_misses: 0,
         }
     }
 
-    /// Sets the contract classes cache.
-    pub fn set_contract_classes(
-        &mut self,
-        contract_classes: ContractClassCache,
-    ) -> Result<(), StateError> {
-        if !self.contract_classes.is_empty() {
-            return Err(StateError::AssignedContractClassCache);
-        }
-        self.contract_classes = contract_classes;
-        Ok(())
+    pub fn drain_private_contract_class_cache(
+        &self,
+    ) -> impl Iterator<Item = (ClassHash, CompiledClass)> {
+        self.contract_class_cache_private.take().into_iter()
     }
 
     /// Creates a copy of this state with an empty cache for saving changes and applying them
     /// later.
-    pub fn create_transactional(&self) -> TransactionalCachedState<T> {
+    pub fn create_transactional(&self) -> TransactionalCachedState<T, C> {
         let state_reader = Arc::new(TransactionalCachedStateReader::new(self));
         CachedState {
             state_reader,
             cache: self.cache.clone(),
-            contract_classes: self.contract_classes.clone(),
+            contract_class_cache: self.contract_class_cache.clone(),
+            contract_class_cache_private: RefCell::new(HashMap::default()),
+            #[cfg(feature = "metrics")]
             cache_hits: 0,
+            #[cfg(feature = "metrics")]
             cache_misses: 0,
         }
     }
 }
 
-impl<T: StateReader> StateReader for CachedState<T> {
+impl<T: StateReader, C: ContractClassCache> StateReader for CachedState<T, C> {
     /// Returns the class hash for a given contract address.
     /// Returns zero as default value if missing
     fn get_class_hash_at(&self, contract_address: &Address) -> Result<ClassHash, StateError> {
@@ -165,32 +175,50 @@ impl<T: StateReader> StateReader for CachedState<T> {
         }
 
         // I: FETCHING FROM CACHE
-        if let Some(compiled_class) = self.contract_classes.get(class_hash) {
+        let mut private_cache = self.contract_class_cache_private.borrow_mut();
+        if let Some(compiled_class) = private_cache.get(class_hash) {
             return Ok(compiled_class.clone());
+        } else if let Some(compiled_class) =
+            self.contract_class_cache().get_contract_class(*class_hash)
+        {
+            private_cache.insert(*class_hash, compiled_class.clone());
+            return Ok(compiled_class);
         }
 
         // I: CASM CONTRACT CLASS : CLASS_HASH
         if let Some(compiled_class_hash) =
             self.cache.class_hash_to_compiled_class_hash.get(class_hash)
         {
-            if let Some(casm_class) = self.contract_classes.get(compiled_class_hash) {
+            if let Some(casm_class) = private_cache.get(compiled_class_hash) {
                 return Ok(casm_class.clone());
+            } else if let Some(casm_class) = self
+                .contract_class_cache()
+                .get_contract_class(*compiled_class_hash)
+            {
+                private_cache.insert(*class_hash, casm_class.clone());
+                return Ok(casm_class);
             }
         }
 
         // II: FETCHING FROM STATE_READER
-        self.state_reader.get_contract_class(class_hash)
+        let contract_class = self.state_reader.get_contract_class(class_hash)?;
+        private_cache.insert(*class_hash, contract_class.clone());
+
+        Ok(contract_class)
     }
 }
 
-impl<T: StateReader> State for CachedState<T> {
+impl<T: StateReader, C: ContractClassCache> State for CachedState<T, C> {
     /// Stores a contract class in the cache.
     fn set_contract_class(
         &mut self,
         class_hash: &ClassHash,
         contract_class: &CompiledClass,
     ) -> Result<(), StateError> {
-        self.contract_classes
+        // `RefCell::get_mut()` provides a mutable reference without the borrowing overhead when we
+        // have a mutable reference to the `RefCell` available.
+        self.contract_class_cache_private
+            .get_mut()
             .insert(*class_hash, contract_class.clone());
 
         Ok(())
@@ -411,8 +439,23 @@ impl<T: StateReader> State for CachedState<T> {
 
         // I: FETCHING FROM CACHE
         // deprecated contract classes dont have compiled class hashes, so we only have one case
-        if let Some(compiled_class) = self.contract_classes.get(class_hash).cloned() {
+        // `RefCell::get_mut()` provides a mutable reference without the borrowing overhead when we
+        // have a mutable reference to the `RefCell` available.
+        if let Some(compiled_class) = self
+            .contract_class_cache_private
+            .get_mut()
+            .get(class_hash)
+            .cloned()
+        {
             self.add_hit();
+            return Ok(compiled_class);
+        } else if let Some(compiled_class) =
+            self.contract_class_cache().get_contract_class(*class_hash)
+        {
+            self.add_hit();
+            self.contract_class_cache_private
+                .get_mut()
+                .insert(*class_hash, compiled_class.clone());
             return Ok(compiled_class);
         }
 
@@ -420,8 +463,24 @@ impl<T: StateReader> State for CachedState<T> {
         if let Some(compiled_class_hash) =
             self.cache.class_hash_to_compiled_class_hash.get(class_hash)
         {
-            if let Some(casm_class) = self.contract_classes.get(compiled_class_hash).cloned() {
+            // `RefCell::get_mut()` provides a mutable reference without the borrowing overhead when
+            // we have a mutable reference to the `RefCell` available.
+            if let Some(casm_class) = self
+                .contract_class_cache_private
+                .get_mut()
+                .get(compiled_class_hash)
+                .cloned()
+            {
                 self.add_hit();
+                return Ok(casm_class);
+            } else if let Some(casm_class) = self
+                .contract_class_cache()
+                .get_contract_class(*compiled_class_hash)
+            {
+                self.add_hit();
+                self.contract_class_cache_private
+                    .get_mut()
+                    .insert(*class_hash, casm_class.clone());
                 return Ok(casm_class);
             }
         }
@@ -447,7 +506,8 @@ impl<T: StateReader> State for CachedState<T> {
 
 /// A CachedState which has access to another, "parent" state, used for executing transactions
 /// without commiting changes to the parent.
-pub type TransactionalCachedState<'a, T> = CachedState<TransactionalCachedStateReader<'a, T>>;
+pub type TransactionalCachedState<'a, T, C> =
+    CachedState<TransactionalCachedStateReader<'a, T, C>, C>;
 
 /// State reader used for transactional states which allows to check the parent state's cache and
 /// state reader if a transactional cache miss happens.
@@ -456,29 +516,34 @@ pub type TransactionalCachedState<'a, T> = CachedState<TransactionalCachedStateR
 /// without referencing the whole parent state, so there's no need to adapt state-modifying
 /// functions in the case that a transactional state is needed.
 #[derive(Debug, MutGetters, Getters, PartialEq, Clone)]
-pub struct TransactionalCachedStateReader<'a, T: StateReader> {
+pub struct TransactionalCachedStateReader<'a, T: StateReader, C: ContractClassCache> {
     /// The parent state's state_reader
     #[get(get = "pub")]
     pub(crate) state_reader: Arc<T>,
     /// The parent state's cache
     #[get(get = "pub")]
     pub(crate) cache: &'a StateCache,
+
     /// The parent state's contract_classes
     #[get(get = "pub")]
-    pub(crate) contract_classes: ContractClassCache,
+    pub(crate) contract_class_cache: Arc<C>,
+    pub(crate) contract_class_cache_private: &'a RefCell<HashMap<ClassHash, CompiledClass>>,
 }
 
-impl<'a, T: StateReader> TransactionalCachedStateReader<'a, T> {
-    fn new(state: &'a CachedState<T>) -> Self {
+impl<'a, T: StateReader, C: ContractClassCache> TransactionalCachedStateReader<'a, T, C> {
+    fn new(state: &'a CachedState<T, C>) -> Self {
         Self {
             state_reader: state.state_reader.clone(),
             cache: &state.cache,
-            contract_classes: state.contract_classes.clone(),
+            contract_class_cache: state.contract_class_cache.clone(),
+            contract_class_cache_private: &state.contract_class_cache_private,
         }
     }
 }
 
-impl<'a, T: StateReader> StateReader for TransactionalCachedStateReader<'a, T> {
+impl<'a, T: StateReader, C: ContractClassCache> StateReader
+    for TransactionalCachedStateReader<'a, T, C>
+{
     /// Returns the class hash for a given contract address.
     /// Returns zero as default value if missing
     fn get_class_hash_at(&self, contract_address: &Address) -> Result<ClassHash, StateError> {
@@ -535,25 +600,40 @@ impl<'a, T: StateReader> StateReader for TransactionalCachedStateReader<'a, T> {
         }
 
         // I: FETCHING FROM CACHE
-        if let Some(compiled_class) = self.contract_classes.get(class_hash) {
+        let mut private_cache = self.contract_class_cache_private.borrow_mut();
+        if let Some(compiled_class) = private_cache.get(class_hash) {
             return Ok(compiled_class.clone());
+        } else if let Some(compiled_class) =
+            self.contract_class_cache().get_contract_class(*class_hash)
+        {
+            private_cache.insert(*class_hash, compiled_class.clone());
+            return Ok(compiled_class);
         }
 
         // I: CASM CONTRACT CLASS : CLASS_HASH
         if let Some(compiled_class_hash) =
             self.cache.class_hash_to_compiled_class_hash.get(class_hash)
         {
-            if let Some(casm_class) = self.contract_classes.get(compiled_class_hash) {
+            if let Some(casm_class) = private_cache.get(compiled_class_hash) {
                 return Ok(casm_class.clone());
+            } else if let Some(casm_class) = self
+                .contract_class_cache()
+                .get_contract_class(*compiled_class_hash)
+            {
+                private_cache.insert(*class_hash, casm_class.clone());
+                return Ok(casm_class);
             }
         }
 
         // II: FETCHING FROM STATE_READER
-        self.state_reader.get_contract_class(class_hash)
+        let contract_class = self.state_reader.get_contract_class(class_hash)?;
+        private_cache.insert(*class_hash, contract_class.clone());
+
+        Ok(contract_class)
     }
 }
 
-impl<T: StateReader> CachedState<T> {
+impl<T: StateReader, C: ContractClassCache> CachedState<T, C> {
     // Updates the cache's storage_initial_values according to those in storage_writes
     // If a key is present in the storage_writes but not in storage_initial_values,
     // the initial value for that key will be fetched from the state_reader and inserted into the cache's storage_initial_values
@@ -602,13 +682,15 @@ impl<T: StateReader> CachedState<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::{
         services::api::contract_classes::deprecated_contract_class::ContractClass,
-        state::in_memory_state_reader::InMemoryStateReader,
+        state::{
+            contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader,
+        },
     };
-
     use num_traits::One;
+    use std::collections::HashMap;
 
     /// Test checks if class hashes and nonces are correctly fetched from the state reader.
     /// It also tests the increment_nonce method.
@@ -638,7 +720,10 @@ mod tests {
             .address_to_storage_mut()
             .insert(storage_entry, storage_value);
 
-        let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let mut cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         assert_eq!(
             cached_state.get_class_hash_at(&contract_address).unwrap(),
@@ -670,9 +755,10 @@ mod tests {
             .class_hash_to_compiled_class
             .insert([1; 32], CompiledClass::Deprecated(Arc::new(contract_class)));
 
-        let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
-
-        cached_state.set_contract_classes(HashMap::new()).unwrap();
+        let cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         assert_eq!(
             cached_state.get_contract_class(&[1; 32]).unwrap(),
@@ -686,8 +772,10 @@ mod tests {
     /// This test verifies the correct handling of storage in the cached state.
     #[test]
     fn cached_state_storage_test() {
-        let mut cached_state =
-            CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut cached_state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let storage_entry: StorageEntry = (Address(31.into()), [0; 32]);
         let value = Felt252::new(10);
@@ -709,7 +797,10 @@ mod tests {
 
         let contract_address = Address(32123.into());
 
-        let mut cached_state = CachedState::new(state_reader, HashMap::new());
+        let mut cached_state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         assert!(cached_state
             .deploy_contract(contract_address, [10; 32])
@@ -725,7 +816,10 @@ mod tests {
         let storage_key = [18; 32];
         let value = Felt252::new(912);
 
-        let mut cached_state = CachedState::new(state_reader, HashMap::new());
+        let mut cached_state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         // set storage_key
         cached_state.set_storage_at(&(contract_address.clone(), storage_key), value.clone());
@@ -756,7 +850,10 @@ mod tests {
 
         let contract_address = Address(0.into());
 
-        let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let mut cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let result = cached_state
             .deploy_contract(contract_address.clone(), [10; 32])
@@ -781,7 +878,10 @@ mod tests {
 
         let contract_address = Address(42.into());
 
-        let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let mut cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         cached_state
             .deploy_contract(contract_address.clone(), [10; 32])
@@ -809,7 +909,10 @@ mod tests {
 
         let contract_address = Address(32123.into());
 
-        let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let mut cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         cached_state
             .deploy_contract(contract_address.clone(), [10; 32])
@@ -838,7 +941,10 @@ mod tests {
 
         let address_one = Address(Felt252::one());
 
-        let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let mut cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let state_diff = StateDiff {
             address_to_class_hash: HashMap::from([(
@@ -873,8 +979,10 @@ mod tests {
     #[test]
     fn count_actual_storage_changes_test() {
         let state_reader = InMemoryStateReader::default();
-
-        let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let mut cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let address_one = Address(1.into());
         let address_two = Address(2.into());
@@ -921,12 +1029,15 @@ mod tests {
     #[test]
     fn test_cache_hit_miss_counter() {
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut cached_state = CachedState::new(state_reader, None, None);
+        let mut cached_state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let address = Address(1.into());
 
         // Simulate a cache miss by querying an address not in the cache.
-        let _ = <CachedState<_> as State>::get_class_hash_at(&mut cached_state, &address);
+        let _ = <CachedState<_, _> as State>::get_class_hash_at(&mut cached_state, &address);
         assert_eq!(cached_state.cache_misses, 1);
         assert_eq!(cached_state.cache_hits, 0);
 
@@ -935,18 +1046,18 @@ mod tests {
             .cache
             .class_hash_writes
             .insert(address.clone(), [0; 32]);
-        let _ = <CachedState<_> as State>::get_class_hash_at(&mut cached_state, &address);
+        let _ = <CachedState<_, _> as State>::get_class_hash_at(&mut cached_state, &address);
         assert_eq!(cached_state.cache_misses, 1);
         assert_eq!(cached_state.cache_hits, 1);
 
         // Simulate another cache hit.
-        let _ = <CachedState<_> as State>::get_class_hash_at(&mut cached_state, &address);
+        let _ = <CachedState<_, _> as State>::get_class_hash_at(&mut cached_state, &address);
         assert_eq!(cached_state.cache_misses, 1);
         assert_eq!(cached_state.cache_hits, 2);
 
         // Simulate another cache miss.
         let other_address = Address(2.into());
-        let _ = <CachedState<_> as State>::get_class_hash_at(&mut cached_state, &other_address);
+        let _ = <CachedState<_, _> as State>::get_class_hash_at(&mut cached_state, &other_address);
         assert_eq!(cached_state.cache_misses, 2);
         assert_eq!(cached_state.cache_hits, 2);
     }

--- a/src/state/contract_class_cache.rs
+++ b/src/state/contract_class_cache.rs
@@ -1,0 +1,90 @@
+//! # Contract cache system
+//!
+//! The contract caches allow the application to keep some contracts within itself, providing them
+//! efficiently when they are needed.
+//!
+//! The trait `ContractClassCache` provides methods for retrieving and inserting elements into the
+//! cache. It also contains a method to extend the shared cache from an iterator so that it can be
+//! used with the private caches.
+
+use crate::{services::api::contract_classes::compiled_class::CompiledClass, utils::ClassHash};
+use std::{collections::HashMap, sync::RwLock};
+
+/// The contract class cache trait, which must be implemented by all caches.
+pub trait ContractClassCache {
+    /// Provides the stored contract class associated with a specific class hash, or `None` if not
+    /// present.
+    fn get_contract_class(&self, class_hash: ClassHash) -> Option<CompiledClass>;
+    /// Inserts or replaces a contract class associated with a specific class hash.
+    fn set_contract_class(&self, class_hash: ClassHash, compiled_class: CompiledClass);
+}
+
+/// A contract class cache which stores nothing. In other words, using this as a cache means there's
+/// effectively no cache.
+#[derive(Clone, Copy, Debug, Default, Hash)]
+pub struct NullContractClassCache;
+
+impl ContractClassCache for NullContractClassCache {
+    fn get_contract_class(&self, _class_hash: ClassHash) -> Option<CompiledClass> {
+        None
+    }
+
+    fn set_contract_class(&self, _class_hash: ClassHash, _compiled_class: CompiledClass) {
+        // Nothing needs to be done here.
+    }
+}
+
+/// A contract class cache which stores everything. This cache is useful for testing but will
+/// probably end up taking all the memory available if the application is long running.
+#[derive(Debug, Default)]
+pub struct PermanentContractClassCache {
+    storage: RwLock<HashMap<ClassHash, CompiledClass>>,
+}
+
+impl PermanentContractClassCache {
+    pub fn extend<I>(&self, other: I)
+    where
+        I: IntoIterator<Item = (ClassHash, CompiledClass)>,
+    {
+        self.storage.write().unwrap().extend(other);
+    }
+}
+
+impl ContractClassCache for PermanentContractClassCache {
+    fn get_contract_class(&self, class_hash: ClassHash) -> Option<CompiledClass> {
+        self.storage.read().unwrap().get(&class_hash).cloned()
+    }
+
+    fn set_contract_class(&self, class_hash: ClassHash, compiled_class: CompiledClass) {
+        self.storage
+            .write()
+            .unwrap()
+            .insert(class_hash, compiled_class);
+    }
+}
+
+impl Clone for PermanentContractClassCache {
+    fn clone(&self) -> Self {
+        Self {
+            storage: RwLock::new(self.storage.read().unwrap().clone()),
+        }
+    }
+}
+
+impl IntoIterator for PermanentContractClassCache {
+    type Item = (ClassHash, CompiledClass);
+    type IntoIter = <HashMap<ClassHash, CompiledClass> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.storage.into_inner().unwrap().into_iter()
+    }
+}
+
+impl IntoIterator for &PermanentContractClassCache {
+    type Item = (ClassHash, CompiledClass);
+    type IntoIter = <HashMap<ClassHash, CompiledClass> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.storage.read().unwrap().clone().into_iter()
+    }
+}

--- a/src/state/contract_storage_state.rs
+++ b/src/state/contract_storage_state.rs
@@ -1,5 +1,6 @@
 use super::{
     cached_state::CachedState,
+    contract_class_cache::ContractClassCache,
     state_api::{State, StateReader},
 };
 use crate::{
@@ -10,16 +11,16 @@ use cairo_vm::felt::Felt252;
 use std::collections::HashSet;
 
 #[derive(Debug)]
-pub(crate) struct ContractStorageState<'a, S: StateReader> {
-    pub(crate) state: &'a mut CachedState<S>,
+pub(crate) struct ContractStorageState<'a, S: StateReader, C: ContractClassCache> {
+    pub(crate) state: &'a mut CachedState<S, C>,
     pub(crate) contract_address: Address,
     /// Maintain all read request values in chronological order
     pub(crate) read_values: Vec<Felt252>,
     pub(crate) accessed_keys: HashSet<ClassHash>,
 }
 
-impl<'a, S: StateReader> ContractStorageState<'a, S> {
-    pub(crate) fn new(state: &'a mut CachedState<S>, contract_address: Address) -> Self {
+impl<'a, S: StateReader, C: ContractClassCache> ContractStorageState<'a, S, C> {
+    pub(crate) fn new(state: &'a mut CachedState<S, C>, contract_address: Address) -> Self {
         Self {
             state,
             contract_address,

--- a/src/state/in_memory_state_reader.rs
+++ b/src/state/in_memory_state_reader.rs
@@ -106,6 +106,7 @@ impl StateReader for InMemoryStateReader {
         &self,
         class_hash: &ClassHash,
     ) -> Result<CompiledClassHash, StateError> {
+        println!("{}", std::backtrace::Backtrace::force_capture());
         self.class_hash_to_compiled_class_hash
             .get(class_hash)
             .ok_or(StateError::NoneCompiledHash(*class_hash))

--- a/src/state/in_memory_state_reader.rs
+++ b/src/state/in_memory_state_reader.rs
@@ -106,7 +106,6 @@ impl StateReader for InMemoryStateReader {
         &self,
         class_hash: &ClassHash,
     ) -> Result<CompiledClassHash, StateError> {
-        println!("{}", std::backtrace::Backtrace::force_capture());
         self.class_hash_to_compiled_class_hash
             .get(class_hash)
             .ok_or(StateError::NoneCompiledHash(*class_hash))

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,24 +1,24 @@
-pub mod cached_state;
-pub(crate) mod contract_storage_state;
-pub mod in_memory_state_reader;
-pub mod state_api;
-pub mod state_cache;
-
+use self::{
+    cached_state::CachedState, contract_class_cache::ContractClassCache, state_api::StateReader,
+};
 use crate::{
     core::errors::state_errors::StateError,
     services::api::contract_classes::compiled_class::CompiledClass,
-    utils::{get_keys, to_cache_state_storage_mapping, to_state_diff_storage_mapping},
+    transaction::error::TransactionError,
+    utils::{
+        get_keys, to_cache_state_storage_mapping, to_state_diff_storage_mapping, Address, ClassHash,
+    },
 };
 use cairo_vm::{felt::Felt252, vm::runners::cairo_runner::ExecutionResources};
 use getset::Getters;
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{
-    transaction::error::TransactionError,
-    utils::{Address, ClassHash},
-};
-
-use self::{cached_state::CachedState, state_api::StateReader};
+pub mod cached_state;
+pub mod contract_class_cache;
+pub(crate) mod contract_storage_state;
+pub mod in_memory_state_reader;
+pub mod state_api;
+pub mod state_cache;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockInfo {
@@ -125,9 +125,10 @@ impl StateDiff {
         }
     }
 
-    pub fn from_cached_state<T>(cached_state: CachedState<T>) -> Result<Self, StateError>
+    pub fn from_cached_state<T, C>(cached_state: CachedState<T, C>) -> Result<Self, StateError>
     where
         T: StateReader,
+        C: ContractClassCache,
     {
         let state_cache = cached_state.cache().to_owned();
 
@@ -146,11 +147,16 @@ impl StateDiff {
         })
     }
 
-    pub fn to_cached_state<T>(&self, state_reader: Arc<T>) -> Result<CachedState<T>, StateError>
+    pub fn to_cached_state<T, C>(
+        &self,
+        state_reader: Arc<T>,
+        contract_class_cache: Arc<C>,
+    ) -> Result<CachedState<T, C>, StateError>
     where
         T: StateReader + Clone,
+        C: ContractClassCache,
     {
-        let mut cache_state = CachedState::new(state_reader, HashMap::new());
+        let mut cache_state = CachedState::new(state_reader, contract_class_cache);
         let cache_storage_mapping = to_cache_state_storage_mapping(&self.storage_updates);
 
         cache_state.cache_mut().set_initial_values(
@@ -217,19 +223,19 @@ fn test_validate_legal_progress() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
-
     use super::StateDiff;
     use crate::{
-        state::in_memory_state_reader::InMemoryStateReader,
         state::{
             cached_state::CachedState,
+            contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader,
             state_api::StateReader,
             state_cache::{StateCache, StorageEntry},
         },
         utils::Address,
     };
     use cairo_vm::felt::Felt252;
+    use std::{collections::HashMap, sync::Arc};
 
     #[test]
     fn test_from_cached_state_without_updates() {
@@ -246,7 +252,10 @@ mod test {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let cached_state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let diff = StateDiff::from_cached_state(cached_state).unwrap();
 
@@ -316,16 +325,27 @@ mod test {
             .address_to_nonce
             .insert(contract_address.clone(), nonce);
 
-        let cached_state_original =
-            CachedState::new(Arc::new(state_reader.clone()), HashMap::new());
+        let cached_state_original = CachedState::new(
+            Arc::new(state_reader.clone()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let diff = StateDiff::from_cached_state(cached_state_original.clone()).unwrap();
 
-        let cached_state = diff.to_cached_state(Arc::new(state_reader)).unwrap();
+        let cached_state = diff
+            .to_cached_state::<_, PermanentContractClassCache>(
+                Arc::new(state_reader),
+                Arc::new(PermanentContractClassCache::default()),
+            )
+            .unwrap();
 
         assert_eq!(
-            cached_state_original.contract_classes(),
-            cached_state.contract_classes()
+            (&*cached_state_original.contract_class_cache().clone())
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+            (&*cached_state.contract_class_cache().clone())
+                .into_iter()
+                .collect::<HashMap<_, _>>()
         );
         assert_eq!(
             cached_state_original
@@ -364,8 +384,11 @@ mod test {
             storage_writes,
             HashMap::new(),
         );
-        let cached_state =
-            CachedState::new_for_testing(Arc::new(state_reader), cache, HashMap::new());
+        let cached_state = CachedState::new_for_testing(
+            Arc::new(state_reader),
+            cache,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let mut diff = StateDiff::from_cached_state(cached_state).unwrap();
 

--- a/src/syscalls/business_logic_syscall_handler.rs
+++ b/src/syscalls/business_logic_syscall_handler.rs
@@ -55,6 +55,7 @@ use cairo_vm::{
 use lazy_static::lazy_static;
 
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
+use crate::state::contract_class_cache::ContractClassCache;
 use num_traits::{One, ToPrimitive, Zero};
 
 const STEP: u128 = 100;
@@ -118,7 +119,7 @@ lazy_static! {
 }
 
 #[derive(Debug)]
-pub struct BusinessLogicSyscallHandler<'a, S: StateReader> {
+pub struct BusinessLogicSyscallHandler<'a, S: StateReader, C: ContractClassCache> {
     pub(crate) events: Vec<OrderedEvent>,
     pub(crate) expected_syscall_ptr: Relocatable,
     pub(crate) resources_manager: ExecutionResourcesManager,
@@ -129,7 +130,7 @@ pub struct BusinessLogicSyscallHandler<'a, S: StateReader> {
     pub(crate) read_only_segments: Vec<(Relocatable, MaybeRelocatable)>,
     pub(crate) internal_calls: Vec<CallInfo>,
     pub(crate) block_context: BlockContext,
-    pub(crate) starknet_storage_state: ContractStorageState<'a, S>,
+    pub(crate) starknet_storage_state: ContractStorageState<'a, S, C>,
     pub(crate) support_reverted: bool,
     pub(crate) entry_point_selector: Felt252,
     pub(crate) selector_to_syscall: &'a HashMap<Felt252, &'static str>,
@@ -137,11 +138,11 @@ pub struct BusinessLogicSyscallHandler<'a, S: StateReader> {
 
 // TODO: execution entry point may no be a parameter field, but there is no way to generate a default for now
 
-impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> BusinessLogicSyscallHandler<'a, S, C> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         tx_execution_context: TransactionExecutionContext,
-        state: &'a mut CachedState<S>,
+        state: &'a mut CachedState<S, C>,
         resources_manager: ExecutionResourcesManager,
         caller_address: Address,
         contract_address: Address,
@@ -173,7 +174,8 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
             selector_to_syscall: &SELECTOR_TO_SYSCALL,
         }
     }
-    pub fn default_with_state(state: &'a mut CachedState<S>) -> Self {
+
+    pub fn default_with_state(state: &'a mut CachedState<S, C>) -> Self {
         BusinessLogicSyscallHandler::new_for_testing(
             BlockInfo::default(),
             Default::default(),
@@ -184,7 +186,7 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
     pub fn new_for_testing(
         block_info: BlockInfo,
         _contract_address: Address,
-        state: &'a mut CachedState<S>,
+        state: &'a mut CachedState<S, C>,
     ) -> Self {
         let syscalls = Vec::from([
             "emit_event".to_string(),
@@ -336,7 +338,7 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
 
         if self.constructor_entry_points_empty(compiled_class)? {
             if !constructor_calldata.is_empty() {
-                return Err(StateError::ConstructorCalldataEmpty());
+                return Err(StateError::ConstructorCalldataEmpty);
             }
 
             let call_info = CallInfo::empty_constructor_call(
@@ -373,7 +375,7 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
                 self.support_reverted,
                 self.block_context.invoke_tx_max_n_steps,
             )
-            .map_err(|_| StateError::ExecutionEntryPoint())?;
+            .map_err(|_| StateError::ExecutionEntryPoint)?;
 
         let call_info = call_info.ok_or(StateError::CustomError(
             revert_error.unwrap_or_else(|| "Execution error".to_string()),
@@ -553,7 +555,7 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
     }
 }
 
-impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> BusinessLogicSyscallHandler<'a, S, C> {
     fn emit_event(
         &mut self,
         vm: &VirtualMachine,

--- a/src/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     state::ExecutionResourcesManager,
     state::{
+        contract_class_cache::ContractClassCache,
         contract_storage_state::ContractStorageState,
         state_api::{State, StateReader},
         BlockInfo,
@@ -49,7 +50,7 @@ use num_traits::{One, ToPrimitive, Zero};
 //* -----------------------------------
 /// Deprecated version of BusinessLogicSyscallHandler.
 #[derive(Debug)]
-pub struct DeprecatedBLSyscallHandler<'a, S: StateReader> {
+pub struct DeprecatedBLSyscallHandler<'a, S: StateReader, C: ContractClassCache> {
     pub(crate) tx_execution_context: TransactionExecutionContext,
     /// Events emitted by the current contract call.
     pub(crate) events: Vec<OrderedEvent>,
@@ -61,15 +62,15 @@ pub struct DeprecatedBLSyscallHandler<'a, S: StateReader> {
     pub(crate) l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
     pub(crate) block_context: BlockContext,
     pub(crate) tx_info_ptr: Option<MaybeRelocatable>,
-    pub(crate) starknet_storage_state: ContractStorageState<'a, S>,
+    pub(crate) starknet_storage_state: ContractStorageState<'a, S, C>,
     pub(crate) internal_calls: Vec<CallInfo>,
     pub(crate) expected_syscall_ptr: Relocatable,
 }
 
-impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> DeprecatedBLSyscallHandler<'a, S, C> {
     pub fn new(
         tx_execution_context: TransactionExecutionContext,
-        state: &'a mut CachedState<S>,
+        state: &'a mut CachedState<S, C>,
         resources_manager: ExecutionResourcesManager,
         caller_address: Address,
         contract_address: Address,
@@ -100,7 +101,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
         }
     }
 
-    pub fn default_with(state: &'a mut CachedState<S>) -> Self {
+    pub fn default_with(state: &'a mut CachedState<S, C>) -> Self {
         DeprecatedBLSyscallHandler::new_for_testing(BlockInfo::default(), Default::default(), state)
     }
 
@@ -113,7 +114,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
     pub fn new_for_testing(
         block_info: BlockInfo,
         _contract_address: Address,
-        state: &'a mut CachedState<S>,
+        state: &'a mut CachedState<S, C>,
     ) -> Self {
         let syscalls = Vec::from([
             "emit_event".to_string(),
@@ -208,7 +209,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
 
         if self.constructor_entry_points_empty(contract_class)? {
             if !constructor_calldata.is_empty() {
-                return Err(StateError::ConstructorCalldataEmpty());
+                return Err(StateError::ConstructorCalldataEmpty);
             }
 
             let call_info = CallInfo::empty_constructor_call(
@@ -243,7 +244,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
                 false,
                 self.block_context.invoke_tx_max_n_steps,
             )
-            .map_err(|_| StateError::ExecutionEntryPoint())?;
+            .map_err(|_| StateError::ExecutionEntryPoint)?;
 
         if let Some(call_info) = call_info.call_info {
             self.events.extend(call_info.events);
@@ -253,7 +254,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
     }
 }
 
-impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> DeprecatedBLSyscallHandler<'a, S, C> {
     pub(crate) fn emit_event(
         &mut self,
         vm: &VirtualMachine,
@@ -926,7 +927,10 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
 mod tests {
     use crate::{
         state::cached_state::CachedState,
-        state::in_memory_state_reader::InMemoryStateReader,
+        state::{
+            contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader,
+        },
         syscalls::syscall_handler_errors::SyscallHandlerError,
         utils::{felt_to_hash, test_utils::*, Address},
     };
@@ -947,7 +951,7 @@ mod tests {
     use std::{any::Any, borrow::Cow, collections::HashMap, sync::Arc};
 
     type DeprecatedBLSyscallHandler<'a> =
-        super::DeprecatedBLSyscallHandler<'a, InMemoryStateReader>;
+        super::DeprecatedBLSyscallHandler<'a, InMemoryStateReader, PermanentContractClassCache>;
 
     #[test]
     fn run_alloc_hint_ap_is_not_empty() {
@@ -968,7 +972,7 @@ mod tests {
 
     #[test]
     fn deploy_from_zero_error() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
 
@@ -994,7 +998,7 @@ mod tests {
 
     #[test]
     fn can_allocate_segment() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall_handler = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
         let data = vec![MaybeRelocatable::Int(7.into())];
@@ -1010,7 +1014,7 @@ mod tests {
 
     #[test]
     fn test_get_block_number() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
 
@@ -1030,7 +1034,7 @@ mod tests {
 
     #[test]
     fn test_get_contract_address_ok() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
 
@@ -1047,7 +1051,7 @@ mod tests {
 
     #[test]
     fn test_storage_read_empty() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall_handler = DeprecatedBLSyscallHandler::default_with(&mut state);
 
         assert_matches!(
@@ -1065,7 +1069,10 @@ mod tests {
             Felt252::zero(),
         );
         // Create empty-cached state
-        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut syscall_handler = DeprecatedBLSyscallHandler::default_with(&mut state);
         // Perform write
         assert!(syscall_handler

--- a/src/syscalls/deprecated_syscall_handler.rs
+++ b/src/syscalls/deprecated_syscall_handler.rs
@@ -2,38 +2,41 @@ use super::{
     deprecated_business_logic_syscall_handler::DeprecatedBLSyscallHandler, hint_code::*,
     other_syscalls, syscall_handler::HintProcessorPostRun,
 };
-use crate::{state::state_api::StateReader, syscalls::syscall_handler_errors::SyscallHandlerError};
-use cairo_vm::{
-    felt::Felt252,
-    hint_processor::hint_processor_definition::HintProcessorLogic,
-    vm::runners::cairo_runner::{ResourceTracker, RunResources},
+use crate::{
+    state::{contract_class_cache::ContractClassCache, state_api::StateReader},
+    syscalls::syscall_handler_errors::SyscallHandlerError,
 };
 use cairo_vm::{
+    felt::Felt252,
     hint_processor::{
         builtin_hint_processor::{
             builtin_hint_processor_definition::{BuiltinHintProcessor, HintProcessorData},
             hint_utils::get_relocatable_from_var_name,
         },
-        hint_processor_definition::HintReference,
+        hint_processor_definition::{HintProcessorLogic, HintReference},
     },
     serde::deserialize_program::ApTracking,
     types::{exec_scope::ExecutionScopes, relocatable::Relocatable},
-    vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
+    vm::{
+        errors::hint_errors::HintError,
+        runners::cairo_runner::{ResourceTracker, RunResources},
+        vm_core::VirtualMachine,
+    },
 };
 use std::{any::Any, collections::HashMap};
 
 /// Definition of the deprecated syscall hint processor with associated structs
-pub(crate) struct DeprecatedSyscallHintProcessor<'a, S: StateReader> {
+pub(crate) struct DeprecatedSyscallHintProcessor<'a, S: StateReader, C: ContractClassCache> {
     pub(crate) builtin_hint_processor: BuiltinHintProcessor,
-    pub(crate) syscall_handler: DeprecatedBLSyscallHandler<'a, S>,
+    pub(crate) syscall_handler: DeprecatedBLSyscallHandler<'a, S, C>,
     run_resources: RunResources,
 }
 
 /// Implementations and methods for DeprecatedSyscallHintProcessor
-impl<'a, S: StateReader> DeprecatedSyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> DeprecatedSyscallHintProcessor<'a, S, C> {
     /// Constructor for DeprecatedSyscallHintProcessor
     pub fn new(
-        syscall_handler: DeprecatedBLSyscallHandler<'a, S>,
+        syscall_handler: DeprecatedBLSyscallHandler<'a, S, C>,
         run_resources: RunResources,
     ) -> Self {
         DeprecatedSyscallHintProcessor {
@@ -156,7 +159,9 @@ impl<'a, S: StateReader> DeprecatedSyscallHintProcessor<'a, S> {
 }
 
 /// Implement the HintProcessorLogic trait for DeprecatedSyscallHintProcessor
-impl<'a, S: StateReader> HintProcessorLogic for DeprecatedSyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> HintProcessorLogic
+    for DeprecatedSyscallHintProcessor<'a, S, C>
+{
     /// Executes the received hint
     fn execute_hint(
         &mut self,
@@ -180,7 +185,9 @@ impl<'a, S: StateReader> HintProcessorLogic for DeprecatedSyscallHintProcessor<'
 }
 
 /// Implement the ResourceTracker trait for DeprecatedSyscallHintProcessor
-impl<'a, S: StateReader> ResourceTracker for DeprecatedSyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> ResourceTracker
+    for DeprecatedSyscallHintProcessor<'a, S, C>
+{
     fn consumed(&self) -> bool {
         self.run_resources.consumed()
     }
@@ -199,7 +206,9 @@ impl<'a, S: StateReader> ResourceTracker for DeprecatedSyscallHintProcessor<'a, 
 }
 
 /// Implement the HintProcessorPostRun trait for DeprecatedSyscallHintProcessor
-impl<'a, S: StateReader> HintProcessorPostRun for DeprecatedSyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> HintProcessorPostRun
+    for DeprecatedSyscallHintProcessor<'a, S, C>
+{
     /// Validates the execution post run
     fn post_run(
         &self,
@@ -224,12 +233,7 @@ fn get_syscall_ptr(
 /// Unit tests for this module
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
-    use crate::services::api::contract_classes::compiled_class::CompiledClass;
-    use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
-    use crate::state::StateDiff;
     use crate::{
         add_segments, allocate_selector, any_box,
         definitions::{
@@ -238,9 +242,14 @@ mod tests {
         },
         execution::{OrderedEvent, OrderedL2ToL1Message, TransactionExecutionContext},
         memory_insert,
-        services::api::contract_classes::deprecated_contract_class::ContractClass,
-        state::in_memory_state_reader::InMemoryStateReader,
-        state::{cached_state::CachedState, state_api::State},
+        services::api::contract_classes::{
+            compiled_class::CompiledClass,
+            deprecated_contract_class::{ContractClass, EntryPointType},
+        },
+        state::{
+            cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader, state_api::State, StateDiff,
+        },
         syscalls::deprecated_syscall_request::{
             DeprecatedDeployRequest, DeprecatedSendMessageToL1SysCallRequest,
             DeprecatedSyscallRequest,
@@ -254,18 +263,20 @@ mod tests {
     };
     use cairo_vm::relocatable;
     use num_traits::Num;
+    use std::sync::Arc;
 
     type DeprecatedBLSyscallHandler<'a> =
         crate::syscalls::deprecated_business_logic_syscall_handler::DeprecatedBLSyscallHandler<
             'a,
             InMemoryStateReader,
+            PermanentContractClassCache,
         >;
-    type SyscallHintProcessor<'a, T> = super::DeprecatedSyscallHintProcessor<'a, T>;
+    type SyscallHintProcessor<'a, T, C> = super::DeprecatedSyscallHintProcessor<'a, T, C>;
 
     /// Test checks if the send_message_to_l1 syscall is read correctly.
     #[test]
     fn read_send_message_to_l1_request() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
         add_segments!(vm, 3);
@@ -288,7 +299,7 @@ mod tests {
     /// Test verifies if the read syscall can correctly read a deploy request.
     #[test]
     fn read_deploy_syscall_request() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
         add_segments!(vm, 2);
@@ -321,7 +332,7 @@ mod tests {
     /// Test checks the get block timestamp for business logic.
     #[test]
     fn get_block_timestamp_for_business_logic() {
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
         add_segments!(vm, 2);
@@ -339,7 +350,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_BLOCK_TIMESTAMP.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall_handler = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -373,7 +384,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_SEQUENCER_ADDRESS.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall_handler = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -427,7 +438,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(EMIT_EVENT_CODE.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall_handler = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -486,7 +497,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_TX_INFO.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -594,7 +605,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_TX_INFO.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -635,7 +646,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_CALLER_ADDRESS.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -683,7 +694,7 @@ mod tests {
         let hint_data = HintProcessorData::new_default(SEND_MESSAGE_TO_L1.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::<InMemoryStateReader>::default();
+        let mut state = CachedState::<InMemoryStateReader, PermanentContractClassCache>::default();
         let mut hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -732,7 +743,10 @@ mod tests {
             ]
         );
 
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -768,7 +782,10 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_CONTRACT_ADDRESS.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -810,7 +827,10 @@ mod tests {
         let hint_data = HintProcessorData::new_default(GET_TX_SIGNATURE.to_string(), ids_data);
 
         // invoke syscall
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -878,7 +898,10 @@ mod tests {
 
         let hint_data = HintProcessorData::new_default(STORAGE_READ.to_string(), ids_data);
 
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -943,7 +966,10 @@ mod tests {
 
         let hint_data = HintProcessorData::new_default(STORAGE_WRITE.to_string(), ids_data);
 
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
@@ -1017,18 +1043,14 @@ mod tests {
         let hint_data = HintProcessorData::new_default(DEPLOY.to_string(), ids_data);
 
         // Create SyscallHintProcessor
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
         );
-        // Initialize state.set_contract_classes
-        syscall_handler_hint_processor
-            .syscall_handler
-            .starknet_storage_state
-            .state
-            .set_contract_classes(HashMap::new())
-            .unwrap();
 
         // Set contract class
         let contract_class = ContractClass::from_path("starknet_programs/fibonacci.json").unwrap();
@@ -1118,18 +1140,14 @@ mod tests {
         );
 
         // Create SyscallHintProcessor
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let mut syscall_handler_hint_processor = SyscallHintProcessor::new(
             DeprecatedBLSyscallHandler::default_with(&mut state),
             RunResources::default(),
         );
-        // Initialize state.set_contract_classes
-        syscall_handler_hint_processor
-            .syscall_handler
-            .starknet_storage_state
-            .state
-            .set_contract_classes(HashMap::new())
-            .unwrap();
 
         // Set contract class
         let contract_class =

--- a/src/syscalls/deprecated_syscall_response.rs
+++ b/src/syscalls/deprecated_syscall_response.rs
@@ -309,28 +309,34 @@ impl DeprecatedWriteSyscallResponse for DeprecatedStorageReadResponse {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
-
     use super::*;
     use crate::{
         add_segments,
         state::cached_state::CachedState,
-        state::in_memory_state_reader::InMemoryStateReader,
+        state::{
+            contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader,
+        },
         utils::{get_integer, test_utils::vm},
     };
     use cairo_vm::relocatable;
+    use std::sync::Arc;
 
     type DeprecatedBLSyscallHandler<'a> =
         crate::syscalls::deprecated_business_logic_syscall_handler::DeprecatedBLSyscallHandler<
             'a,
             InMemoryStateReader,
+            PermanentContractClassCache,
         >;
 
     /// Unit test to check the write_get_caller_address_response function
     #[test]
     fn write_get_caller_address_response() {
         // Initialize a VM and syscall handler
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
         let syscall = DeprecatedBLSyscallHandler::default_with(&mut state);
         let mut vm = vm!();
 

--- a/src/syscalls/syscall_handler.rs
+++ b/src/syscalls/syscall_handler.rs
@@ -1,5 +1,5 @@
 use super::business_logic_syscall_handler::BusinessLogicSyscallHandler;
-use crate::state::state_api::StateReader;
+use crate::state::{contract_class_cache::ContractClassCache, state_api::StateReader};
 use crate::transaction::error::TransactionError;
 use cairo_lang_casm::{
     hints::{Hint, StarknetHint},
@@ -32,15 +32,15 @@ pub(crate) trait HintProcessorPostRun {
 }
 
 #[allow(unused)]
-pub(crate) struct SyscallHintProcessor<'a, S: StateReader> {
+pub(crate) struct SyscallHintProcessor<'a, S: StateReader, C: ContractClassCache> {
     pub(crate) cairo1_hint_processor: Cairo1HintProcessor,
-    pub(crate) syscall_handler: BusinessLogicSyscallHandler<'a, S>,
+    pub(crate) syscall_handler: BusinessLogicSyscallHandler<'a, S, C>,
     pub(crate) run_resources: RunResources,
 }
 
-impl<'a, S: StateReader> SyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> SyscallHintProcessor<'a, S, C> {
     pub fn new(
-        syscall_handler: BusinessLogicSyscallHandler<'a, S>,
+        syscall_handler: BusinessLogicSyscallHandler<'a, S, C>,
         hints: &[(usize, Vec<Hint>)],
         run_resources: RunResources,
     ) -> Self {
@@ -52,7 +52,9 @@ impl<'a, S: StateReader> SyscallHintProcessor<'a, S> {
     }
 }
 
-impl<'a, S: StateReader> HintProcessorLogic for SyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> HintProcessorLogic
+    for SyscallHintProcessor<'a, S, C>
+{
     fn execute_hint(
         &mut self,
         vm: &mut VirtualMachine,
@@ -111,7 +113,7 @@ impl<'a, S: StateReader> HintProcessorLogic for SyscallHintProcessor<'a, S> {
     }
 }
 
-impl<'a, S: StateReader> ResourceTracker for SyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> ResourceTracker for SyscallHintProcessor<'a, S, C> {
     fn consumed(&self) -> bool {
         self.run_resources.consumed()
     }
@@ -129,7 +131,9 @@ impl<'a, S: StateReader> ResourceTracker for SyscallHintProcessor<'a, S> {
     }
 }
 
-impl<'a, S: StateReader> HintProcessorPostRun for SyscallHintProcessor<'a, S> {
+impl<'a, S: StateReader, C: ContractClassCache> HintProcessorPostRun
+    for SyscallHintProcessor<'a, S, C>
+{
     fn post_run(
         &self,
         runner: &mut VirtualMachine,

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,14 +1,3 @@
-pub mod erc20;
-pub mod state;
-pub mod state_error;
-pub mod type_utils;
-
-use std::{collections::HashMap, sync::Arc};
-
-use cairo_vm::felt::{felt_str, Felt252};
-use lazy_static::lazy_static;
-use num_traits::Zero;
-
 use crate::{
     definitions::{
         block_context::{BlockContext, StarknetChainId, StarknetOsConfig},
@@ -18,12 +7,21 @@ use crate::{
         compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
     },
     state::{
-        cached_state::CachedState, in_memory_state_reader::InMemoryStateReader,
-        state_cache::StorageEntry, BlockInfo,
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader, state_cache::StorageEntry, BlockInfo,
     },
     utils::{felt_to_hash, Address, ClassHash},
 };
+use lazy_static::lazy_static;
+use num_traits::Zero;
+use std::{collections::HashMap, sync::Arc};
 
+pub mod erc20;
+pub mod state;
+pub mod state_error;
+pub mod type_utils;
+
+use cairo_vm::felt::{felt_str, Felt252};
 pub const ACCOUNT_CONTRACT_PATH: &str = "starknet_programs/account_without_validation.json";
 pub const ERC20_CONTRACT_PATH: &str = "starknet_programs/ERC20.json";
 pub const TEST_CONTRACT_PATH: &str = "starknet_programs/fibonacci.json";
@@ -81,8 +79,13 @@ pub fn new_starknet_block_context_for_testing() -> BlockContext {
     )
 }
 
-pub fn create_account_tx_test_state(
-) -> Result<(BlockContext, CachedState<InMemoryStateReader>), Box<dyn std::error::Error>> {
+pub fn create_account_tx_test_state() -> Result<
+    (
+        BlockContext,
+        CachedState<InMemoryStateReader, PermanentContractClassCache>,
+    ),
+    Box<dyn std::error::Error>,
+> {
     let block_context = new_starknet_block_context_for_testing();
 
     let test_contract_class_hash = felt_to_hash(&TEST_CLASS_HASH.clone());
@@ -158,7 +161,7 @@ pub fn create_account_tx_test_state(
             }
             Arc::new(state_reader)
         },
-        HashMap::new(),
+        Arc::new(PermanentContractClassCache::default()),
     );
 
     Ok((block_context, cached_state))

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -1,23 +1,29 @@
-use crate::definitions::constants::QUERY_VERSION_BASE;
-use crate::execution::execution_entry_point::ExecutionResult;
-use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
-use crate::state::cached_state::CachedState;
+use super::fee::charge_fee;
+use super::{verify_version, Transaction};
+use crate::state::contract_class_cache::ContractClassCache;
 use crate::{
     core::{
         contract_address::compute_deprecated_class_hash,
         transaction_hash::calculate_declare_transaction_hash,
     },
     definitions::{
-        block_context::BlockContext, constants::VALIDATE_DECLARE_ENTRY_POINT_SELECTOR,
+        block_context::BlockContext,
+        constants::{QUERY_VERSION_BASE, VALIDATE_DECLARE_ENTRY_POINT_SELECTOR},
         transaction_type::TransactionType,
     },
     execution::{
-        execution_entry_point::ExecutionEntryPoint, CallInfo, TransactionExecutionContext,
-        TransactionExecutionInfo,
+        execution_entry_point::{ExecutionEntryPoint, ExecutionResult},
+        CallInfo, TransactionExecutionContext, TransactionExecutionInfo,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::state_api::{State, StateReader},
-    state::ExecutionResourcesManager,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass,
+        deprecated_contract_class::{ContractClass, EntryPointType},
+    },
+    state::{
+        cached_state::CachedState,
+        state_api::{State, StateReader},
+        ExecutionResourcesManager,
+    },
     transaction::error::TransactionError,
     utils::{
         calculate_tx_resources, felt_to_hash, verify_no_calls_to_other_contracts, Address,
@@ -26,10 +32,6 @@ use crate::{
 };
 use cairo_vm::felt::Felt252;
 use num_traits::Zero;
-
-use super::fee::charge_fee;
-use super::{verify_version, Transaction};
-use crate::services::api::contract_classes::compiled_class::CompiledClass;
 use std::sync::Arc;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -151,9 +153,9 @@ impl Declare {
 
     /// Executes a call to the cairo-vm using the accounts_validation.cairo contract to validate
     /// the contract that is being declared. Then it returns the transaction execution info of the run.
-    pub fn apply<S: StateReader>(
+    pub fn apply<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         verify_version(&self.version, self.max_fee, &self.nonce, &self.signature)?;
@@ -203,9 +205,9 @@ impl Declare {
         )
     }
 
-    pub fn run_validate_entrypoint<S: StateReader>(
+    pub fn run_validate_entrypoint<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         resources_manager: &mut ExecutionResourcesManager,
         block_context: &BlockContext,
     ) -> Result<Option<CallInfo>, TransactionError> {
@@ -264,9 +266,9 @@ impl Declare {
 
     /// Calculates actual fee used by the transaction using the execution
     /// info returned by apply(), then updates the transaction execution info with the data of the fee.
-    pub fn execute<S: StateReader>(
+    pub fn execute<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         self.handle_nonce(state)?;
@@ -324,13 +326,6 @@ impl Declare {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cairo_vm::{
-        felt::{felt_str, Felt252},
-        vm::runners::cairo_runner::ExecutionResources,
-    };
-    use num_traits::{One, Zero};
-    use std::{collections::HashMap, path::PathBuf, sync::Arc};
-
     use crate::{
         definitions::{
             block_context::{BlockContext, StarknetChainId},
@@ -341,12 +336,16 @@ mod tests {
         services::api::contract_classes::{
             compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
         },
-        state::cached_state::CachedState,
         state::in_memory_state_reader::InMemoryStateReader,
+        state::{cached_state::CachedState, contract_class_cache::PermanentContractClassCache},
         utils::{felt_to_hash, Address},
     };
-
-    use super::Declare;
+    use cairo_vm::{
+        felt::{felt_str, Felt252},
+        vm::runners::cairo_runner::ExecutionResources,
+    };
+    use num_traits::{One, Zero};
+    use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
     #[test]
     fn declare_fibonacci() {
@@ -355,13 +354,13 @@ mod tests {
             ContractClass::from_path("starknet_programs/account_without_validation.json").unwrap();
 
         // Instantiate CachedState
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         //  ------------ contract data --------------------
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = hash.to_be_bytes();
 
-        contract_class_cache.insert(
+        contract_class_cache.set_contract_class(
             class_hash,
             CompiledClass::Deprecated(Arc::new(contract_class.clone())),
         );
@@ -380,7 +379,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::new(1));
 
-        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -468,13 +467,16 @@ mod tests {
         let contract_class = ContractClass::from_path(path).unwrap();
 
         // Instantiate CachedState
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         //  ------------ contract data --------------------
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(class_hash, contract_class);
+        contract_class_cache.set_contract_class(
+            class_hash,
+            CompiledClass::Deprecated(Arc::new(contract_class)),
+        );
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -515,13 +517,13 @@ mod tests {
         let contract_class = ContractClass::from_path(path).unwrap();
 
         // Instantiate CachedState
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         //  ------------ contract data --------------------
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(
+        contract_class_cache.set_contract_class(
             class_hash,
             CompiledClass::Deprecated(Arc::new(contract_class)),
         );
@@ -540,7 +542,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::new(1));
 
-        let _state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let _state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -581,13 +583,13 @@ mod tests {
         let contract_class = ContractClass::from_path(path).unwrap();
 
         // Instantiate CachedState
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         //  ------------ contract data --------------------
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(
+        contract_class_cache.set_contract_class(
             class_hash,
             CompiledClass::Deprecated(Arc::new(contract_class)),
         );
@@ -606,7 +608,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::new(1));
 
-        let _state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let _state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -646,13 +648,13 @@ mod tests {
         let contract_class = ContractClass::from_path(path).unwrap();
 
         // Instantiate CachedState
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         //  ------------ contract data --------------------
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(
+        contract_class_cache.set_contract_class(
             class_hash,
             CompiledClass::Deprecated(Arc::new(contract_class)),
         );
@@ -671,7 +673,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::zero());
 
-        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -725,13 +727,13 @@ mod tests {
         let contract_class = ContractClass::from_path(path).unwrap();
 
         // Instantiate CachedState
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         //  ------------ contract data --------------------
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(
+        contract_class_cache.set_contract_class(
             class_hash,
             CompiledClass::Deprecated(Arc::new(contract_class)),
         );
@@ -750,7 +752,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::zero());
 
-        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
         //* ---------------------------------------
         //*    Test declare with previous data
@@ -793,11 +795,11 @@ mod tests {
     #[test]
     fn validate_transaction_should_fail() {
         // Instantiate CachedState
-        let contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         let state_reader = Arc::new(InMemoryStateReader::default());
 
-        let mut state = CachedState::new(state_reader, contract_class_cache);
+        let mut state = CachedState::new(state_reader, Arc::new(contract_class_cache));
 
         // There are no account contracts in the state, so the transaction should fail
         let fib_contract_class =
@@ -832,13 +834,13 @@ mod tests {
         let contract_class = ContractClass::from_path(path).unwrap();
 
         // Instantiate CachedState
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         //  ------------ contract data --------------------
         let hash = compute_deprecated_class_hash(&contract_class).unwrap();
         let class_hash = felt_to_hash(&hash);
 
-        contract_class_cache.insert(
+        contract_class_cache.set_contract_class(
             class_hash,
             CompiledClass::Deprecated(Arc::new(contract_class)),
         );
@@ -857,7 +859,7 @@ mod tests {
             .address_to_nonce_mut()
             .insert(sender_address, Felt252::zero());
 
-        let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+        let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
         //* ---------------------------------------
         //*    Test declare with previous data

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -171,7 +171,7 @@ impl Declare {
         )))?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
-            &vec![validate_info.clone()],
+            &[validate_info.as_ref()],
             TransactionType::Declare,
             changes,
             None,

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -324,7 +324,7 @@ impl DeclareV2 {
         )))?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
-            &[execution_result.call_info.clone()],
+            &[execution_result.call_info.as_ref()],
             TransactionType::Declare,
             storage_changes,
             None,
@@ -423,7 +423,7 @@ impl DeclareV2 {
 
         if execution_result.call_info.is_some() {
             verify_no_calls_to_other_contracts(&execution_result.call_info)?;
-            remaining_gas -= execution_result.call_info.clone().unwrap().gas_consumed;
+            remaining_gas -= execution_result.call_info.as_ref().unwrap().gas_consumed;
         }
 
         Ok((execution_result, remaining_gas))

--- a/src/transaction/deploy.rs
+++ b/src/transaction/deploy.rs
@@ -1,11 +1,4 @@
-use std::sync::Arc;
-
-use crate::execution::execution_entry_point::ExecutionResult;
-use crate::services::api::contract_classes::deprecated_contract_class::{
-    ContractClass, EntryPointType,
-};
-use crate::state::cached_state::CachedState;
-use crate::syscalls::syscall_handler_errors::SyscallHandlerError;
+use super::Transaction;
 use crate::{
     core::{
         contract_address::compute_deprecated_class_hash, errors::hash_errors::HashError,
@@ -16,22 +9,30 @@ use crate::{
         transaction_type::TransactionType,
     },
     execution::{
-        execution_entry_point::ExecutionEntryPoint, CallInfo, TransactionExecutionContext,
-        TransactionExecutionInfo,
+        execution_entry_point::{ExecutionEntryPoint, ExecutionResult},
+        CallInfo, TransactionExecutionContext, TransactionExecutionInfo,
     },
     hash_utils::calculate_contract_address,
     services::api::{
-        contract_class_errors::ContractClassError, contract_classes::compiled_class::CompiledClass,
+        contract_class_errors::ContractClassError,
+        contract_classes::{
+            compiled_class::CompiledClass,
+            deprecated_contract_class::{ContractClass, EntryPointType},
+        },
     },
-    state::state_api::{State, StateReader},
-    state::ExecutionResourcesManager,
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::ContractClassCache,
+        state_api::{State, StateReader},
+        ExecutionResourcesManager,
+    },
+    syscalls::syscall_handler_errors::SyscallHandlerError,
     transaction::error::TransactionError,
     utils::{calculate_tx_resources, felt_to_hash, Address, ClassHash},
 };
 use cairo_vm::felt::Felt252;
 use num_traits::Zero;
-
-use super::Transaction;
+use std::sync::Arc;
 
 /// Represents a Deploy Transaction in the starknet network
 #[derive(Debug, Clone)]
@@ -143,9 +144,9 @@ impl Deploy {
     /// ## Parameters
     /// - state: A state that implements the [`State`] and [`StateReader`] traits.
     /// - block_context: The block's execution context.
-    pub fn apply<S: StateReader>(
+    pub fn apply<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         state.set_contract_class(&self.contract_hash, &self.contract_class)?;
@@ -202,9 +203,9 @@ impl Deploy {
     /// ## Parameters
     /// - state: A state that implements the [`State`] and [`StateReader`] traits.
     /// - block_context: The block's execution context.
-    pub fn invoke_constructor<S: StateReader>(
+    pub fn invoke_constructor<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         let call = ExecutionEntryPoint::new(
@@ -266,9 +267,9 @@ impl Deploy {
     /// ## Parameters
     /// - state: A state that implements the [`State`] and [`StateReader`] traits.
     /// - block_context: The block's execution context.
-    pub fn execute<S: StateReader>(
+    pub fn execute<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         let mut tx_exec_info = self.apply(state, block_context)?;
@@ -302,19 +303,24 @@ impl Deploy {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
-
     use super::*;
     use crate::{
-        state::cached_state::CachedState, state::in_memory_state_reader::InMemoryStateReader,
+        state::{
+            cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader,
+        },
         utils::calculate_sn_keccak,
     };
+    use std::{collections::HashMap, sync::Arc};
 
     #[test]
     fn invoke_constructor_test() {
         // Instantiate CachedState
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, HashMap::new());
+        let mut state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         // Set contract_class
         let contract_class =
@@ -362,7 +368,10 @@ mod tests {
     fn invoke_constructor_no_calldata_should_fail() {
         // Instantiate CachedState
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, HashMap::new());
+        let mut state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let contract_class =
             ContractClass::from_path("starknet_programs/constructor.json").unwrap();
@@ -391,7 +400,10 @@ mod tests {
     fn deploy_contract_without_constructor_should_fail() {
         // Instantiate CachedState
         let state_reader = Arc::new(InMemoryStateReader::default());
-        let mut state = CachedState::new(state_reader, HashMap::new());
+        let mut state = CachedState::new(
+            state_reader,
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let contract_path = "starknet_programs/amm.json";
         let contract_class = ContractClass::from_path(contract_path).unwrap();

--- a/src/transaction/deploy.rs
+++ b/src/transaction/deploy.rs
@@ -182,7 +182,7 @@ impl Deploy {
         let changes = state.count_actual_storage_changes(None)?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
-            &[Some(call_info.clone())],
+            &[Some(&call_info)],
             TransactionType::Deploy,
             changes,
             None,
@@ -245,7 +245,7 @@ impl Deploy {
         let changes = state.count_actual_storage_changes(None)?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
-            &[call_info.clone()],
+            &[call_info.as_ref()],
             TransactionType::Deploy,
             changes,
             None,

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -236,7 +236,7 @@ impl DeployAccount {
 
         let actual_resources = calculate_tx_resources(
             resources_manager,
-            &[Some(constructor_call_info.clone()), validate_info.clone()],
+            &[Some(&constructor_call_info), validate_info.as_ref()],
             TransactionType::DeployAccount,
             state.count_actual_storage_changes(Some((
                 &block_context.starknet_os_config.fee_token_address,

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -1,10 +1,8 @@
-use super::fee::{calculate_tx_fee, charge_fee};
-use super::{invoke_function::verify_no_calls_to_other_contracts, Transaction};
-use crate::definitions::constants::QUERY_VERSION_BASE;
-use crate::execution::execution_entry_point::ExecutionResult;
-use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
-use crate::state::cached_state::CachedState;
-use crate::state::StateDiff;
+use super::{
+    fee::{calculate_tx_fee, charge_fee},
+    invoke_function::verify_no_calls_to_other_contracts,
+    Transaction,
+};
 use crate::{
     core::{
         errors::state_errors::StateError,
@@ -13,21 +11,28 @@ use crate::{
     definitions::{
         block_context::BlockContext,
         constants::{
-            CONSTRUCTOR_ENTRY_POINT_SELECTOR, INITIAL_GAS_COST,
+            CONSTRUCTOR_ENTRY_POINT_SELECTOR, INITIAL_GAS_COST, QUERY_VERSION_BASE,
             VALIDATE_DEPLOY_ENTRY_POINT_SELECTOR,
         },
         transaction_type::TransactionType,
     },
     execution::{
-        execution_entry_point::ExecutionEntryPoint, CallInfo, TransactionExecutionContext,
-        TransactionExecutionInfo,
+        execution_entry_point::{ExecutionEntryPoint, ExecutionResult},
+        CallInfo, TransactionExecutionContext, TransactionExecutionInfo,
     },
     hash_utils::calculate_contract_address,
     services::api::{
-        contract_class_errors::ContractClassError, contract_classes::compiled_class::CompiledClass,
+        contract_class_errors::ContractClassError,
+        contract_classes::{
+            compiled_class::CompiledClass, deprecated_contract_class::EntryPointType,
+        },
     },
-    state::state_api::{State, StateReader},
-    state::ExecutionResourcesManager,
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::ContractClassCache,
+        state_api::{State, StateReader},
+        ExecutionResourcesManager, StateDiff,
+    },
     syscalls::syscall_handler_errors::SyscallHandlerError,
     transaction::error::TransactionError,
     utils::{calculate_tx_resources, Address, ClassHash},
@@ -151,9 +156,9 @@ impl DeployAccount {
         }
     }
 
-    pub fn execute<S: StateReader>(
+    pub fn execute<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         self.handle_nonce(state)?;
@@ -215,9 +220,9 @@ impl DeployAccount {
 
     /// Execute a call to the cairo-vm using the accounts_validation.cairo contract to validate
     /// the contract that is being declared. Then it returns the transaction execution info of the run.
-    fn apply<S: StateReader>(
+    fn apply<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
         let contract_class = state.get_contract_class(&self.class_hash)?;
@@ -256,10 +261,10 @@ impl DeployAccount {
         ))
     }
 
-    pub fn handle_constructor<S: StateReader>(
+    pub fn handle_constructor<S: StateReader, C: ContractClassCache>(
         &self,
         contract_class: CompiledClass,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError> {
@@ -295,9 +300,9 @@ impl DeployAccount {
         Ok(())
     }
 
-    pub fn run_constructor_entrypoint<S: StateReader>(
+    pub fn run_constructor_entrypoint<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
         resources_manager: &mut ExecutionResourcesManager,
     ) -> Result<CallInfo, TransactionError> {
@@ -342,9 +347,9 @@ impl DeployAccount {
         )
     }
 
-    pub fn run_validate_entrypoint<S: StateReader>(
+    pub fn run_validate_entrypoint<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         resources_manager: &mut ExecutionResourcesManager,
         block_context: &BlockContext,
     ) -> Result<Option<CallInfo>, TransactionError> {
@@ -458,17 +463,16 @@ impl TryFrom<starknet_api::transaction::DeployAccountTransaction> for DeployAcco
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, path::PathBuf, sync::Arc};
-
     use super::*;
     use crate::{
         core::{contract_address::compute_deprecated_class_hash, errors::state_errors::StateError},
         definitions::block_context::StarknetChainId,
         services::api::contract_classes::deprecated_contract_class::ContractClass,
-        state::cached_state::CachedState,
         state::in_memory_state_reader::InMemoryStateReader,
+        state::{cached_state::CachedState, contract_class_cache::PermanentContractClassCache},
         utils::felt_to_hash,
     };
+    use std::{path::PathBuf, sync::Arc};
 
     #[test]
     fn get_state_selector() {
@@ -479,7 +483,10 @@ mod tests {
         let class_hash = felt_to_hash(&hash);
 
         let block_context = BlockContext::default();
-        let mut _state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut _state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let internal_deploy = DeployAccount::new(
             class_hash,
@@ -511,7 +518,10 @@ mod tests {
         let class_hash = felt_to_hash(&hash);
 
         let block_context = BlockContext::default();
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let internal_deploy = DeployAccount::new(
             class_hash,
@@ -561,7 +571,10 @@ mod tests {
         let class_hash = felt_to_hash(&hash);
 
         let block_context = BlockContext::default();
-        let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+        let mut state = CachedState::new(
+            Arc::new(InMemoryStateReader::default()),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         let internal_deploy = DeployAccount::new(
             class_hash,

--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -1,19 +1,20 @@
 use super::error::TransactionError;
-use crate::definitions::constants::{FEE_FACTOR, QUERY_VERSION_BASE};
-use crate::execution::execution_entry_point::ExecutionResult;
-use crate::execution::CallType;
-use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
-use crate::state::cached_state::CachedState;
 use crate::{
     definitions::{
         block_context::BlockContext,
-        constants::{INITIAL_GAS_COST, TRANSFER_ENTRY_POINT_SELECTOR},
+        constants::{
+            FEE_FACTOR, INITIAL_GAS_COST, QUERY_VERSION_BASE, TRANSFER_ENTRY_POINT_SELECTOR,
+        },
     },
     execution::{
-        execution_entry_point::ExecutionEntryPoint, CallInfo, TransactionExecutionContext,
+        execution_entry_point::{ExecutionEntryPoint, ExecutionResult},
+        CallInfo, CallType, TransactionExecutionContext,
     },
-    state::state_api::StateReader,
-    state::ExecutionResourcesManager,
+    services::api::contract_classes::deprecated_contract_class::EntryPointType,
+    state::{
+        cached_state::CachedState, contract_class_cache::ContractClassCache,
+        state_api::StateReader, ExecutionResourcesManager,
+    },
 };
 use cairo_vm::felt::Felt252;
 use num_traits::{ToPrimitive, Zero};
@@ -24,8 +25,8 @@ pub type FeeInfo = (Option<CallInfo>, u128);
 
 /// Transfers the amount actual_fee from the caller account to the sequencer.
 /// Returns the resulting CallInfo of the transfer call.
-pub(crate) fn execute_fee_transfer<S: StateReader>(
-    state: &mut CachedState<S>,
+pub(crate) fn execute_fee_transfer<S: StateReader, C: ContractClassCache>(
+    state: &mut CachedState<S, C>,
     block_context: &BlockContext,
     tx_execution_context: &mut TransactionExecutionContext,
     actual_fee: u128,
@@ -135,8 +136,8 @@ fn max_of_keys(cairo_rsc: &HashMap<String, usize>, weights: &HashMap<String, f64
 /// - `tx_execution_context`: The transaction's execution context.
 /// - `skip_fee_transfer`: Whether to skip the fee transfer.
 ///
-pub fn charge_fee<S: StateReader>(
-    state: &mut CachedState<S>,
+pub fn charge_fee<S: StateReader, C: ContractClassCache>(
+    state: &mut CachedState<S, C>,
     resources: &HashMap<String, usize>,
     block_context: &BlockContext,
     max_fee: u128,
@@ -183,23 +184,22 @@ pub fn charge_fee<S: StateReader>(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
-
     use crate::{
         definitions::block_context::BlockContext,
         execution::TransactionExecutionContext,
         state::{
-            cached_state::{CachedState, ContractClassCache},
+            cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
             in_memory_state_reader::InMemoryStateReader,
         },
         transaction::fee::charge_fee,
     };
+    use std::{collections::HashMap, sync::Arc};
 
     #[test]
     fn charge_fee_v0_max_fee_exceeded_should_charge_nothing() {
         let mut state = CachedState::new(
             Arc::new(InMemoryStateReader::default()),
-            ContractClassCache::default(),
+            Arc::new(PermanentContractClassCache::default()),
         );
         let mut tx_execution_context = TransactionExecutionContext::default();
         let mut block_context = BlockContext::default();
@@ -228,7 +228,7 @@ mod tests {
     fn charge_fee_v1_max_fee_exceeded_should_charge_max_fee() {
         let mut state = CachedState::new(
             Arc::new(InMemoryStateReader::default()),
-            ContractClassCache::default(),
+            Arc::new(PermanentContractClassCache::default()),
         );
         let mut tx_execution_context = TransactionExecutionContext {
             version: 1.into(),

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -271,7 +271,7 @@ impl InvokeFunction {
         )))?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
-            &vec![call_info.clone(), validate_info.clone()],
+            &[call_info.as_ref(), validate_info.as_ref()],
             self.tx_type,
             changes,
             None,
@@ -405,14 +405,14 @@ impl InvokeFunction {
 pub fn verify_no_calls_to_other_contracts(
     call_info: &Option<CallInfo>,
 ) -> Result<CallInfo, TransactionError> {
-    let call_info = call_info.clone().ok_or(TransactionError::CallInfoIsNone)?;
-    let invoked_contract_address = call_info.contract_address.clone();
+    let call_info = call_info.as_ref().ok_or(TransactionError::CallInfoIsNone)?;
+    let invoked_contract_address = &call_info.contract_address;
     for internal_call in call_info.gen_call_topology() {
-        if internal_call.contract_address != invoked_contract_address {
+        if internal_call.contract_address != *invoked_contract_address {
             return Err(TransactionError::UnauthorizedActionOnValidate);
         }
     }
-    Ok(call_info)
+    Ok(call_info.clone())
 }
 
 // Performs validation on fields related to function invocation transaction.

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -131,7 +131,7 @@ impl L1Handler {
         let changes = state.count_actual_storage_changes(None)?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
-            &[call_info.clone()],
+            &[call_info.as_ref()],
             TransactionType::L1Handler,
             changes,
             Some(self.get_payload_size()),

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     execution::execution_entry_point::ExecutionResult,
     services::api::contract_classes::deprecated_contract_class::EntryPointType,
-    state::cached_state::CachedState,
+    state::{cached_state::CachedState, contract_class_cache::ContractClassCache},
 };
 use cairo_vm::felt::Felt252;
 use getset::Getters;
@@ -93,9 +93,9 @@ impl L1Handler {
     }
 
     /// Applies self to 'state' by executing the L1-handler entry point.
-    pub fn execute<S: StateReader>(
+    pub fn execute<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
         remaining_gas: u128,
     ) -> Result<TransactionExecutionInfo, TransactionError> {
@@ -206,30 +206,28 @@ impl L1Handler {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        collections::{HashMap, HashSet},
-        sync::Arc,
-    };
-
-    use crate::services::api::contract_classes::{
-        compiled_class::CompiledClass, deprecated_contract_class::EntryPointType,
+    use crate::{
+        definitions::{block_context::BlockContext, transaction_type::TransactionType},
+        execution::{CallInfo, TransactionExecutionInfo},
+        services::api::contract_classes::{
+            compiled_class::CompiledClass,
+            deprecated_contract_class::{ContractClass, EntryPointType},
+        },
+        state::{
+            cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+            in_memory_state_reader::InMemoryStateReader, state_api::State,
+        },
+        transaction::l1_handler::L1Handler,
+        utils::Address,
     };
     use cairo_vm::{
         felt::{felt_str, Felt252},
         vm::runners::cairo_runner::ExecutionResources,
     };
     use num_traits::{Num, Zero};
-
-    use crate::{
-        definitions::{block_context::BlockContext, transaction_type::TransactionType},
-        execution::{CallInfo, TransactionExecutionInfo},
-        services::api::contract_classes::deprecated_contract_class::ContractClass,
-        state::{
-            cached_state::CachedState, in_memory_state_reader::InMemoryStateReader,
-            state_api::State,
-        },
-        transaction::l1_handler::L1Handler,
-        utils::Address,
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
     };
 
     #[test]
@@ -257,7 +255,7 @@ mod test {
         // Set contract_class
         let class_hash = [1; 32];
         let contract_class = ContractClass::from_path("starknet_programs/l1l2.json").unwrap();
-        // Set contact_state
+        // Set contract_state
         let contract_address = Address(0.into());
         let nonce = Felt252::zero();
 
@@ -268,10 +266,10 @@ mod test {
             .address_to_nonce
             .insert(contract_address, nonce);
 
-        let mut state = CachedState::new(Arc::new(state_reader), HashMap::new());
-
-        // Initialize state.contract_classes
-        state.set_contract_classes(HashMap::new()).unwrap();
+        let mut state = CachedState::new(
+            Arc::new(state_reader),
+            Arc::new(PermanentContractClassCache::default()),
+        );
 
         state
             .set_contract_class(

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -1,3 +1,20 @@
+use crate::{
+    definitions::block_context::BlockContext,
+    execution::TransactionExecutionInfo,
+    state::{
+        cached_state::CachedState, contract_class_cache::ContractClassCache, state_api::StateReader,
+    },
+    utils::Address,
+};
+pub use declare::Declare;
+pub use declare_v2::DeclareV2;
+pub use deploy::Deploy;
+pub use deploy_account::DeployAccount;
+use error::TransactionError;
+pub use invoke_function::InvokeFunction;
+pub use l1_handler::L1Handler;
+pub use verify_version::verify_version;
+
 pub mod declare;
 pub mod declare_v2;
 pub mod deploy;
@@ -7,22 +24,6 @@ pub mod fee;
 pub mod invoke_function;
 pub mod l1_handler;
 mod verify_version;
-
-pub use declare::Declare;
-pub use declare_v2::DeclareV2;
-pub use deploy::Deploy;
-pub use deploy_account::DeployAccount;
-pub use invoke_function::InvokeFunction;
-pub use l1_handler::L1Handler;
-pub use verify_version::verify_version;
-
-use crate::{
-    definitions::block_context::BlockContext,
-    execution::TransactionExecutionInfo,
-    state::{cached_state::CachedState, state_api::StateReader},
-    utils::Address,
-};
-use error::TransactionError;
 
 /// Represents a transaction inside the starknet network.
 /// The transaction are actions that may modified the state of the network.
@@ -66,9 +67,9 @@ impl Transaction {
     ///- state: a structure that implements State and StateReader traits.
     ///- block_context: The block context of the transaction that is about to be executed.
     ///- remaining_gas: The gas supplied to execute the transaction.
-    pub fn execute<S: StateReader>(
+    pub fn execute<S: StateReader, C: ContractClassCache>(
         &self,
-        state: &mut CachedState<S>,
+        state: &mut CachedState<S, C>,
         block_context: &BlockContext,
         remaining_gas: u128,
     ) -> Result<TransactionExecutionInfo, TransactionError> {

--- a/starknet_programs/syscalls.cairo
+++ b/starknet_programs/syscalls.cairo
@@ -72,10 +72,10 @@ func test_call_contract{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
     let (value) = lib_state.read();
     assert value = 10;
 
-    let (call_contact_address) = ISyscallsLib.stateful_get_contract_address(
+    let (call_contract_address) = ISyscallsLib.stateful_get_contract_address(
         contract_address=contract_address
     );
-    assert call_contact_address = contract_address;
+    assert call_contract_address = contract_address;
 
     return ();
 }
@@ -181,11 +181,11 @@ func test_library_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     let (value) = lib_state.read();
     assert value = 11;
 
-    let self_contact_address = get_contract_address();
-    let call_contact_address = ISyscallsLib.library_call_stateful_get_contract_address(
+    let self_contract_address = get_contract_address();
+    let call_contract_address = ISyscallsLib.library_call_stateful_get_contract_address(
         class_hash=0x0202020202020202020202020202020202020202020202020202020202020202
     );
-    assert self_contact_address = call_contact_address;
+    assert self_contract_address = call_contract_address;
 
     return ();
 }
@@ -255,7 +255,7 @@ func test_deploy_with_constructor{syscall_ptr: felt*}(
     // Set constructor.
     let (ptr) = alloc();
     assert [ptr] = constructor;
-    
+
     let contract_address = deploy(
         class_hash,
         contract_address_salt,
@@ -276,7 +276,7 @@ func test_deploy_and_call_contract{syscall_ptr: felt*, pedersen_ptr: HashBuiltin
     // Set constructor.
     let (ptr) = alloc();
     assert [ptr] = constructor;
-    
+
     // Deploy contract
     let (contract_address) = deploy(
         class_hash,

--- a/tests/complex_contracts/amm_contracts/amm.rs
+++ b/tests/complex_contracts/amm_contracts/amm.rs
@@ -1,22 +1,27 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-
-use cairo_vm::vm::runners::builtin_runner::HASH_BUILTIN_NAME;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
-use cairo_vm::{felt::Felt252, vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME};
+use crate::complex_contracts::utils::*;
+use cairo_vm::{
+    felt::Felt252,
+    vm::runners::{
+        builtin_runner::{HASH_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME},
+        cairo_runner::ExecutionResources,
+    },
+};
 use num_traits::Zero;
-use starknet_in_rust::definitions::block_context::BlockContext;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
+    definitions::block_context::BlockContext,
     execution::{CallInfo, CallType},
     services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::{cached_state::CachedState, state_api::StateReader},
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    state::{
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader, state_api::StateReader,
+        ExecutionResourcesManager,
+    },
     transaction::error::TransactionError,
     utils::{calculate_sn_keccak, Address},
+    EntryPointType,
 };
-
-use crate::complex_contracts::utils::*;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 fn init_pool(
     calldata: &[Felt252],
@@ -54,7 +59,10 @@ fn swap(calldata: &[Felt252], call_config: &mut CallConfig) -> Result<CallInfo, 
 #[test]
 fn amm_init_pool_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -121,7 +129,10 @@ fn amm_init_pool_test() {
 #[test]
 fn amm_add_demo_tokens_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -201,7 +212,10 @@ fn amm_add_demo_tokens_test() {
 #[test]
 fn amm_get_pool_token_balance() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -273,7 +287,10 @@ fn amm_get_pool_token_balance() {
 #[test]
 fn amm_swap_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -375,7 +392,10 @@ fn amm_swap_test() {
 #[test]
 fn amm_init_pool_should_fail_with_amount_out_of_bounds() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -411,7 +431,10 @@ fn amm_init_pool_should_fail_with_amount_out_of_bounds() {
 #[test]
 fn amm_swap_should_fail_with_unexistent_token() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -447,7 +470,10 @@ fn amm_swap_should_fail_with_unexistent_token() {
 #[test]
 fn amm_swap_should_fail_with_amount_out_of_bounds() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -483,7 +509,10 @@ fn amm_swap_should_fail_with_amount_out_of_bounds() {
 #[test]
 fn amm_swap_should_fail_when_user_does_not_have_enough_funds() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,
@@ -522,7 +551,10 @@ fn amm_swap_should_fail_when_user_does_not_have_enough_funds() {
 #[test]
 fn amm_get_account_token_balance_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, class_hash) = deploy(
         &mut state,

--- a/tests/complex_contracts/amm_contracts/amm_proxy.rs
+++ b/tests/complex_contracts/amm_contracts/amm_proxy.rs
@@ -1,24 +1,31 @@
 use crate::complex_contracts::utils::*;
-use cairo_vm::felt::Felt252;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use cairo_vm::{felt::Felt252, vm::runners::cairo_runner::ExecutionResources};
 use num_traits::Zero;
 use starknet_crypto::FieldElement;
-use starknet_in_rust::definitions::block_context::BlockContext;
-use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
+    definitions::block_context::BlockContext,
     execution::{CallInfo, CallType},
-    state::{cached_state::CachedState, state_api::StateReader},
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    state::{
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader, state_api::StateReader,
+        ExecutionResourcesManager,
+    },
     utils::{calculate_sn_keccak, Address},
+    EntryPointType,
 };
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 #[test]
 fn amm_proxy_init_pool_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -116,7 +123,10 @@ fn amm_proxy_init_pool_test() {
 #[test]
 fn amm_proxy_get_pool_token_balance_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -220,7 +230,10 @@ fn amm_proxy_get_pool_token_balance_test() {
 #[test]
 fn amm_proxy_add_demo_token_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -330,7 +343,10 @@ fn amm_proxy_add_demo_token_test() {
 #[test]
 fn amm_proxy_get_account_token_balance() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,
@@ -453,7 +469,10 @@ fn amm_proxy_get_account_token_balance() {
 #[test]
 fn amm_proxy_swap() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
     // Deploy contract
     let (contract_address, contract_class_hash) = deploy(
         &mut state,

--- a/tests/complex_contracts/nft/erc721.rs
+++ b/tests/complex_contracts/nft/erc721.rs
@@ -1,30 +1,39 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-
+use crate::complex_contracts::utils::*;
 use assert_matches::assert_matches;
-use cairo_vm::felt::Felt252;
-use cairo_vm::vm::runners::builtin_runner::{HASH_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME};
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use cairo_vm::{
+    felt::Felt252,
+    vm::runners::{
+        builtin_runner::{HASH_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME},
+        cairo_runner::ExecutionResources,
+    },
+};
 use num_traits::Zero;
 use starknet_crypto::FieldElement;
-use starknet_in_rust::definitions::block_context::BlockContext;
-use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass;
-use starknet_in_rust::state::cached_state::CachedState;
-use starknet_in_rust::transaction::error::TransactionError;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
+    definitions::block_context::BlockContext,
     execution::{CallInfo, CallType, OrderedEvent},
-    state::state_api::StateReader,
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    state::{
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+        in_memory_state_reader::InMemoryStateReader, state_api::StateReader,
+        ExecutionResourcesManager,
+    },
+    transaction::error::TransactionError,
     utils::{calculate_sn_keccak, Address},
+    EntryPointType,
 };
-
-use crate::complex_contracts::utils::*;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 #[test]
 fn erc721_constructor_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be(b"some-nft");
     let collection_symbol = Felt252::from(555);
@@ -67,7 +76,10 @@ fn erc721_constructor_test() {
 #[test]
 fn erc721_balance_of_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -154,7 +166,10 @@ fn erc721_balance_of_test() {
 #[test]
 fn erc721_test_owner_of() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -233,7 +248,10 @@ fn erc721_test_owner_of() {
 #[test]
 fn erc721_test_get_approved() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -329,7 +347,10 @@ fn erc721_test_get_approved() {
 #[test]
 fn erc721_test_is_approved_for_all() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -428,7 +449,10 @@ fn erc721_test_is_approved_for_all() {
 #[test]
 fn erc721_test_approve() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -529,7 +553,10 @@ fn erc721_test_approve() {
 #[test]
 fn erc721_set_approval_for_all() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -624,7 +651,10 @@ fn erc721_set_approval_for_all() {
 #[test]
 fn erc721_transfer_from_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -767,7 +797,10 @@ fn erc721_transfer_from_test() {
 #[test]
 fn erc721_transfer_from_and_get_owner_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -855,7 +888,10 @@ fn erc721_transfer_from_and_get_owner_test() {
 #[test]
 fn erc721_safe_transfer_from_should_fail_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -919,7 +955,10 @@ fn erc721_safe_transfer_from_should_fail_test() {
 #[test]
 fn erc721_calling_constructor_twice_should_fail_test() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -965,7 +1004,10 @@ fn erc721_calling_constructor_twice_should_fail_test() {
 #[test]
 fn erc721_constructor_should_fail_with_to_equal_zero() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -989,7 +1031,10 @@ fn erc721_constructor_should_fail_with_to_equal_zero() {
 #[test]
 fn erc721_transfer_fail_to_zero_address() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);
@@ -1040,7 +1085,10 @@ fn erc721_transfer_fail_to_zero_address() {
 #[test]
 fn erc721_transfer_fail_not_owner() {
     let block_context = BlockContext::default();
-    let mut state = CachedState::new(Arc::new(InMemoryStateReader::default()), HashMap::new());
+    let mut state = CachedState::new(
+        Arc::new(InMemoryStateReader::default()),
+        Arc::new(PermanentContractClassCache::default()),
+    );
 
     let collection_name = Felt252::from_bytes_be("some-nft".as_bytes());
     let collection_symbol = Felt252::from(555);

--- a/tests/complex_contracts/utils.rs
+++ b/tests/complex_contracts/utils.rs
@@ -15,19 +15,22 @@ use starknet_in_rust::{
     services::api::contract_classes::{
         compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
     },
-    state::{cached_state::CachedState, state_api::State},
+    state::{
+        cached_state::CachedState, contract_class_cache::PermanentContractClassCache,
+        state_api::State,
+    },
     state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
     transaction::{error::TransactionError, Deploy},
     utils::{calculate_sn_keccak, Address},
+    ContractEntryPoint, EntryPointType,
 };
-use starknet_in_rust::{ContractEntryPoint, EntryPointType};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
 
 pub struct CallConfig<'a> {
-    pub state: &'a mut CachedState<InMemoryStateReader>,
+    pub state: &'a mut CachedState<InMemoryStateReader, PermanentContractClassCache>,
     pub caller_address: &'a Address,
     pub address: &'a Address,
     pub class_hash: &'a [u8; 32],
@@ -136,7 +139,7 @@ pub fn execute_entry_point(
 }
 
 pub fn deploy(
-    state: &mut CachedState<InMemoryStateReader>,
+    state: &mut CachedState<InMemoryStateReader, PermanentContractClassCache>,
     path: &str,
     calldata: &[Felt252],
     block_context: &BlockContext,

--- a/tests/delegate_call.rs
+++ b/tests/delegate_call.rs
@@ -2,20 +2,24 @@
 
 use cairo_vm::felt::Felt252;
 use num_traits::{One, Zero};
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::cached_state::CachedState,
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        ExecutionResourcesManager,
+    },
     utils::Address,
+    EntryPointType,
 };
-use std::sync::Arc;
-use std::{collections::HashMap, path::PathBuf};
+use std::{path::PathBuf, sync::Arc};
 
 #[test]
 fn delegate_call() {
@@ -23,7 +27,7 @@ fn delegate_call() {
     //*    Create state reader with class hash data
     //* --------------------------------------------
 
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
     let nonce = Felt252::zero();
 
     // Add get_number.cairo contract to the state
@@ -34,7 +38,7 @@ fn delegate_call() {
     let address = Address(Felt252::one()); // const CONTRACT_ADDRESS = 1;
     let class_hash = [2; 32];
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -68,7 +72,7 @@ fn delegate_call() {
     let address = Address(1111.into());
     let class_hash = [1; 32];
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -83,7 +87,7 @@ fn delegate_call() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     //* ------------------------------------
     //*    Create execution entry point

--- a/tests/delegate_l1_handler.rs
+++ b/tests/delegate_l1_handler.rs
@@ -2,29 +2,31 @@
 
 use cairo_vm::felt::{felt_str, Felt252};
 use num_traits::{One, Zero};
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::{
-        cached_state::CachedState, in_memory_state_reader::InMemoryStateReader,
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
         ExecutionResourcesManager,
     },
     utils::Address,
+    EntryPointType,
 };
-use std::sync::Arc;
-use std::{collections::HashMap, path::PathBuf};
+use std::{path::PathBuf, sync::Arc};
 
 #[test]
 fn delegate_l1_handler() {
     //* --------------------------------------------
     //*    Create state reader with class hash data
     //* --------------------------------------------
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
     let nonce = Felt252::zero();
 
     // Add get_number.cairo contract to the state
@@ -35,7 +37,7 @@ fn delegate_l1_handler() {
     let address = Address(Felt252::one()); // const CONTRACT_ADDRESS = 1;
     let class_hash = [2; 32];
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -63,7 +65,7 @@ fn delegate_l1_handler() {
     let address = Address(1111.into());
     let class_hash = [1; 32];
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -78,7 +80,7 @@ fn delegate_l1_handler() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     //* ------------------------------------
     //*    Create execution entry point

--- a/tests/fibonacci.rs
+++ b/tests/fibonacci.rs
@@ -2,24 +2,29 @@
 #![deny(warnings)]
 
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
-use cairo_vm::{felt::Felt252, vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME};
+use cairo_vm::{
+    felt::Felt252,
+    vm::runners::{builtin_runner::RANGE_CHECK_BUILTIN_NAME, cairo_runner::ExecutionResources},
+};
 use num_traits::Zero;
-use starknet_in_rust::definitions::block_context::BlockContext;
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
-    definitions::constants::TRANSACTION_VERSION,
+    definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::cached_state::CachedState,
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        ExecutionResourcesManager,
+    },
     utils::{Address, ClassHash},
+    EntryPointType,
 };
-use std::sync::Arc;
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 #[test]
 fn integration_test() {
@@ -43,7 +48,7 @@ fn integration_test() {
     //*    Create state reader with class hash data
     //* --------------------------------------------
 
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     //  ------------ contract data --------------------
 
@@ -51,7 +56,7 @@ fn integration_test() {
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -67,7 +72,7 @@ fn integration_test() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     //* ------------------------------------
     //*    Create execution entry point
@@ -149,13 +154,14 @@ fn integration_test_cairo1() {
     let fib_entrypoint_selector = &entrypoints.external.get(0).unwrap().selector;
 
     // Create state reader with class hash data
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+    contract_class_cache
+        .set_contract_class(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -165,7 +171,7 @@ fn integration_test_cairo1() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     // Create an execution entry point
     let calldata = [0.into(), 1.into(), 12.into()].to_vec();

--- a/tests/increase_balance.rs
+++ b/tests/increase_balance.rs
@@ -1,25 +1,26 @@
 #![deny(warnings)]
 
-use cairo_vm::felt::Felt252;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use cairo_vm::{felt::Felt252, vm::runners::cairo_runner::ExecutionResources};
 use num_traits::Zero;
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::{cached_state::CachedState, state_cache::StorageEntry},
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        state_cache::StorageEntry,
+        ExecutionResourcesManager,
+    },
     utils::{calculate_sn_keccak, Address},
+    EntryPointType,
 };
-use std::sync::Arc;
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-};
+use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 #[test]
 fn hello_starknet_increase_balance() {
@@ -44,7 +45,7 @@ fn hello_starknet_increase_balance() {
     //*    Create state reader with class hash data
     //* --------------------------------------------
 
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     //  ------------ contract data --------------------
 
@@ -54,7 +55,7 @@ fn hello_starknet_increase_balance() {
     let storage_entry: StorageEntry = (address.clone(), [1; 32]);
     let storage = Felt252::zero();
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -73,7 +74,7 @@ fn hello_starknet_increase_balance() {
     //*    Create state with previous data
     //* ---------------------------------------
 
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     //* ------------------------------------
     //*    Create execution entry point

--- a/tests/internal_calls.rs
+++ b/tests/internal_calls.rs
@@ -1,22 +1,26 @@
 #![deny(warnings)]
 
-use std::sync::Arc;
-
 use cairo_vm::felt::Felt252;
 use num_traits::Zero;
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::{cached_state::CachedState, state_cache::StorageEntry},
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        state_cache::StorageEntry,
+        ExecutionResourcesManager,
+    },
     utils::{calculate_sn_keccak, Address, ClassHash},
+    EntryPointType,
 };
-use std::collections::HashMap;
+use std::sync::Arc;
 
 #[test]
 fn test_internal_calls() {
@@ -49,10 +53,14 @@ fn test_internal_calls() {
 
     let mut state = CachedState::new(
         Arc::new(state_reader),
-        HashMap::from([(
-            [0x01; 32],
-            CompiledClass::Deprecated(Arc::new(contract_class)),
-        )]),
+        Arc::new({
+            let cache = PermanentContractClassCache::default();
+            cache.set_contract_class(
+                [0x01; 32],
+                CompiledClass::Deprecated(Arc::new(contract_class)),
+            );
+            cache
+        }),
     );
 
     let entry_point_selector = Felt252::from_bytes_be(&calculate_sn_keccak(b"a"));

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -1,62 +1,62 @@
 // This module tests our code against the blockifier to ensure they work in the same way.
 use assert_matches::assert_matches;
 use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
-use cairo_vm::felt::{felt_str, Felt252};
-use cairo_vm::vm::runners::builtin_runner::{HASH_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME};
-use cairo_vm::vm::{
-    errors::{
-        cairo_run_errors::CairoRunError, vm_errors::VirtualMachineError, vm_exception::VmException,
+use cairo_vm::{
+    felt::{felt_str, Felt252},
+    vm::runners::builtin_runner::{HASH_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME},
+    vm::{
+        errors::{
+            cairo_run_errors::CairoRunError, vm_errors::VirtualMachineError,
+            vm_exception::VmException,
+        },
+        runners::cairo_runner::ExecutionResources,
     },
-    runners::cairo_runner::ExecutionResources,
 };
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Num, One, Zero};
-use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
-use starknet_in_rust::core::contract_address::{
-    compute_casm_class_hash, compute_sierra_class_hash,
-};
-use starknet_in_rust::core::errors::state_errors::StateError;
-use starknet_in_rust::definitions::constants::{
-    DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS, VALIDATE_ENTRY_POINT_SELECTOR,
-};
-use starknet_in_rust::execution::execution_entry_point::ExecutionEntryPoint;
-use starknet_in_rust::execution::TransactionExecutionContext;
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass;
-use starknet_in_rust::state::ExecutionResourcesManager;
-use starknet_in_rust::transaction::fee::calculate_tx_fee;
-use starknet_in_rust::transaction::{DeclareV2, Deploy};
-use starknet_in_rust::CasmContractClass;
-use starknet_in_rust::EntryPointType;
+use pretty_assertions_sorted::assert_eq_sorted;
 use starknet_in_rust::{
+    core::{
+        contract_address::{compute_casm_class_hash, compute_sierra_class_hash},
+        errors::state_errors::StateError,
+    },
     definitions::{
         block_context::{BlockContext, StarknetChainId, StarknetOsConfig},
         constants::{
-            CONSTRUCTOR_ENTRY_POINT_SELECTOR, EXECUTE_ENTRY_POINT_SELECTOR, TRANSACTION_VERSION,
-            TRANSFER_ENTRY_POINT_SELECTOR, TRANSFER_EVENT_SELECTOR,
-            VALIDATE_DECLARE_ENTRY_POINT_SELECTOR, VALIDATE_DEPLOY_ENTRY_POINT_SELECTOR,
+            CONSTRUCTOR_ENTRY_POINT_SELECTOR, DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS,
+            EXECUTE_ENTRY_POINT_SELECTOR, TRANSACTION_VERSION, TRANSFER_ENTRY_POINT_SELECTOR,
+            TRANSFER_EVENT_SELECTOR, VALIDATE_DECLARE_ENTRY_POINT_SELECTOR,
+            VALIDATE_DEPLOY_ENTRY_POINT_SELECTOR, VALIDATE_ENTRY_POINT_SELECTOR,
         },
         transaction_type::TransactionType,
     },
-    execution::{CallInfo, CallType, OrderedEvent, TransactionExecutionInfo},
-    state::in_memory_state_reader::InMemoryStateReader,
+    execution::{
+        execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, OrderedEvent,
+        TransactionExecutionContext, TransactionExecutionInfo,
+    },
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::{
         cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
         state_api::{State, StateReader},
-        state_cache::StateCache,
-        state_cache::StorageEntry,
-        BlockInfo,
+        state_cache::{StateCache, StorageEntry},
+        BlockInfo, ExecutionResourcesManager,
     },
     transaction::{
-        error::TransactionError,
-        DeployAccount,
-        {invoke_function::InvokeFunction, Declare},
+        error::TransactionError, fee::calculate_tx_fee, invoke_function::InvokeFunction, Declare,
+        DeclareV2, Deploy, DeployAccount,
     },
     utils::{calculate_sn_keccak, felt_to_hash, Address, ClassHash},
+    CasmContractClass, EntryPointType,
 };
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 const ACCOUNT_CONTRACT_PATH: &str = "starknet_programs/account_without_validation.json";
 const ERC20_CONTRACT_PATH: &str = "starknet_programs/ERC20.json";
@@ -119,8 +119,13 @@ pub fn new_starknet_block_context_for_testing() -> BlockContext {
     )
 }
 
-fn create_account_tx_test_state(
-) -> Result<(BlockContext, CachedState<InMemoryStateReader>), Box<dyn std::error::Error>> {
+fn create_account_tx_test_state() -> Result<
+    (
+        BlockContext,
+        CachedState<InMemoryStateReader, PermanentContractClassCache>,
+    ),
+    Box<dyn std::error::Error>,
+> {
     let block_context = new_starknet_block_context_for_testing();
 
     let test_contract_class_hash = felt_to_hash(&TEST_CLASS_HASH.clone());
@@ -196,46 +201,50 @@ fn create_account_tx_test_state(
             }
             Arc::new(state_reader)
         },
-        HashMap::new(),
+        Arc::new(PermanentContractClassCache::default()),
     );
 
     Ok((block_context, cached_state))
 }
 
-fn expected_state_before_tx() -> CachedState<InMemoryStateReader> {
+fn expected_state_before_tx() -> CachedState<InMemoryStateReader, PermanentContractClassCache> {
     let in_memory_state_reader = initial_in_memory_state_reader();
 
-    CachedState::new(Arc::new(in_memory_state_reader), HashMap::new())
+    CachedState::new(
+        Arc::new(in_memory_state_reader),
+        Arc::new(PermanentContractClassCache::default()),
+    )
 }
 
-fn expected_state_after_tx(fee: u128) -> CachedState<InMemoryStateReader> {
+fn expected_state_after_tx(
+    fee: u128,
+) -> CachedState<InMemoryStateReader, PermanentContractClassCache> {
     let in_memory_state_reader = initial_in_memory_state_reader();
 
-    let contract_classes_cache = HashMap::from([
-        (
-            felt_to_hash(&TEST_CLASS_HASH.clone()),
-            CompiledClass::Deprecated(Arc::new(
-                ContractClass::from_path(TEST_CONTRACT_PATH).unwrap(),
-            )),
-        ),
-        (
-            felt_to_hash(&TEST_ACCOUNT_CONTRACT_CLASS_HASH.clone()),
-            CompiledClass::Deprecated(Arc::new(
-                ContractClass::from_path(ACCOUNT_CONTRACT_PATH).unwrap(),
-            )),
-        ),
-        (
-            felt_to_hash(&TEST_ERC20_CONTRACT_CLASS_HASH.clone()),
-            CompiledClass::Deprecated(Arc::new(
-                ContractClass::from_path(ERC20_CONTRACT_PATH).unwrap(),
-            )),
-        ),
-    ]);
+    let contract_classes_cache = PermanentContractClassCache::default();
+    contract_classes_cache.set_contract_class(
+        felt_to_hash(&TEST_CLASS_HASH.clone()),
+        CompiledClass::Deprecated(Arc::new(
+            ContractClass::from_path(TEST_CONTRACT_PATH).unwrap(),
+        )),
+    );
+    contract_classes_cache.set_contract_class(
+        felt_to_hash(&TEST_ACCOUNT_CONTRACT_CLASS_HASH.clone()),
+        CompiledClass::Deprecated(Arc::new(
+            ContractClass::from_path(ACCOUNT_CONTRACT_PATH).unwrap(),
+        )),
+    );
+    contract_classes_cache.set_contract_class(
+        felt_to_hash(&TEST_ERC20_CONTRACT_CLASS_HASH.clone()),
+        CompiledClass::Deprecated(Arc::new(
+            ContractClass::from_path(ERC20_CONTRACT_PATH).unwrap(),
+        )),
+    );
 
     CachedState::new_for_testing(
         Arc::new(in_memory_state_reader),
         state_cache_after_invoke_tx(fee),
-        contract_classes_cache,
+        Arc::new(contract_classes_cache),
     )
 }
 
@@ -520,8 +529,12 @@ fn test_create_account_tx_test_state() {
     let expected_initial_state = expected_state_before_tx();
     assert_eq!(&state.cache(), &expected_initial_state.cache());
     assert_eq!(
-        &state.contract_classes(),
-        &expected_initial_state.contract_classes()
+        (&*state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>(),
+        (&*expected_initial_state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>()
     );
     assert_eq!(
         &state.state_reader.address_to_class_hash,
@@ -876,8 +889,12 @@ fn test_declare_tx() {
     let expected_initial_state = expected_state_before_tx();
     assert_eq!(&state.cache(), &expected_initial_state.cache());
     assert_eq!(
-        &state.contract_classes(),
-        &expected_initial_state.contract_classes()
+        (&*state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>(),
+        (&*expected_initial_state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>()
     );
     assert_eq!(
         &state.state_reader.address_to_class_hash,
@@ -960,8 +977,12 @@ fn test_declarev2_tx() {
     let expected_initial_state = expected_state_before_tx();
     assert_eq!(&state.cache(), &expected_initial_state.cache());
     assert_eq!(
-        &state.contract_classes(),
-        &expected_initial_state.contract_classes()
+        (&*state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>(),
+        (&*expected_initial_state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>()
     );
     assert_eq!(
         &state.state_reader.address_to_class_hash,
@@ -1348,8 +1369,12 @@ fn test_invoke_tx_state() {
     let expected_initial_state = expected_state_before_tx();
     assert_eq!(&state.cache(), &expected_initial_state.cache());
     assert_eq!(
-        &state.contract_classes(),
-        &expected_initial_state.contract_classes()
+        (&*state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>(),
+        (&*expected_initial_state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>()
     );
     assert_eq!(
         &state.state_reader.address_to_class_hash,
@@ -1421,8 +1446,12 @@ fn test_invoke_with_declarev2_tx() {
     let expected_initial_state = expected_state_before_tx();
     assert_eq!(&state.cache(), &expected_initial_state.cache());
     assert_eq!(
-        &state.contract_classes(),
-        &expected_initial_state.contract_classes()
+        (&*state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>(),
+        (&*expected_initial_state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>()
     );
     assert_eq!(
         &state.state_reader.address_to_class_hash,
@@ -1518,7 +1547,14 @@ fn test_deploy_account() {
     let (state_before, state_after) = expected_deploy_account_states();
 
     assert_eq!(&state.cache(), &state_before.cache());
-    assert_eq!(&state.contract_classes(), &state_before.contract_classes());
+    assert_eq!(
+        (&*state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>(),
+        (&*state_before.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>()
+    );
 
     let tx_info = deploy_account_tx
         .execute(&mut state, &block_context)
@@ -1628,8 +1664,15 @@ fn test_deploy_account_revert() {
     let (state_before, mut state_after) = expected_deploy_account_states();
 
     assert_eq_sorted!(&state.cache(), &state_before.cache());
-    assert_eq_sorted!(&state.contract_classes(), &state_before.contract_classes());
-    assert!(&state.contract_classes().is_empty());
+    assert_eq!(
+        (&*state.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>(),
+        (&*state_before.contract_class_cache().clone())
+            .into_iter()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(state.contract_class_cache().as_ref().into_iter().count(), 0);
 
     let tx_info = deploy_account_tx
         .execute(&mut state, &block_context)
@@ -1663,10 +1706,10 @@ fn test_deploy_account_revert() {
         .storage_initial_values_mut()
         .extend(state_after.cache_mut().storage_initial_values_mut().clone());
 
-    // Set contract class cache
-    state_reverted
-        .set_contract_classes(state_after.contract_classes().clone())
-        .unwrap();
+    // // Set contract class cache
+    // state_reverted
+    //     .set_contract_classes(state_after.contract_class_cache().clone())
+    //     .unwrap();
 
     // Set storage writes related to the fee transfer
     state_reverted
@@ -1746,8 +1789,8 @@ fn test_deploy_account_revert() {
 }
 
 fn expected_deploy_account_states() -> (
-    CachedState<InMemoryStateReader>,
-    CachedState<InMemoryStateReader>,
+    CachedState<InMemoryStateReader, PermanentContractClassCache>,
+    CachedState<InMemoryStateReader, PermanentContractClassCache>,
 ) {
     let fee = Felt252::from(3709);
     let mut state_before = CachedState::new(
@@ -1790,7 +1833,7 @@ fn expected_deploy_account_states() -> (
             ]),
             HashMap::new(),
         )),
-        HashMap::new(),
+        Arc::new(PermanentContractClassCache::default()),
     );
     state_before.set_storage_at(
         &(
@@ -1801,6 +1844,11 @@ fn expected_deploy_account_states() -> (
     );
 
     let mut state_after = state_before.clone();
+
+    // Make the contract cache independent (otherwise tests will fail because the initial state's
+    // cache will not be empty anymore).
+    *state_after.contract_class_cache_mut() = Arc::new(PermanentContractClassCache::default());
+
     state_after.cache_mut().nonce_initial_values_mut().insert(
         Address(felt_str!(
             "386181506763903095743576862849245034886954647214831045800703908858571591162"
@@ -2228,12 +2276,13 @@ fn test_library_call_with_declare_v2() {
     let casm_contract_hash;
     #[cfg(not(feature = "cairo_1_tests"))]
     {
-        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2.clone()
+        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO2.clone();
     }
     #[cfg(feature = "cairo_1_tests")]
     {
-        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1.clone()
+        casm_contract_hash = TEST_FIB_COMPILED_CONTRACT_CLASS_HASH_CAIRO1.clone();
     }
+
     // Create an execution entry point
     let calldata = vec![
         casm_contract_hash,

--- a/tests/multi_syscall_test.rs
+++ b/tests/multi_syscall_test.rs
@@ -1,20 +1,23 @@
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_vm::felt::Felt252;
 use num_traits::{Num, Zero};
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use starknet_in_rust::utils::calculate_sn_keccak;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, OrderedEvent,
         OrderedL2ToL1Message, TransactionExecutionContext,
     },
-    state::cached_state::CachedState,
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
-    utils::{Address, ClassHash},
+    services::api::contract_classes::compiled_class::CompiledClass,
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        ExecutionResourcesManager,
+    },
+    utils::{calculate_sn_keccak, Address, ClassHash},
+    EntryPointType,
 };
-use std::{collections::HashMap, sync::Arc, vec};
+use std::{sync::Arc, vec};
 
 #[test]
 fn test_multiple_syscall() {
@@ -23,13 +26,14 @@ fn test_multiple_syscall() {
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
 
     // Create state reader with class hash data
-    let mut contract_class_cache: HashMap<[u8; 32], _> = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
+    contract_class_cache
+        .set_contract_class(class_hash, CompiledClass::Casm(Arc::new(contract_class)));
     let mut state_reader = InMemoryStateReader::default();
     state_reader
         .address_to_class_hash_mut()
@@ -39,7 +43,7 @@ fn test_multiple_syscall() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache.clone());
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     // Create an execution entry point
     let calldata = [].to_vec();
@@ -60,7 +64,7 @@ fn test_multiple_syscall() {
         assert_eq!(call_info.retdata, vec![caller_address.clone().0])
     }
 
-    // Block for get_contact_address.
+    // Block for get_contract_address.
     {
         let call_info = test_syscall(
             "contract_address",
@@ -217,7 +221,7 @@ fn test_syscall(
     caller_address: Address,
     entry_point_type: EntryPointType,
     class_hash: [u8; 32],
-    state: &mut CachedState<InMemoryStateReader>,
+    state: &mut CachedState<InMemoryStateReader, PermanentContractClassCache>,
 ) -> CallInfo {
     let entrypoint_selector =
         Felt252::from_bytes_be(&calculate_sn_keccak(entrypoint_selector.as_bytes()));

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -19,16 +19,18 @@ use starknet_in_rust::{
         execution_entry_point::ExecutionEntryPoint, CallInfo, CallType, L2toL1MessageInfo,
         OrderedEvent, OrderedL2ToL1Message, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
     state::{
         cached_state::CachedState,
-        state_api::{State, StateReader},
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        state_api::State,
+        ExecutionResourcesManager,
     },
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
     utils::{calculate_sn_keccak, felt_to_hash, Address, ClassHash},
-};
-use starknet_in_rust::{
-    services::api::contract_classes::compiled_class::CompiledClass, EntryPointType,
+    EntryPointType,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -92,13 +94,13 @@ fn test_contract<'a>(
 
     let mut storage_entries = Vec::new();
     let contract_class_cache = {
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         for (class_hash, contract_path, contract_address) in extra_contracts {
             let contract_class = ContractClass::from_path(contract_path)
                 .expect("Could not load extra contract from JSON");
 
-            contract_class_cache.insert(
+            contract_class_cache.set_contract_class(
                 class_hash,
                 CompiledClass::Deprecated(Arc::new(contract_class.clone())),
             );
@@ -121,7 +123,7 @@ fn test_contract<'a>(
 
         contract_class_cache
     };
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
     storage_entries
         .into_iter()
         .for_each(|(a, b, c)| state.set_storage_at(&(a, b), c));
@@ -1085,18 +1087,18 @@ fn deploy_cairo1_from_cairo0_with_constructor() {
     let test_contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
 
     // Create state reader with class hash data
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
     // simulate contract declare
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         test_class_hash,
         CompiledClass::Casm(Arc::new(test_contract_class.clone())),
     );
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -1110,7 +1112,7 @@ fn deploy_cairo1_from_cairo0_with_constructor() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     // arguments of deploy contract
     let calldata: Vec<_> = [test_felt_hash, salt, Felt252::one()].to_vec();
@@ -1187,18 +1189,18 @@ fn deploy_cairo1_from_cairo0_without_constructor() {
     let test_contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
 
     // Create state reader with class hash data
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
     // simulate contract declare
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         test_class_hash,
         CompiledClass::Casm(Arc::new(test_contract_class.clone())),
     );
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -1212,7 +1214,7 @@ fn deploy_cairo1_from_cairo0_without_constructor() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     // arguments of deploy contract
     let calldata: Vec<_> = [test_felt_hash, salt].to_vec();
@@ -1291,18 +1293,18 @@ fn deploy_cairo1_and_invoke() {
     let test_contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
 
     // Create state reader with class hash data
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
     // simulate contract declare
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         test_class_hash,
         CompiledClass::Casm(Arc::new(test_contract_class.clone())),
     );
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -1316,7 +1318,7 @@ fn deploy_cairo1_and_invoke() {
         .insert(address.clone(), nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     // arguments of deploy contract
     let calldata: Vec<_> = [test_felt_hash, salt].to_vec();
@@ -1417,13 +1419,13 @@ fn send_messages_to_l1_different_contract_calls() {
         .to_owned();
 
     // Create state reader with class hash data
-    let mut contract_class_cache = HashMap::new();
+    let contract_class_cache = PermanentContractClassCache::default();
 
     let address = Address(1111.into());
     let class_hash: ClassHash = [1; 32];
     let nonce = Felt252::zero();
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         class_hash,
         CompiledClass::Deprecated(Arc::new(contract_class)),
     );
@@ -1444,7 +1446,7 @@ fn send_messages_to_l1_different_contract_calls() {
     let send_msg_class_hash: ClassHash = [2; 32];
     let send_msg_nonce = Felt252::zero();
 
-    contract_class_cache.insert(
+    contract_class_cache.set_contract_class(
         send_msg_class_hash,
         CompiledClass::Deprecated(Arc::new(send_msg_contract_class)),
     );
@@ -1456,7 +1458,7 @@ fn send_messages_to_l1_different_contract_calls() {
         .insert(send_msg_address, send_msg_nonce);
 
     // Create state from the state_reader and contract cache.
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
 
     // Create an execution entry point
     let calldata = [25.into(), 50.into(), 75.into()].to_vec();

--- a/tests/syscalls_errors.rs
+++ b/tests/syscalls_errors.rs
@@ -1,25 +1,27 @@
 #![deny(warnings)]
 
+use assert_matches::assert_matches;
 use cairo_vm::felt::Felt252;
-use starknet_in_rust::utils::felt_to_hash;
-use starknet_in_rust::EntryPointType;
 use starknet_in_rust::{
     core::errors::state_errors::StateError,
     definitions::{block_context::BlockContext, constants::TRANSACTION_VERSION},
     execution::{
         execution_entry_point::ExecutionEntryPoint, CallType, TransactionExecutionContext,
     },
-    services::api::contract_classes::deprecated_contract_class::ContractClass,
-    state::{cached_state::CachedState, state_api::State},
-    state::{in_memory_state_reader::InMemoryStateReader, ExecutionResourcesManager},
-    utils::{calculate_sn_keccak, Address, ClassHash},
+    services::api::contract_classes::{
+        compiled_class::CompiledClass, deprecated_contract_class::ContractClass,
+    },
+    state::{
+        cached_state::CachedState,
+        contract_class_cache::{ContractClassCache, PermanentContractClassCache},
+        in_memory_state_reader::InMemoryStateReader,
+        state_api::State,
+        ExecutionResourcesManager,
+    },
+    utils::{calculate_sn_keccak, felt_to_hash, Address, ClassHash},
+    EntryPointType,
 };
-use std::path::Path;
-use std::sync::Arc;
-
-use assert_matches::assert_matches;
-use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
-use std::collections::HashMap;
+use std::{path::Path, sync::Arc};
 
 #[allow(clippy::too_many_arguments)]
 fn test_contract<'a>(
@@ -69,13 +71,13 @@ fn test_contract<'a>(
 
     let mut storage_entries = Vec::new();
     let contract_class_cache = {
-        let mut contract_class_cache = HashMap::new();
+        let contract_class_cache = PermanentContractClassCache::default();
 
         for (class_hash, contract_path, contract_address) in extra_contracts {
             let contract_class = ContractClass::from_path(contract_path)
                 .expect("Could not load extra contract from JSON");
 
-            contract_class_cache.insert(
+            contract_class_cache.set_contract_class(
                 class_hash,
                 CompiledClass::Deprecated(Arc::new(contract_class.clone())),
             );
@@ -101,7 +103,7 @@ fn test_contract<'a>(
 
         contract_class_cache
     };
-    let mut state = CachedState::new(Arc::new(state_reader), contract_class_cache);
+    let mut state = CachedState::new(Arc::new(state_reader), Arc::new(contract_class_cache));
     storage_entries
         .into_iter()
         .for_each(|(a, b, c)| state.set_storage_at(&(a, b), c));


### PR DESCRIPTION
`CallInfo` is a big struct, so avoiding clones of it may be beneficial
