### PR TITLE
fix wrong from_address in deprecated execute_constructor_entry_point

### DIFF
--- a/src/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -246,7 +246,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
             .map_err(|_| StateError::ExecutionEntryPoint())?;
 
         if let Some(call_info) = call_info.call_info {
-            self.events.extend(call_info.events);
+            self.internal_calls.push(call_info);
         }
 
         Ok(())

--- a/tests/syscalls.rs
+++ b/tests/syscalls.rs
@@ -172,7 +172,7 @@ fn test_contract<'a>(
     );
     assert_eq!(result.calldata, calldata);
     assert_eq_sorted!(result.retdata, return_data.into());
-    assert_eq!(result.internal_calls, internal_calls.into());
+    assert_eq_sorted!(result.internal_calls, internal_calls.into());
     assert_eq!(result.execution_resources, execution_resources);
 
     assert_eq!(result.gas_consumed, 0);
@@ -1009,86 +1009,113 @@ fn test_deploy_and_call_contract_syscall() {
             new_constant.clone(),
         ],
         [
-        // Invoke storage_var_and_constructor.cairo mult_constant function
-        CallInfo {
-            caller_address: Address(11111.into()),
-            call_type: Some(CallType::Call),
-            contract_address: deploy_address.clone(),
-            code_address: None,
-            class_hash: Some(deploy_class_hash),
-            entry_point_selector: Some(
-                Felt252::from_str_radix(
-                    "1576037374104670872807053137865113122553607263175471701007015754752102201893",
-                    10,
-                )
-                .unwrap(),
-            ),
-            entry_point_type: Some(EntryPointType::External),
-            calldata: vec![4.into()],
-            retdata: vec![(constructor_constant.clone() * Felt252::new(4))],
-            storage_read_values: vec![constructor_constant.clone()],
-            accessed_storage_keys: HashSet::from([constant_storage_key]),
-            execution_resources: ExecutionResources {
-                n_steps: 52,
+            // constructor
+            CallInfo {
+                caller_address: Address(11111.into()),
+                call_type: Some(CallType::Call),
+                contract_address: deploy_address.clone(),
+                code_address: None,
+                class_hash: Some(deploy_class_hash),
+                entry_point_selector: Some(
+                    Felt252::from_str_radix(
+                        "1159040026212278395030414237414753050475174923702621880048416706425641521556",
+                        10,
+                    )
+                    .unwrap(),
+                ),
+                entry_point_type: Some(EntryPointType::Constructor),
+                calldata: vec![550.into()],
+                retdata: vec![],
+                storage_read_values: vec![0.into()],
+                accessed_storage_keys: HashSet::from([constant_storage_key]),
+                execution_resources: ExecutionResources {
+                    n_steps: 40,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
-            ..Default::default()
-        },
-        // Invoke storage_var_and_constructor.cairo set_constant function
-        CallInfo {
-            caller_address: Address(11111.into()),
-            call_type: Some(CallType::Call),
-            contract_address: deploy_address.clone(),
-            code_address: None,
-            class_hash: Some(deploy_class_hash),
-            entry_point_selector: Some(
-                Felt252::from_str_radix(
-                    "1201037417712951658445715615949920673423990292207294106968654696818998525373",
-                    10,
-                )
-                .unwrap(),
-            ),
-            entry_point_type: Some(EntryPointType::External),
-            calldata: vec![new_constant.clone()],
-            retdata: vec![],
-            storage_read_values: vec![constructor_constant],
-            accessed_storage_keys: HashSet::from([constant_storage_key]),
-            execution_resources: ExecutionResources {
-                n_steps: 40,
+            // Invoke storage_var_and_constructor.cairo mult_constant function
+            CallInfo {
+                caller_address: Address(11111.into()),
+                call_type: Some(CallType::Call),
+                contract_address: deploy_address.clone(),
+                code_address: None,
+                class_hash: Some(deploy_class_hash),
+                entry_point_selector: Some(
+                    Felt252::from_str_radix(
+                        "1576037374104670872807053137865113122553607263175471701007015754752102201893",
+                        10,
+                    )
+                    .unwrap(),
+                ),
+                entry_point_type: Some(EntryPointType::External),
+                calldata: vec![4.into()],
+                retdata: vec![(constructor_constant.clone() * Felt252::new(4))],
+                storage_read_values: vec![constructor_constant.clone()],
+                accessed_storage_keys: HashSet::from([constant_storage_key]),
+                execution_resources: ExecutionResources {
+                    n_steps: 52,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
-            ..Default::default()
-        },
-        // Invoke storage_var_and_constructor.cairo get_constant function
-        CallInfo {
-            caller_address: Address(11111.into()),
-            call_type: Some(CallType::Call),
-            contract_address: deploy_address,
-            code_address: None,
-            class_hash: Some(deploy_class_hash),
-            entry_point_selector: Some(
-                Felt252::from_str_radix(
-                    "915547745133109687566886827729966789818200062539892992518817034473866315209",
-                    10,
-                )
-                .unwrap(),
-            ),
-            entry_point_type: Some(EntryPointType::External),
-            calldata: vec![],
-            retdata: vec![new_constant.clone()],
-            storage_read_values: vec![new_constant.clone()],
-            accessed_storage_keys: HashSet::from([constant_storage_key]),
-            execution_resources: ExecutionResources {
-                n_steps: 46,
+            // Invoke storage_var_and_constructor.cairo set_constant function
+            CallInfo {
+                caller_address: Address(11111.into()),
+                call_type: Some(CallType::Call),
+                contract_address: deploy_address.clone(),
+                code_address: None,
+                class_hash: Some(deploy_class_hash),
+                entry_point_selector: Some(
+                    Felt252::from_str_radix(
+                        "1201037417712951658445715615949920673423990292207294106968654696818998525373",
+                        10,
+                    )
+                    .unwrap(),
+                ),
+                entry_point_type: Some(EntryPointType::External),
+                calldata: vec![new_constant.clone()],
+                retdata: vec![],
+                storage_read_values: vec![constructor_constant],
+                accessed_storage_keys: HashSet::from([constant_storage_key]),
+                execution_resources: ExecutionResources {
+                    n_steps: 40,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
-            ..Default::default()
-        }        ],
+            // Invoke storage_var_and_constructor.cairo get_constant function
+            CallInfo {
+                caller_address: Address(11111.into()),
+                call_type: Some(CallType::Call),
+                contract_address: deploy_address,
+                code_address: None,
+                class_hash: Some(deploy_class_hash),
+                entry_point_selector: Some(
+                    Felt252::from_str_radix(
+                        "915547745133109687566886827729966789818200062539892992518817034473866315209",
+                        10,
+                    )
+                    .unwrap(),
+                ),
+                entry_point_type: Some(EntryPointType::External),
+                calldata: vec![],
+                retdata: vec![new_constant.clone()],
+                storage_read_values: vec![new_constant.clone()],
+                accessed_storage_keys: HashSet::from([constant_storage_key]),
+                execution_resources: ExecutionResources {
+                    n_steps: 46,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        ],
         [new_constant],
         ExecutionResources {
             n_steps: 325,
             n_memory_holes: 2,
-            builtin_instance_counter: HashMap::default()},
+            builtin_instance_counter: HashMap::default()
+        },
     );
 }
 


### PR DESCRIPTION
Fixes #1040

Pushing to self.events was wrong, the call info should be added to internal_calls.
