### PR TITLE
update cairo native to use gas consumed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=f82ed76d93d61533d38abc862430f8dab73545b4#f82ed76d93d61533d38abc862430f8dab73545b4"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=03cd09ba3e51852da2234fb32a74056787abba8e#03cd09ba3e51852da2234fb32a74056787abba8e"
 dependencies = [
  "bumpalo",
  "cairo-felt",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=f82ed76d93d61533d38abc862430f8dab73545b4#f82ed76d93d61533d38abc862430f8dab73545b4"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=03cd09ba3e51852da2234fb32a74056787abba8e#03cd09ba3e51852da2234fb32a74056787abba8e"
 dependencies = [
  "cairo-felt",
  "cairo-lang-runner",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=4cf98c2e#4cf98c2e0e35b23f584053c4c25938d52f6dedac"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=f82ed76d93d61533d38abc862430f8dab73545b4#f82ed76d93d61533d38abc862430f8dab73545b4"
 dependencies = [
  "bumpalo",
  "cairo-felt",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=4cf98c2e#4cf98c2e0e35b23f584053c4c25938d52f6dedac"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=f82ed76d93d61533d38abc862430f8dab73545b4#f82ed76d93d61533d38abc862430f8dab73545b4"
 dependencies = [
  "cairo-felt",
  "cairo-lang-runner",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=120f972724ebe5dafce4f7a7b766551187067148#120f972724ebe5dafce4f7a7b766551187067148"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=4cf98c2e#4cf98c2e0e35b23f584053c4c25938d52f6dedac"
 dependencies = [
  "bumpalo",
  "cairo-felt",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=120f972724ebe5dafce4f7a7b766551187067148#120f972724ebe5dafce4f7a7b766551187067148"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=4cf98c2e#4cf98c2e0e35b23f584053c4c25938d52f6dedac"
 dependencies = [
  "cairo-felt",
  "cairo-lang-runner",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac#db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=120f972724ebe5dafce4f7a7b766551187067148#120f972724ebe5dafce4f7a7b766551187067148"
 dependencies = [
  "bumpalo",
  "cairo-felt",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac#db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=120f972724ebe5dafce4f7a7b766551187067148#120f972724ebe5dafce4f7a7b766551187067148"
 dependencies = [
  "cairo-felt",
  "cairo-lang-runner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cairo-lang-runner = { workspace = true }
 cairo-lang-sierra = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "120f972724ebe5dafce4f7a7b766551187067148", optional = true }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "4cf98c2e", optional = true }
 cairo-vm = { workspace = true, features = ["cairo-1-hints"] }
 flate2 = "1.0.25"
 getset = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cairo-lang-runner = { workspace = true }
 cairo-lang-sierra = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "db1c3f6b044a4a6a3de3ab33e472c2e2263d81ac", optional = true }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "120f972724ebe5dafce4f7a7b766551187067148", optional = true }
 cairo-vm = { workspace = true, features = ["cairo-1-hints"] }
 flate2 = "1.0.25"
 getset = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cairo-lang-runner = { workspace = true }
 cairo-lang-sierra = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "4cf98c2e", optional = true }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "f82ed76d93d61533d38abc862430f8dab73545b4", optional = true }
 cairo-vm = { workspace = true, features = ["cairo-1-hints"] }
 flate2 = "1.0.25"
 getset = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cairo-lang-runner = { workspace = true }
 cairo-lang-sierra = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "f82ed76d93d61533d38abc862430f8dab73545b4", optional = true }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "03cd09ba3e51852da2234fb32a74056787abba8e", optional = true }
 cairo-vm = { workspace = true, features = ["cairo-1-hints"] }
 flate2 = "1.0.25"
 getset = "0.1.2"

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -763,8 +763,6 @@ impl ExecutionEntryPoint {
             .execute(entry_point_id, json!(params), returns, required_init_gas)
             .map_err(|e| TransactionError::CustomError(format!("cairo-native error: {:?}", e)))?;
 
-        let values: Value = serde_json::from_reader(writer.clone().as_slice()).unwrap();
-        dbg!(values);
         let value = NativeExecutionResult::deserialize_from_ret_types(
             &mut serde_json::Deserializer::from_slice(&writer),
             &ret_types,
@@ -790,7 +788,7 @@ impl ExecutionEntryPoint {
             failure_flag: value.failure_flag,
             l2_to_l1_messages: syscall_handler.l2_to_l1_messages,
             internal_calls: syscall_handler.internal_calls,
-            gas_consumed: value.gas_consumed,
+            gas_consumed: self.initial_gas - value.remaining_gas,
         })
     }
 }

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -640,6 +640,10 @@ impl ExecutionEntryPoint {
         tx_execution_context: &TransactionExecutionContext,
         block_context: &BlockContext,
     ) -> Result<CallInfo, TransactionError> {
+        use cairo_lang_sierra::{
+            extensions::core::{CoreLibfunc, CoreType, CoreTypeConcrete},
+            program_registry::ProgramRegistry,
+        };
         use serde_json::json;
 
         let entry_point = match self.entry_point_type {
@@ -664,6 +668,8 @@ impl ExecutionEntryPoint {
         };
 
         let sierra_program = contract_class.extract_sierra_program().unwrap();
+        let program_registry: ProgramRegistry<CoreType, CoreLibfunc> =
+            ProgramRegistry::new(&sierra_program).unwrap();
 
         let native_context = NativeContext::new();
         let mut native_program = native_context.compile(&sierra_program).unwrap();
@@ -694,14 +700,20 @@ impl ExecutionEntryPoint {
             .as_ptr()
             .as_ptr() as *const () as usize;
 
-        let fn_id = &sierra_program
+        let entry_point_fn = &sierra_program
             .funcs
             .iter()
             .find(|x| x.id.id == (entry_point.function_idx as u64))
-            .unwrap()
-            .id;
+            .unwrap();
+        let ret_types: Vec<&CoreTypeConcrete> = entry_point_fn
+            .signature
+            .ret_types
+            .iter()
+            .map(|x| program_registry.get_type(x).unwrap())
+            .collect();
+        let entry_point_id = &entry_point_fn.id;
 
-        let required_init_gas = native_program.get_required_init_gas(fn_id);
+        let required_init_gas = native_program.get_required_init_gas(entry_point_id);
 
         let calldata: Vec<_> = self
             .calldata
@@ -719,13 +731,13 @@ impl ExecutionEntryPoint {
         */
 
         let wrapped_calldata = vec![calldata];
-        let params: Vec<Value> = sierra_program.funcs[fn_id.id as usize]
+        let params: Vec<Value> = sierra_program.funcs[entry_point_id.id as usize]
             .params
             .iter()
             .map(|param| {
                 match param.ty.debug_name.as_ref().unwrap().as_str() {
                     "GasBuiltin" => {
-                        json!(self.initial_gas as u64)
+                        json!(self.initial_gas)
                     }
                     "Pedersen" | "SegmentArena" | "RangeCheck" | "Bitwise" | "Poseidon" => {
                         json!(null)
@@ -748,11 +760,16 @@ impl ExecutionEntryPoint {
         let native_executor = NativeExecutor::new(native_program);
 
         native_executor
-            .execute(fn_id, json!(params), returns, required_init_gas)
+            .execute(entry_point_id, json!(params), returns, required_init_gas)
             .map_err(|e| TransactionError::CustomError(format!("cairo-native error: {:?}", e)))?;
 
-        let result: String = String::from_utf8(writer).unwrap();
-        let value = serde_json::from_str::<NativeExecutionResult>(&result).unwrap();
+        let values: Value = serde_json::from_reader(writer.clone().as_slice()).unwrap();
+        dbg!(values);
+        let value = NativeExecutionResult::deserialize_from_ret_types(
+            &mut serde_json::Deserializer::from_slice(&writer),
+            &ret_types,
+        )
+        .expect("failed to serialize starknet execution result");
 
         Ok(CallInfo {
             caller_address: self.caller_address.clone(),
@@ -773,8 +790,7 @@ impl ExecutionEntryPoint {
             failure_flag: value.failure_flag,
             l2_to_l1_messages: syscall_handler.l2_to_l1_messages,
             internal_calls: syscall_handler.internal_calls,
-            // TODO: check it's correct
-            gas_consumed: self.initial_gas - u128::from(value.gas_builtin.unwrap_or(0)),
+            gas_consumed: value.gas_consumed,
         })
     }
 }

--- a/src/syscalls/business_logic_syscall_handler.rs
+++ b/src/syscalls/business_logic_syscall_handler.rs
@@ -57,9 +57,10 @@ use lazy_static::lazy_static;
 use crate::services::api::contract_classes::deprecated_contract_class::EntryPointType;
 use num_traits::{One, ToPrimitive, Zero};
 
-const STEP: u128 = 100;
-const SYSCALL_BASE: u128 = 100 * STEP;
-const KECCAK_ROUND_COST: u128 = 180000;
+pub(crate) const STEP: u128 = 100;
+pub(crate) const SYSCALL_BASE: u128 = 100 * STEP;
+pub(crate) const KECCAK_ROUND_COST: u128 = 180000;
+
 lazy_static! {
     /// Felt->syscall map that was extracted from new_syscalls.json (Cairo 1.0 syscalls)
     static ref SELECTOR_TO_SYSCALL: HashMap<Felt252, &'static str> = {
@@ -91,7 +92,7 @@ lazy_static! {
     // Taken from starkware/starknet/constants.py in cairo-lang
     // See further documentation on cairo_programs/constants.cairo
     /// Maps syscall name to gas costs
-    static ref SYSCALL_GAS_COST: HashMap<&'static str, u128> = {
+    pub(crate) static ref SYSCALL_GAS_COST: HashMap<&'static str, u128> = {
         let mut map = HashMap::new();
 
         map.insert("initial", 100_000_000 * STEP);

--- a/src/syscalls/native_syscall_handler.rs
+++ b/src/syscalls/native_syscall_handler.rs
@@ -539,10 +539,8 @@ where
         let ExecutionResult { call_info, .. } = call
             .execute(
                 self.starknet_storage_state.state,
-                // TODO: This fields dont make much sense in the Cairo Native context,
-                // they are only dummy values for the `execute` method.
-                &BlockContext::default(),
-                &mut ExecutionResourcesManager::default(),
+                &self.block_context,
+                &mut self.resources_manager,
                 &mut self.tx_execution_context,
                 false,
                 u64::MAX,

--- a/tests/cairo_native.rs
+++ b/tests/cairo_native.rs
@@ -143,7 +143,6 @@ fn integration_test_erc20() {
     assert_eq!(native_result.retdata, [].to_vec());
     assert_eq!(native_result.execution_resources, None);
     assert_eq!(native_result.class_hash, Some(NATIVE_CLASS_HASH));
-    // assert_eq!(native_result.gas_consumed, 196270);
 
     assert_eq!(vm_result.events, native_result.events);
     assert_eq!(
@@ -153,7 +152,7 @@ fn integration_test_erc20() {
     assert_eq!(vm_result.l2_to_l1_messages, native_result.l2_to_l1_messages);
     // TODO: Make these asserts work
     // assert_eq!(vm_result.execution_resources, native_result.execution_resources);
-    // assert_eq!(vm_result.gas_consumed, native_result.gas_consumed);
+    assert_eq!(vm_result.gas_consumed, native_result.gas_consumed);
 
     #[allow(clippy::too_many_arguments)]
     fn compare_results(
@@ -164,7 +163,7 @@ fn integration_test_erc20() {
         casm_entrypoints: &CasmContractEntryPoints,
         calldata: &[Felt252],
         caller_address: &Address,
-        _debug_name: &str,
+        debug_name: &str,
     ) {
         let native_selector = &native_entrypoints
             .external
@@ -207,10 +206,10 @@ fn integration_test_erc20() {
         assert_eq!(vm_result.l2_to_l1_messages, native_result.l2_to_l1_messages);
 
         // TODO: Make these asserts work
-        // assert_eq!(vm_result.gas_consumed, native_result.gas_consumed, "gas consumed mismatch for {debug_name}",);
-
-        // This assert is probably impossible to make work because native doesn't track resources.
-        // assert_eq!(vm_result.execution_resources, native_result.execution_resources);
+        assert_eq!(
+            vm_result.gas_consumed, native_result.gas_consumed,
+            "gas consumed mismatch for {debug_name}",
+        );
     }
 
     // --------------- GET TOTAL SUPPLY -----------------
@@ -579,6 +578,7 @@ fn call_echo_contract_test() {
     );
 
     assert_eq!(result.retdata, [Felt252::new(99999999)]);
+    assert_eq!(result.gas_consumed, 89110);
 }
 
 #[test]
@@ -688,7 +688,7 @@ fn call_events_contract_test() {
         storage_read_values: Vec::new(),
         accessed_storage_keys: HashSet::new(),
         internal_calls: Vec::new(),
-        gas_consumed: 19640,
+        gas_consumed: 9640,
         failure_flag: false,
     };
 

--- a/tests/cairo_native.rs
+++ b/tests/cairo_native.rs
@@ -150,8 +150,6 @@ fn integration_test_erc20() {
         native_result.accessed_storage_keys
     );
     assert_eq!(vm_result.l2_to_l1_messages, native_result.l2_to_l1_messages);
-    // TODO: Make these asserts work
-    // assert_eq!(vm_result.execution_resources, native_result.execution_resources);
     assert_eq!(vm_result.gas_consumed, native_result.gas_consumed);
 
     #[allow(clippy::too_many_arguments)]
@@ -205,7 +203,6 @@ fn integration_test_erc20() {
         );
         assert_eq!(vm_result.l2_to_l1_messages, native_result.l2_to_l1_messages);
 
-        // TODO: Make these asserts work
         assert_eq!(
             vm_result.gas_consumed, native_result.gas_consumed,
             "gas consumed mismatch for {debug_name}",

--- a/tests/cairo_native.rs
+++ b/tests/cairo_native.rs
@@ -143,7 +143,7 @@ fn integration_test_erc20() {
     assert_eq!(native_result.retdata, [].to_vec());
     assert_eq!(native_result.execution_resources, None);
     assert_eq!(native_result.class_hash, Some(NATIVE_CLASS_HASH));
-    assert_eq!(native_result.gas_consumed, 0);
+    // assert_eq!(native_result.gas_consumed, 196270);
 
     assert_eq!(vm_result.events, native_result.events);
     assert_eq!(
@@ -155,6 +155,7 @@ fn integration_test_erc20() {
     // assert_eq!(vm_result.execution_resources, native_result.execution_resources);
     // assert_eq!(vm_result.gas_consumed, native_result.gas_consumed);
 
+    #[allow(clippy::too_many_arguments)]
     fn compare_results(
         state_vm: &mut CachedState<InMemoryStateReader>,
         state_native: &mut CachedState<InMemoryStateReader>,
@@ -163,6 +164,7 @@ fn integration_test_erc20() {
         casm_entrypoints: &CasmContractEntryPoints,
         calldata: &[Felt252],
         caller_address: &Address,
+        _debug_name: &str,
     ) {
         let native_selector = &native_entrypoints
             .external
@@ -205,7 +207,7 @@ fn integration_test_erc20() {
         assert_eq!(vm_result.l2_to_l1_messages, native_result.l2_to_l1_messages);
 
         // TODO: Make these asserts work
-        // assert_eq!(vm_result.gas_consumed, native_result.gas_consumed);
+        // assert_eq!(vm_result.gas_consumed, native_result.gas_consumed, "gas consumed mismatch for {debug_name}",);
 
         // This assert is probably impossible to make work because native doesn't track resources.
         // assert_eq!(vm_result.execution_resources, native_result.execution_resources);
@@ -221,6 +223,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[],
         &caller_address,
+        "get total supply 1",
     );
 
     // ---------------- GET DECIMALS ----------------------
@@ -233,6 +236,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[],
         &caller_address,
+        "get decimals 1",
     );
 
     // ---------------- GET NAME ----------------------
@@ -245,6 +249,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[],
         &caller_address,
+        "get name",
     );
 
     // // ---------------- GET SYMBOL ----------------------
@@ -257,6 +262,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[],
         &caller_address,
+        "get symbol",
     );
 
     // ---------------- GET BALANCE OF CALLER ----------------------
@@ -269,6 +275,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[caller_address.0.clone()],
         &caller_address,
+        "get balance of caller",
     );
 
     // // ---------------- ALLOWANCE OF ADDRESS 1 ----------------------
@@ -281,6 +288,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[caller_address.0.clone(), 1.into()],
         &caller_address,
+        "get allowance of address 1",
     );
 
     // // ---------------- INCREASE ALLOWANCE OF ADDRESS 1 by 10_000 ----------------------
@@ -293,6 +301,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[1.into(), 10_000.into()],
         &caller_address,
+        "increase allowance of address 1 by 10000",
     );
 
     // ---------------- ALLOWANCE OF ADDRESS 1 ----------------------
@@ -306,6 +315,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[caller_address.0.clone(), 1.into()],
         &caller_address,
+        "allowance of address 1 part 2",
     );
 
     // ---------------- APPROVE ADDRESS 1 TO MAKE TRANSFERS ON BEHALF OF THE CALLER ----------------------
@@ -318,6 +328,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[1.into(), 5000.into()],
         &caller_address,
+        "approve address 1 to make transfers",
     );
 
     // ---------------- TRANSFER 3 TOKENS FROM CALLER TO ADDRESS 2 ---------
@@ -330,6 +341,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[2.into(), 3.into()],
         &caller_address,
+        "transfer 3 tokens",
     );
 
     // // ---------------- GET BALANCE OF CALLER ----------------------
@@ -342,6 +354,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[caller_address.0.clone()],
         &caller_address,
+        "GET BALANCE OF CALLER",
     );
 
     // // ---------------- GET BALANCE OF ADDRESS 2 ----------------------
@@ -354,6 +367,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[2.into()],
         &caller_address,
+        "GET BALANCE OF ADDRESS 2",
     );
 
     // // ---------------- TRANSFER 1 TOKEN FROM CALLER TO ADDRESS 2, CALLED FROM ADDRESS 1 ----------------------
@@ -366,6 +380,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[1.into(), 2.into(), 1.into()],
         &caller_address,
+        "TRANSFER 1 TOKEN FROM CALLER TO ADDRESS 2, CALLED FROM ADDRESS 1",
     );
 
     // // ---------------- GET BALANCE OF ADDRESS 2 ----------------------
@@ -378,6 +393,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[2.into()],
         &caller_address,
+        "GET BALANCE OF ADDRESS 2 part 2",
     );
 
     // // ---------------- GET BALANCE OF CALLER ----------------------
@@ -390,6 +406,7 @@ fn integration_test_erc20() {
         &casm_entrypoints,
         &[caller_address.0.clone()],
         &caller_address,
+        "GET BALANCE OF CALLER last",
     );
 }
 
@@ -671,7 +688,7 @@ fn call_events_contract_test() {
         storage_read_values: Vec::new(),
         accessed_storage_keys: HashSet::new(),
         internal_calls: Vec::new(),
-        gas_consumed: 0,
+        gas_consumed: 19640,
         failure_flag: false,
     };
 
@@ -706,7 +723,7 @@ fn execute(
         entrypoint_type,
         Some(CallType::Delegate),
         Some(*class_hash),
-        u64::MAX.into(), // gas is u64 in cairo-native and sierra
+        u64::MAX.into(),
     );
 
     // Execute the entrypoint

--- a/tests/cairo_native.rs
+++ b/tests/cairo_native.rs
@@ -143,7 +143,7 @@ fn integration_test_erc20() {
     assert_eq!(native_result.retdata, [].to_vec());
     assert_eq!(native_result.execution_resources, None);
     assert_eq!(native_result.class_hash, Some(NATIVE_CLASS_HASH));
-    assert_eq!(native_result.gas_consumed, 18446744073709551615); // (u64::MAX)
+    assert_eq!(native_result.gas_consumed, 0);
 
     assert_eq!(vm_result.events, native_result.events);
     assert_eq!(
@@ -671,7 +671,7 @@ fn call_events_contract_test() {
         storage_read_values: Vec::new(),
         accessed_storage_keys: HashSet::new(),
         internal_calls: Vec::new(),
-        gas_consumed: 340282366920938463463374607431768211455, // TODO: fix gas consumed
+        gas_consumed: 0,
         failure_flag: false,
     };
 


### PR DESCRIPTION
The gas is compared againt the vm and matches correctly.

The only obscure thing i found is the need to deduct SYSCALL_BASE (or 10_000) from the remaining gas just once.

fixes #1063

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
