### PR TITLE
Fix `get_onchain_data_segment_length`

### DIFF
--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 pub(crate) const L2_TO_L1_MSG_HEADER_SIZE: usize = 3;
 pub(crate) const L1_TO_L2_MSG_HEADER_SIZE: usize = 5;
-pub(crate) const DEPLOYMENT_INFO_SIZE: usize = 2;
+pub(crate) const DEPLOYMENT_INFO_SIZE: usize = 1;
 pub(crate) const CONSUMED_MSG_TO_L2_N_TOPICS: usize = 3;
 pub(crate) const LOG_MSG_TO_L1_N_TOPICS: usize = 2;
 pub(crate) const N_DEFAULT_TOPICS: usize = 1; // Events have one default topic.

--- a/src/execution/gas_usage.rs
+++ b/src/execution/gas_usage.rs
@@ -110,7 +110,9 @@ pub const fn get_onchain_data_segment_length(
     n_storage_changes: usize,
     n_deployments: usize,
 ) -> usize {
-    n_modified_contracts * 2 + n_storage_changes * 2 + n_deployments * DEPLOYMENT_INFO_SIZE
+    n_modified_contracts * 2
+    + n_deployments * DEPLOYMENT_INFO_SIZE
+    + n_storage_changes * 2
 }
 
 /// Calculates the cost of ConsumedMessageToL2 event emissions caused by an L1 handler with the given

--- a/src/execution/gas_usage.rs
+++ b/src/execution/gas_usage.rs
@@ -110,9 +110,7 @@ pub const fn get_onchain_data_segment_length(
     n_storage_changes: usize,
     n_deployments: usize,
 ) -> usize {
-    n_modified_contracts * 2
-    + n_deployments * DEPLOYMENT_INFO_SIZE
-    + n_storage_changes * 2
+    n_modified_contracts * 2 + n_deployments * DEPLOYMENT_INFO_SIZE + n_storage_changes * 2
 }
 
 /// Calculates the cost of ConsumedMessageToL2 event emissions caused by an L1 handler with the given

--- a/src/execution/gas_usage.rs
+++ b/src/execution/gas_usage.rs
@@ -264,7 +264,7 @@ mod test {
 
         assert_eq!(
             calculate_tx_gas_usage(vec![message1, message2], 2, 2, Some(2), 1),
-            77051
+            76439
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1024,7 +1024,7 @@ mod test {
 
         assert_eq!(
             estimate_fee(&[deploy, invoke_tx], state, block_context,).unwrap(),
-            [(0, 2448), (0, 2448)]
+            [(0, 1836), (0, 2448)]
         );
     }
 

--- a/tests/deploy_account.rs
+++ b/tests/deploy_account.rs
@@ -104,7 +104,7 @@ fn internal_deploy_account() {
                 ("n_steps", 3612),
                 ("pedersen_builtin", 23),
                 ("range_check_builtin", 83),
-                ("l1_gas_usage", 3672)
+                ("l1_gas_usage", 3060)
             ]
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
@@ -270,7 +270,7 @@ fn internal_deploy_account_cairo1() {
                 ("n_steps", n_steps),
                 ("pedersen_builtin", 23),
                 ("range_check_builtin", 87),
-                ("l1_gas_usage", 4896)
+                ("l1_gas_usage", 4284)
             ]
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -1490,7 +1490,7 @@ fn test_invoke_with_declarev2_tx() {
 fn test_deploy_account() {
     let (block_context, mut state) = create_account_tx_test_state().unwrap();
 
-    let expected_fee = 3709;
+    let expected_fee = 3097;
 
     let deploy_account_tx = DeployAccount::new(
         felt_to_hash(&TEST_ACCOUNT_CONTRACT_CLASS_HASH),
@@ -1561,7 +1561,7 @@ fn test_deploy_account() {
         ("n_steps".to_string(), 3625),
         ("range_check_builtin".to_string(), 83),
         ("pedersen_builtin".to_string(), 23),
-        ("l1_gas_usage".to_string(), 3672),
+        ("l1_gas_usage".to_string(), 3060),
     ]);
 
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, &block_context).unwrap();
@@ -1706,12 +1706,12 @@ fn test_deploy_account_revert() {
         ("n_steps".to_string(), 3625),
         ("range_check_builtin".to_string(), 83),
         ("pedersen_builtin".to_string(), 23),
-        ("l1_gas_usage".to_string(), 3672),
+        ("l1_gas_usage".to_string(), 3060),
     ]);
 
     let fee = calculate_tx_fee(&resources, *GAS_PRICE, &block_context).unwrap();
 
-    assert_eq!(fee, 3709);
+    assert_eq!(fee, 3097);
 
     let mut expected_execution_info = TransactionExecutionInfo::new(
         None,
@@ -1749,7 +1749,7 @@ fn expected_deploy_account_states() -> (
     CachedState<InMemoryStateReader>,
     CachedState<InMemoryStateReader>,
 ) {
-    let fee = Felt252::from(3709);
+    let fee = Felt252::from(3097);
     let mut state_before = CachedState::new(
         Arc::new(InMemoryStateReader::new(
             HashMap::from([


### PR DESCRIPTION
Fixes the calculation of onchain_data_segment_length used for fee calculation.
Closes #1042
Still needs further work to take into account `n_compiled_class_hash_changes`, which requires a bigger refactor, as it involves changing both the signature & behaviour of the `count_actual_storage_changes` function defined in the `State` trait

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
