### PR TITLE
Fix `get_execution_info` syscall

### DIFF
--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -272,6 +272,11 @@ fn test_get_gas_price() {
         186551, // real block     186552
         RpcChain::MainNet
     )]
+#[test_case(
+    "0x176a92e8df0128d47f24eebc17174363457a956fa233cc6a7f8561bfbd5023a",
+    317092, // real block 317093
+    RpcChain::MainNet
+)]
 fn starknet_in_rust_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number));
 

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -539,10 +539,6 @@ impl ExecutionEntryPoint {
         runner
             .vm
             .mark_address_range_as_accessed(args_ptr.unwrap(), entrypoint_args.len())?;
-        runner
-            .hint_processor
-            .syscall_handler
-            .mark_read_only_segments_as_accessed(&mut runner.vm)?;
 
         *resources_manager = runner
             .hint_processor

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -524,12 +524,13 @@ impl ExecutionEntryPoint {
             &ref_vec,
             Some(program.data_len() + program_extra_data.len()),
         )?;
-
+        dbg!("mark", core_program_end_ptr, program_extra_data.len());
         runner
             .vm
             .mark_address_range_as_accessed(core_program_end_ptr, program_extra_data.len())?;
 
         runner.validate_and_process_os_context(os_context)?;
+        runner.hint_processor.syscall_handler.mark_read_only_segments_as_accessed(&mut runner.vm)?;
 
         // When execution starts the stack holds entry_points_args + [ret_fp, ret_pc].
         let initial_fp = runner

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -517,14 +517,12 @@ impl ExecutionEntryPoint {
         ));
 
         let ref_vec: Vec<&CairoArg> = entrypoint_args.iter().collect();
-        dbg!(&runner.hint_processor.syscall_handler.read_only_segments);
         // run the Cairo1 entrypoint
         runner.run_from_entrypoint(
             entry_point.offset,
             &ref_vec,
             Some(program.data_len() + program_extra_data.len()),
         )?;
-        dbg!(&runner.hint_processor.syscall_handler.read_only_segments);
         runner
             .vm
             .mark_address_range_as_accessed(core_program_end_ptr, program_extra_data.len())?;

--- a/src/syscalls/business_logic_syscall_handler.rs
+++ b/src/syscalls/business_logic_syscall_handler.rs
@@ -554,24 +554,6 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
         }
         Ok(())
     }
-
-    /// Marks read-only segments as accessed
-    pub(crate) fn mark_read_only_segments_as_accessed(
-        &self,
-        vm: &mut VirtualMachine,
-    ) -> Result<(), TransactionError> {
-        for (segment_ptr, segment_size) in self.read_only_segments.clone() {
-            vm.mark_address_range_as_accessed(
-                segment_ptr,
-                segment_size
-                    .get_int_ref()
-                    .ok_or(TransactionError::NotAFelt)?
-                    .to_usize()
-                    .unwrap_or_default(),
-            )?;
-        }
-        Ok(())
-    }
 }
 
 impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {

--- a/src/syscalls/business_logic_syscall_handler.rs
+++ b/src/syscalls/business_logic_syscall_handler.rs
@@ -133,6 +133,7 @@ pub struct BusinessLogicSyscallHandler<'a, S: StateReader> {
     pub(crate) support_reverted: bool,
     pub(crate) entry_point_selector: Felt252,
     pub(crate) selector_to_syscall: &'a HashMap<Felt252, &'static str>,
+    pub(crate) execution_info_ptr: Option<Relocatable>,
 }
 
 // TODO: execution entry point may no be a parameter field, but there is no way to generate a default for now
@@ -171,6 +172,7 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
             support_reverted,
             entry_point_selector,
             selector_to_syscall: &SELECTOR_TO_SYSCALL,
+            execution_info_ptr: None,
         }
     }
     pub fn default_with_state(state: &'a mut CachedState<S>) -> Self {
@@ -227,6 +229,7 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
             support_reverted: false,
             entry_point_selector,
             selector_to_syscall: &SELECTOR_TO_SYSCALL,
+            execution_info_ptr: None,
         }
     }
 
@@ -558,7 +561,14 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
         vm: &mut VirtualMachine,
     ) -> Result<(), TransactionError> {
         for (segment_ptr, segment_size) in self.read_only_segments.clone() {
-            vm.mark_address_range_as_accessed(segment_ptr, segment_size.get_int_ref().ok_or(TransactionError::NotAFelt)?.to_usize().unwrap_or_default())?;
+            vm.mark_address_range_as_accessed(
+                segment_ptr,
+                segment_size
+                    .get_int_ref()
+                    .ok_or(TransactionError::NotAFelt)?
+                    .to_usize()
+                    .unwrap_or_default(),
+            )?;
         }
         Ok(())
     }
