### PR TITLE
Update the `no_coverage` attribute to the new `coverage(off)` mechanism.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,9 +1426,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "coverage-helper"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9db510e477cf3c14a6c56aa2ed28e499f1e27e01c17723b41ece793d11cf3fe"
+checksum = "3036399e8abfc9d696c1ee94f7677f9704e903d96299b0026e339eed6055dcaf"
 
 [[package]]
 name = "cpufeatures"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde_json_pythonic = "0.1.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-coverage-helper = "0.1.0"
+coverage-helper = "0.2.0"
 pretty_assertions_sorted = "1.2.3"
 
 [[bench]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,4 +19,4 @@ mimalloc = { version = "0.1.29", default-features = false, optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-coverage-helper = "0.1.0"
+coverage-helper = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 #![forbid(unsafe_code)]
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{


### PR DESCRIPTION
# Update the `no_coverage` attribute to the new `coverage(off)` mechanism

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
