### PR TITLE
Fix/Refactor `State::count actual storage changes`

### DIFF
--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 pub(crate) const L2_TO_L1_MSG_HEADER_SIZE: usize = 3;
 pub(crate) const L1_TO_L2_MSG_HEADER_SIZE: usize = 5;
-pub(crate) const DEPLOYMENT_INFO_SIZE: usize = 1;
+pub(crate) const CLASS_UPDATE_SIZE: usize = 1;
 pub(crate) const CONSUMED_MSG_TO_L2_N_TOPICS: usize = 3;
 pub(crate) const LOG_MSG_TO_L1_N_TOPICS: usize = 2;
 pub(crate) const N_DEFAULT_TOPICS: usize = 1; // Events have one default topic.

--- a/src/execution/gas_usage.rs
+++ b/src/execution/gas_usage.rs
@@ -93,20 +93,17 @@ pub fn get_message_segment_lenght(
 }
 
 /// Calculates the amount of `felt252` added to the output message's segment by the given operations.
-///
-/// # Parameters:
-///
-/// - `n_modified_contracts`: The number of contracts modified by the transaction.
-/// - `n_storage_changes`: The number of storage changes made by the transaction.
-/// - `n_deployments`: The number of contracts deployed by the transaction.
-///
-/// # Returns:
-///
-/// The on-chain data segment length
 pub const fn get_onchain_data_segment_length(storage_changes: &StorageChangesCount) -> usize {
+    // For each newly modified contract:
+    // contract address (1 word).
+    // + 1 word with the following info: A flag indicating whether the class hash was updated, the
+    // number of entry updates, and the new nonce.
     storage_changes.n_modified_contracts * 2
+    // For each class updated (through a deploy or a class replacement).
         + storage_changes.n_class_hash_updates * CLASS_UPDATE_SIZE
+        // For each modified storage cell: key, new value.
         + storage_changes.n_storage_updates * 2
+         // For each compiled class updated (through declare): class_hash, compiled_class_hash
         + storage_changes.n_compiled_class_hash_updates * 2
 }
 

--- a/src/execution/gas_usage.rs
+++ b/src/execution/gas_usage.rs
@@ -1,7 +1,7 @@
 use crate::definitions::constants::*;
 use crate::execution::L2toL1MessageInfo;
 use crate::services::eth_definitions::eth_gas_constants::*;
-use crate::state::state_api::StorageChangesCount;
+use crate::state::state_api::StateChangesCount;
 
 /// Estimates L1 gas usage by Starknet's update state and the verifier
 ///
