### PR TITLE
update cairo native to latest revision, u128 gas, mut self

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=b2a2574727a22de44a00f3654299230a679f2b7c#b2a2574727a22de44a00f3654299230a679f2b7c"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac#db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac"
 dependencies = [
  "bumpalo",
  "cairo-felt",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=b2a2574727a22de44a00f3654299230a679f2b7c#b2a2574727a22de44a00f3654299230a679f2b7c"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac#db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac"
 dependencies = [
  "cairo-felt",
  "cairo-lang-runner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cairo-lang-runner = { workspace = true }
 cairo-lang-sierra = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "b2a2574727a22de44a00f3654299230a679f2b7c", optional = true }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac", optional = true }
 cairo-vm = { workspace = true, features = ["cairo-1-hints"] }
 flate2 = "1.0.25"
 getset = "0.1.2"

--- a/src/syscalls/native_syscall_handler.rs
+++ b/src/syscalls/native_syscall_handler.rs
@@ -41,9 +41,9 @@ where
 
 impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> {
     fn get_block_hash(
-        &self,
+        &mut self,
         block_number: u64,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<cairo_vm::felt::Felt252> {
         println!("Called `get_block_hash({block_number})` from MLIR.");
         Ok(Felt252::from_bytes_be(b"get_block_hash ok"))
@@ -51,7 +51,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
 
     fn get_execution_info(
         &self,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<cairo_native::starknet::ExecutionInfo> {
         println!("Called `get_execution_info()` from MLIR.");
         Ok(ExecutionInfo {
@@ -80,12 +80,12 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
     }
 
     fn deploy(
-        &self,
+        &mut self,
         class_hash: cairo_vm::felt::Felt252,
         contract_address_salt: cairo_vm::felt::Felt252,
         calldata: &[cairo_vm::felt::Felt252],
         deploy_from_zero: bool,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<(cairo_vm::felt::Felt252, Vec<cairo_vm::felt::Felt252>)> {
         println!("Called `deploy({class_hash}, {contract_address_salt}, {calldata:?}, {deploy_from_zero})` from MLIR.");
         Ok((
@@ -95,20 +95,20 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
     }
 
     fn replace_class(
-        &self,
+        &mut self,
         class_hash: cairo_vm::felt::Felt252,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<()> {
         println!("Called `replace_class({class_hash})` from MLIR.");
         Ok(())
     }
 
     fn library_call(
-        &self,
+        &mut self,
         class_hash: cairo_vm::felt::Felt252,
         function_selector: cairo_vm::felt::Felt252,
         calldata: &[cairo_vm::felt::Felt252],
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Vec<cairo_vm::felt::Felt252>> {
         println!(
             "Called `library_call({class_hash}, {function_selector}, {calldata:?})` from MLIR."
@@ -121,7 +121,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         address: cairo_vm::felt::Felt252,
         entrypoint_selector: cairo_vm::felt::Felt252,
         calldata: &[cairo_vm::felt::Felt252],
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Vec<cairo_vm::felt::Felt252>> {
         println!(
             "Called `call_contract({address}, {entrypoint_selector}, {calldata:?})` from MLIR."
@@ -170,7 +170,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &mut self,
         address_domain: u32,
         address: cairo_vm::felt::Felt252,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<cairo_vm::felt::Felt252> {
         let value = match self.starknet_storage_state.read(&address.to_be_bytes()) {
             Ok(value) => Ok(dbg!(value)),
@@ -186,7 +186,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         address_domain: u32,
         address: cairo_vm::felt::Felt252,
         value: cairo_vm::felt::Felt252,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<()> {
         println!("Called `storage_write({address_domain}, {address}, {value})` from MLIR.");
         self.starknet_storage_state
@@ -198,7 +198,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &mut self,
         keys: &[cairo_vm::felt::Felt252],
         data: &[cairo_vm::felt::Felt252],
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<()> {
         let order = self.n_emitted_events;
         println!("Called `emit_event(KEYS: {keys:?}, DATA: {data:?})` from MLIR.");
@@ -212,7 +212,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &mut self,
         to_address: cairo_vm::felt::Felt252,
         payload: &[cairo_vm::felt::Felt252],
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<()> {
         println!("Called `send_message_to_l1({to_address}, {payload:?})` from MLIR.");
         let addr = Address(to_address);
@@ -227,16 +227,20 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         Ok(())
     }
 
-    fn keccak(&self, input: &[u64], _gas: &mut u64) -> SyscallResult<cairo_native::starknet::U256> {
+    fn keccak(
+        &self,
+        input: &[u64],
+        _gas: &mut u128,
+    ) -> SyscallResult<cairo_native::starknet::U256> {
         println!("Called `keccak({input:?})` from MLIR.");
         Ok(U256(Felt252::from(1234567890).to_le_bytes()))
     }
 
     fn secp256k1_add(
-        &self,
+        &mut self,
         _p0: cairo_native::starknet::Secp256k1Point,
         _p1: cairo_native::starknet::Secp256k1Point,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -245,7 +249,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &self,
         _x: cairo_native::starknet::U256,
         _y_parity: bool,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -253,7 +257,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
     fn secp256k1_get_xy(
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
         todo!()
     }
@@ -262,7 +266,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
         _m: cairo_native::starknet::U256,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -271,7 +275,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &self,
         _x: cairo_native::starknet::U256,
         _y: cairo_native::starknet::U256,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -280,7 +284,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &self,
         _p0: cairo_native::starknet::Secp256k1Point,
         _p1: cairo_native::starknet::Secp256k1Point,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -289,7 +293,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &self,
         _x: cairo_native::starknet::U256,
         _y_parity: bool,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
@@ -297,7 +301,7 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
     fn secp256r1_get_xy(
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<(cairo_native::starknet::U256, cairo_native::starknet::U256)> {
         todo!()
     }
@@ -306,69 +310,69 @@ impl<'a, S: StateReader> StarkNetSyscallHandler for NativeSyscallHandler<'a, S> 
         &self,
         _p: cairo_native::starknet::Secp256k1Point,
         _m: cairo_native::starknet::U256,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
 
     fn secp256r1_new(
-        &self,
+        &mut self,
         _x: cairo_native::starknet::U256,
         _y: cairo_native::starknet::U256,
-        _gas: &mut u64,
+        _gas: &mut u128,
     ) -> SyscallResult<Option<cairo_native::starknet::Secp256k1Point>> {
         todo!()
     }
 
-    fn pop_log(&self) {
+    fn pop_log(&mut self) {
         todo!()
     }
 
-    fn set_account_contract_address(&self, _contract_address: cairo_vm::felt::Felt252) {
+    fn set_account_contract_address(&mut self, _contract_address: cairo_vm::felt::Felt252) {
         todo!()
     }
 
-    fn set_block_number(&self, _block_number: u64) {
+    fn set_block_number(&mut self, _block_number: u64) {
         todo!()
     }
 
-    fn set_block_timestamp(&self, _block_timestamp: u64) {
+    fn set_block_timestamp(&mut self, _block_timestamp: u64) {
         todo!()
     }
 
-    fn set_caller_address(&self, _address: cairo_vm::felt::Felt252) {
+    fn set_caller_address(&mut self, _address: cairo_vm::felt::Felt252) {
         todo!()
     }
 
-    fn set_chain_id(&self, _chain_id: cairo_vm::felt::Felt252) {
+    fn set_chain_id(&mut self, _chain_id: cairo_vm::felt::Felt252) {
         todo!()
     }
 
-    fn set_contract_address(&self, _address: cairo_vm::felt::Felt252) {
+    fn set_contract_address(&mut self, _address: cairo_vm::felt::Felt252) {
         todo!()
     }
 
-    fn set_max_fee(&self, _max_fee: u128) {
+    fn set_max_fee(&mut self, _max_fee: u128) {
         todo!()
     }
 
-    fn set_nonce(&self, _nonce: cairo_vm::felt::Felt252) {
+    fn set_nonce(&mut self, _nonce: cairo_vm::felt::Felt252) {
         todo!()
     }
 
-    fn set_sequencer_address(&self, _address: cairo_vm::felt::Felt252) {
+    fn set_sequencer_address(&mut self, _address: cairo_vm::felt::Felt252) {
         todo!()
     }
 
-    fn set_signature(&self, _signature: &[cairo_vm::felt::Felt252]) {
+    fn set_signature(&mut self, _signature: &[cairo_vm::felt::Felt252]) {
         todo!()
     }
 
-    fn set_transaction_hash(&self, _transaction_hash: cairo_vm::felt::Felt252) {
+    fn set_transaction_hash(&mut self, _transaction_hash: cairo_vm::felt::Felt252) {
         todo!()
     }
 
-    fn set_version(&self, _version: cairo_vm::felt::Felt252) {
+    fn set_version(&mut self, _version: cairo_vm::felt::Felt252) {
         todo!()
     }
 }


### PR DESCRIPTION
Updates cairo-native to latest revision, which changes gas from u64 to u128 and lets us use &mut self on the starknet interface.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
