### PR TITLE
Fix bug in `From<StarknetRsContractClass> for CompiledClass` implementation

### DIFF
--- a/rpc_state_reader/tests/blockifier_tests.rs
+++ b/rpc_state_reader/tests/blockifier_tests.rs
@@ -309,6 +309,11 @@ fn blockifier_test_recent_tx() {
     885298, // real block 885299
     RpcChain::TestNet
 )]
+#[test_case(
+    "0x5a5de1f42f6005f3511ea6099daed9bcbcf9de334ee714e8563977e25f71601",
+    281513, // real block 281514
+    RpcChain::MainNet
+)]
 fn blockifier_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number));
 

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -287,6 +287,11 @@ fn test_get_gas_price() {
     885298, // real block 885299
     RpcChain::TestNet
 )]
+#[test_case(
+    "0x5a5de1f42f6005f3511ea6099daed9bcbcf9de334ee714e8563977e25f71601",
+    281513, // real block 281514
+    RpcChain::MainNet
+)]
 fn starknet_in_rust_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number));
 

--- a/src/services/api/contract_classes/compiled_class.rs
+++ b/src/services/api/contract_classes/compiled_class.rs
@@ -130,7 +130,7 @@ impl From<StarknetRsContractClass> for CompiledClass {
                         )
                     })
                     .collect::<Vec<ContractEntryPoint>>();
-                entry_points_by_type.insert(EntryPointType::Constructor, l1_handler_entries);
+                entry_points_by_type.insert(EntryPointType::L1Handler, l1_handler_entries);
 
                 let v = serde_json::to_value(&_deprecated_contract_class.abi).unwrap();
                 let abi: Option<AbiType> = serde_json::from_value(v).unwrap();


### PR DESCRIPTION
L1 handler entrypoints were being added as Constructor entrypoints, leading to the wrong entrypoint being executed in some cases when deploying accounts.
Depends on #1089 in order to run the tests
## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