@@ -20,13 +20,13 @@ use crate::state::state_api::StorageChangesCount;
 /// The estimation of L1 gas usage as a `usize` value.
 pub fn calculate_tx_gas_usage(
     l2_to_l1_messages: Vec<L2toL1MessageInfo>,
-    storage_changes: &StorageChangesCount,
+    state_changes: &StateChangesCount,
     l1_handler_payload_size: Option<usize>,
 ) -> usize {
     let residual_message_segment_length =
         get_message_segment_lenght(&l2_to_l1_messages, l1_handler_payload_size);
 
-    let residual_onchain_data_segment_length = get_onchain_data_segment_length(storage_changes);
+    let residual_onchain_data_segment_length = get_onchain_data_segment_length(state_changes);
 
     let n_l2_to_l1_messages = l2_to_l1_messages.len();
     let n_l1_to_l2_messages = match l1_handler_payload_size {
@@ -93,18 +93,18 @@ pub fn get_message_segment_lenght(
 }
 
 /// Calculates the amount of `felt252` added to the output message's segment by the given operations.
-pub const fn get_onchain_data_segment_length(storage_changes: &StorageChangesCount) -> usize {
+pub const fn get_onchain_data_segment_length(state_changes: &StateChangesCount) -> usize {
     // For each newly modified contract:
     // contract address (1 word).
     // + 1 word with the following info: A flag indicating whether the class hash was updated, the
     // number of entry updates, and the new nonce.
-    storage_changes.n_modified_contracts * 2
+    state_changes.n_modified_contracts * 2
     // For each class updated (through a deploy or a class replacement).
-        + storage_changes.n_class_hash_updates * CLASS_UPDATE_SIZE
+        + state_changes.n_class_hash_updates * CLASS_UPDATE_SIZE
         // For each modified storage cell: key, new value.
-        + storage_changes.n_storage_updates * 2
+        + state_changes.n_storage_updates * 2
          // For each compiled class updated (through declare): class_hash, compiled_class_hash
-        + storage_changes.n_compiled_class_hash_updates * 2
+        + state_changes.n_compiled_class_hash_updates * 2
 }
 
 /// Calculates the cost of ConsumedMessageToL2 event emissions caused by an L1 handler with the given
@@ -257,7 +257,7 @@ mod test {
         assert_eq!(
             calculate_tx_gas_usage(
                 vec![message1, message2],
-                &StorageChangesCount {
+                &StateChangesCount {
                     n_storage_updates: 2,
                     n_class_hash_updates: 1,
                     n_compiled_class_hash_updates: 0,

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -1,5 +1,5 @@
 use super::{
-    state_api::{State, StateReader, StorageChangesCount},
+    state_api::{State, StateChangesCount, StateReader},
     state_cache::{StateCache, StorageEntry},
 };
 use crate::{
@@ -283,10 +283,10 @@ impl<T: StateReader> State for CachedState<T> {
         Ok(())
     }
 
-    fn count_actual_storage_changes(
+    fn count_actual_state_changes(
         &mut self,
         fee_token_and_sender_address: Option<(&Address, &Address)>,
-    ) -> Result<StorageChangesCount, StateError> {
+    ) -> Result<StateChangesCount, StateError> {
         self.update_initial_values_of_write_only_accesses()?;
 
         let mut storage_updates = subtract_mappings(
@@ -327,7 +327,7 @@ impl<T: StateReader> State for CachedState<T> {
             modified_contracts.remove(fee_token_address);
         }
 
-        Ok(StorageChangesCount {
+        Ok(StateChangesCount {
             n_storage_updates: storage_updates.len(),
             n_class_hash_updates,
             n_compiled_class_hash_updates: compiled_class_hash_updates.count(),
@@ -812,7 +812,7 @@ mod tests {
 
     /// This test calculate the number of actual storage changes.
     #[test]
-    fn count_actual_storage_changes_test() {
+    fn count_actual_state_changes_test() {
         let state_reader = InMemoryStateReader::default();
 
         let mut cached_state = CachedState::new(Arc::new(state_reader), HashMap::new());
@@ -834,7 +834,7 @@ mod tests {
         let fee_token_address = Address(123.into());
         let sender_address = Address(321.into());
 
-        let expected_changes = StorageChangesCount {
+        let expected_changes = StateChangesCount {
             n_storage_updates: 3 + 1, // + 1 fee transfer balance update,
             n_class_hash_updates: 0,
             n_compiled_class_hash_updates: 0,
@@ -842,7 +842,7 @@ mod tests {
         };
 
         let changes = cached_state
-            .count_actual_storage_changes(Some((&fee_token_address, &sender_address)))
+            .count_actual_state_changes(Some((&fee_token_address, &sender_address)))
             .unwrap();
 
         assert_eq!(changes, expected_changes);

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -26,6 +26,13 @@ pub trait StateReader {
     ) -> Result<CompiledClassHash, StateError>;
 }
 
+pub struct StorageChangesCount {
+    pub n_storage_updates: usize,
+    pub n_class_hash_updates: usize,
+    pub n_compiled_class_hash_updates: usize,
+    pub n_modified_contracts: usize
+}
+
 pub trait State {
     fn set_contract_class(
         &mut self,

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -27,7 +27,7 @@ pub trait StateReader {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct StorageChangesCount {
+pub struct StateChangesCount {
     pub n_storage_updates: usize,
     pub n_class_hash_updates: usize,
     pub n_compiled_class_hash_updates: usize,
@@ -71,11 +71,11 @@ pub trait State {
 
     fn apply_state_update(&mut self, sate_updates: &StateDiff) -> Result<(), StateError>;
 
-    /// Counts the amount of modified contracts and the updates to the storage
-    fn count_actual_storage_changes(
+    /// Counts the amount of state changes
+    fn count_actual_state_changes(
         &mut self,
         fee_token_and_sender_address: Option<(&Address, &Address)>,
-    ) -> Result<StorageChangesCount, StateError>;
+    ) -> Result<StateChangesCount, StateError>;
 
     /// Returns the class hash of the contract class at the given address.
     /// Returns zero by default if the value is not present

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -26,11 +26,12 @@ pub trait StateReader {
     ) -> Result<CompiledClassHash, StateError>;
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct StorageChangesCount {
     pub n_storage_updates: usize,
     pub n_class_hash_updates: usize,
     pub n_compiled_class_hash_updates: usize,
-    pub n_modified_contracts: usize
+    pub n_modified_contracts: usize,
 }
 
 pub trait State {
@@ -74,7 +75,7 @@ pub trait State {
     fn count_actual_storage_changes(
         &mut self,
         fee_token_and_sender_address: Option<(&Address, &Address)>,
-    ) -> Result<(usize, usize), StateError>;
+    ) -> Result<StorageChangesCount, StateError>;
 
     /// Returns the class hash of the contract class at the given address.
     /// Returns zero by default if the value is not present

--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -166,7 +166,7 @@ impl Declare {
         } else {
             self.run_validate_entrypoint(state, &mut resources_manager, block_context)?
         };
-        let changes = state.count_actual_storage_changes(Some((
+        let changes = state.count_actual_state_changes(Some((
             &block_context.starknet_os_config.fee_token_address,
             &self.sender_address,
         )))?;

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -328,7 +328,7 @@ impl DeclareV2 {
             (info, gas)
         };
 
-        let storage_changes = state.count_actual_storage_changes(Some((
+        let storage_changes = state.count_actual_state_changes(Some((
             &block_context.starknet_os_config.fee_token_address,
             &self.sender_address,
         )))?;

--- a/src/transaction/deploy.rs
+++ b/src/transaction/deploy.rs
@@ -187,7 +187,7 @@ impl Deploy {
 
         let resources_manager = ExecutionResourcesManager::default();
 
-        let changes = state.count_actual_storage_changes(None)?;
+        let changes = state.count_actual_state_changes(None)?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
             &[Some(call_info.clone())],
@@ -250,7 +250,7 @@ impl Deploy {
             block_context.validate_max_n_steps,
         )?;
 
-        let changes = state.count_actual_storage_changes(None)?;
+        let changes = state.count_actual_state_changes(None)?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
             &[call_info.clone()],

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -250,7 +250,7 @@ impl DeployAccount {
             resources_manager,
             &[Some(constructor_call_info.clone()), validate_info.clone()],
             TransactionType::DeployAccount,
-            state.count_actual_storage_changes(Some((
+            state.count_actual_state_changes(Some((
                 &block_context.starknet_os_config.fee_token_address,
                 &self.contract_address,
             )))?,

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -265,7 +265,7 @@ impl InvokeFunction {
                 remaining_gas,
             )?
         };
-        let changes = state.count_actual_storage_changes(Some((
+        let changes = state.count_actual_state_changes(Some((
             &block_context.starknet_os_config.fee_token_address,
             &self.contract_address,
         )))?;

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -137,7 +137,7 @@ impl L1Handler {
             )?
         };
 
-        let changes = state.count_actual_storage_changes(None)?;
+        let changes = state.count_actual_state_changes(None)?;
         let actual_resources = calculate_tx_resources(
             resources_manager,
             &[call_info.clone()],

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::core::errors::hash_errors::HashError;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
-use crate::state::state_api::State;
+use crate::state::state_api::{State, StorageChangesCount};
 use crate::{
     definitions::transaction_type::TransactionType,
     execution::{
@@ -169,14 +169,11 @@ pub fn calculate_tx_resources(
     resources_manager: ExecutionResourcesManager,
     call_info: &[Option<CallInfo>],
     tx_type: TransactionType,
-    storage_changes: (usize, usize),
+    storage_changes: StorageChangesCount,
     l1_handler_payload_size: Option<usize>,
     n_reverted_steps: usize,
 ) -> Result<HashMap<String, usize>, TransactionError> {
-    let (n_modified_contracts, n_storage_changes) = storage_changes;
-
     let non_optional_calls: Vec<CallInfo> = call_info.iter().flatten().cloned().collect();
-    let n_deployments = non_optional_calls.iter().map(get_call_n_deployments).sum();
 
     let mut l2_to_l1_messages = Vec::new();
 
@@ -184,13 +181,8 @@ pub fn calculate_tx_resources(
         l2_to_l1_messages.extend(call_info.get_sorted_l2_to_l1_messages()?)
     }
 
-    let l1_gas_usage = calculate_tx_gas_usage(
-        l2_to_l1_messages,
-        n_modified_contracts,
-        n_storage_changes,
-        l1_handler_payload_size,
-        n_deployments,
-    );
+    let l1_gas_usage =
+        calculate_tx_gas_usage(l2_to_l1_messages, &storage_changes, l1_handler_payload_size);
 
     let cairo_usage = resources_manager.cairo_usage.clone();
     let tx_syscall_counter = resources_manager.syscall_counter;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::core::errors::hash_errors::HashError;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
-use crate::state::state_api::{State, StorageChangesCount};
+use crate::state::state_api::{State, StateChangesCount};
 use crate::{
     definitions::transaction_type::TransactionType,
     execution::{
@@ -169,7 +169,7 @@ pub fn calculate_tx_resources(
     resources_manager: ExecutionResourcesManager,
     call_info: &[Option<CallInfo>],
     tx_type: TransactionType,
-    storage_changes: StorageChangesCount,
+    state_changes: StateChangesCount,
     l1_handler_payload_size: Option<usize>,
     n_reverted_steps: usize,
 ) -> Result<HashMap<String, usize>, TransactionError> {
@@ -182,7 +182,7 @@ pub fn calculate_tx_resources(
     }
 
     let l1_gas_usage =
-        calculate_tx_gas_usage(l2_to_l1_messages, &storage_changes, l1_handler_payload_size);
+        calculate_tx_gas_usage(l2_to_l1_messages, &state_changes, l1_handler_payload_size);
 
     let cairo_usage = resources_manager.cairo_usage.clone();
     let tx_syscall_counter = resources_manager.syscall_counter;

--- a/tests/internals.rs
+++ b/tests/internals.rs
@@ -1260,7 +1260,7 @@ fn expected_fib_transaction_execution_info(
     }
     let resources = HashMap::from([
         ("n_steps".to_string(), n_steps),
-        ("l1_gas_usage".to_string(), 4896),
+        ("l1_gas_usage".to_string(), 5508),
         ("pedersen_builtin".to_string(), 16),
         ("range_check_builtin".to_string(), 104),
     ]);
@@ -1477,7 +1477,7 @@ fn test_invoke_with_declarev2_tx() {
     ];
     let invoke_tx = invoke_tx(calldata, u128::MAX);
 
-    let expected_gas_consumed = 4908;
+    let expected_gas_consumed = 5551;
     let result = invoke_tx
         .execute(state, block_context, expected_gas_consumed)
         .unwrap();


### PR DESCRIPTION
Fully implements the fix described in #1085 
Main changes:
- Renames `State::count_actual_storage_changes` to `State::count_actual_state_changes`
- Changes `State::count_actual_state_changes` output to`StateChangesCount` (adding `class_hash` & `compiled_class_hash` changes count)
- Adds the amount of `compiled_class_hash` changes to the `onchain_data_segment_length` calculation
- Uses amount of `class_hash_updates` instead of `n_deployments` in `onchain_data_segment_length` calculation
## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