@@ -635,63 +645,65 @@ impl<'a, S: StateReader> BusinessLogicSyscallHandler<'a, S> {
         })
     }
 
+    fn get_or_allocate_execution_info(
+        &mut self,
+        vm: &mut VirtualMachine,
+    ) -> Result<Relocatable, SyscallHandlerError> {
+        if let Some(ptr) = self.execution_info_ptr {
+            return Ok(ptr);
+        }
+
+        // Allocate block_info
+        let block_info = &self.block_context.block_info;
+        let block_info_data = vec![
+            MaybeRelocatable::from(Felt252::from(block_info.block_number)),
+            MaybeRelocatable::from(Felt252::from(block_info.block_timestamp)),
+            MaybeRelocatable::from(&block_info.sequencer_address.0),
+        ];
+        let block_info_ptr = self.allocate_segment(vm, block_info_data)?;
+
+        // Allocate signature
+        let signature: Vec<MaybeRelocatable> = self.tx_execution_context
+            .signature
+            .iter()
+            .map(|s| MaybeRelocatable::from(s))
+            .collect();
+        let signature_start_ptr = self.allocate_segment(vm, signature)?;
+        let signature_end_ptr = (signature_start_ptr + self.tx_execution_context.signature.len())?;
+
+        // Allocate tx info
+        let tx_info = &self.tx_execution_context;
+        let tx_info_data = vec![
+            MaybeRelocatable::from(&tx_info.version),
+            MaybeRelocatable::from(&tx_info.account_contract_address.0),
+            MaybeRelocatable::from(Felt252::from(tx_info.max_fee)),
+            signature_start_ptr.into(),
+            signature_end_ptr.into(),
+            MaybeRelocatable::from(&tx_info.transaction_hash),
+            MaybeRelocatable::from(&self.block_context.starknet_os_config.chain_id),
+            MaybeRelocatable::from(&tx_info.nonce),
+        ];
+        let tx_info_ptr = self.allocate_segment(vm, tx_info_data)?;
+
+        let execution_info = vec![
+            block_info_ptr.into(),
+            tx_info_ptr.into(),
+            MaybeRelocatable::from(&self.caller_address.0),
+            MaybeRelocatable::from(&self.contract_address.0),
+            MaybeRelocatable::from(&self.entry_point_selector),
+        ];
+        let execution_info_ptr = self.allocate_segment(vm, execution_info)?;
+
+        self.execution_info_ptr = Some(execution_info_ptr);
+        Ok(execution_info_ptr)
+    }
+
     fn get_execution_info(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
         remaining_gas: u128,
     ) -> Result<SyscallResponse, SyscallHandlerError> {
-        let tx_info = &self.tx_execution_context;
-        let block_info = &self.block_context.block_info;
-
-        let mut res_segment = vm.add_memory_segment();
-
-        let signature_start = res_segment;
-        for s in tx_info.signature.iter() {
-            vm.insert_value(res_segment, s)?;
-            res_segment = (res_segment + 1)?;
-        }
-        let signature_end = res_segment;
-
-        let tx_info_ptr = res_segment;
-        vm.insert_value::<Felt252>(res_segment, tx_info.version.clone())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value(res_segment, tx_info.account_contract_address.0.clone())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(res_segment, tx_info.max_fee.into())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value(res_segment, signature_start)?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value(res_segment, signature_end)?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value(res_segment, tx_info.transaction_hash.clone())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(
-            res_segment,
-            self.block_context.starknet_os_config.chain_id.clone(),
-        )?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(res_segment, tx_info.nonce.clone())?;
-        res_segment = (res_segment + 1)?;
-
-        let block_info_ptr = res_segment;
-        vm.insert_value::<Felt252>(res_segment, block_info.block_number.into())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(res_segment, block_info.block_timestamp.into())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(res_segment, block_info.sequencer_address.0.clone())?;
-        res_segment = (res_segment + 1)?;
-
-        let exec_info_ptr = res_segment;
-        vm.insert_value(res_segment, block_info_ptr)?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value(res_segment, tx_info_ptr)?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(res_segment, self.caller_address.0.clone())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(res_segment, self.contract_address.0.clone())?;
-        res_segment = (res_segment + 1)?;
-        vm.insert_value::<Felt252>(res_segment, self.entry_point_selector.clone())?;
-
+        let exec_info_ptr = self.get_or_allocate_execution_info(vm)?;
         Ok(SyscallResponse {
             gas: remaining_gas,
             body: Some(ResponseBody::GetExecutionInfo { exec_info_ptr }),


### PR DESCRIPTION
The `get_execution_info` syscall should:
- Hold an execution_info_ptr that holds a reference to the execution_info segment created by the first call to the `get_execution_info` syscall, and use it on every following call instead of writting all the information at each call
- Write the execution_info on read-only segments, so that they are not counted as memory holes if not accessed

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
