### PR TITLE
Save `SierraProgram` + `ContractEntryPoints` instead of `SierraContractClass` in `CompiledProgram`

### DIFF
--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -671,10 +671,10 @@ impl ExecutionEntryPoint {
         };
 
         let program_registry: ProgramRegistry<CoreType, CoreLibfunc> =
-            ProgramRegistry::new(&sierra_program).unwrap();
+            ProgramRegistry::new(sierra_program).unwrap();
 
         let native_context = NativeContext::new();
-        let mut native_program = native_context.compile(&sierra_program).unwrap();
+        let mut native_program = native_context.compile(sierra_program).unwrap();
         let contract_storage_state =
             ContractStorageState::new(state, self.contract_address.clone());
 

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -26,7 +26,9 @@ use crate::{
         validate_contract_deployed, Address,
     },
 };
+use cairo_lang_sierra::program::Program as SierraProgram;
 use cairo_lang_starknet::casm_contract_class::{CasmContractClass, CasmContractEntryPoint};
+use cairo_lang_starknet::contract_class::ContractEntryPoints;
 use cairo_vm::{
     felt::Felt252,
     types::{
@@ -164,12 +166,12 @@ impl ExecutionEntryPoint {
                     }
                 }
             }
-            CompiledClass::Sierra(sierra_contract_class) => {
+            CompiledClass::Sierra(sierra_program_and_entrypoints) => {
                 let mut transactional_state = state.create_transactional();
 
                 match self.native_execute(
                     &mut transactional_state,
-                    sierra_contract_class,
+                    sierra_program_and_entrypoints,
                     tx_execution_context,
                     block_context,
                 ) {
@@ -622,7 +624,7 @@ impl ExecutionEntryPoint {
     fn native_execute<S: StateReader>(
         &self,
         _state: &mut CachedState<S>,
-        _contract_class: Arc<cairo_lang_starknet::contract_class::ContractClass>,
+        _sierra_program_and_entrypoints: Arc<(SierraProgram, ContractEntryPoints)>,
         _tx_execution_context: &mut TransactionExecutionContext,
         _block_context: &BlockContext,
     ) -> Result<CallInfo, TransactionError> {
@@ -636,7 +638,7 @@ impl ExecutionEntryPoint {
     fn native_execute<S: StateReader>(
         &self,
         state: &mut CachedState<S>,
-        contract_class: Arc<cairo_lang_starknet::contract_class::ContractClass>,
+        sierra_program_and_entrypoints: Arc<(SierraProgram, ContractEntryPoints)>,
         tx_execution_context: &TransactionExecutionContext,
         block_context: &BlockContext,
     ) -> Result<CallInfo, TransactionError> {
@@ -647,29 +649,27 @@ impl ExecutionEntryPoint {
         use serde_json::json;
 
         use crate::syscalls::business_logic_syscall_handler::SYSCALL_BASE;
+        let sierra_program = &sierra_program_and_entrypoints.0;
+        let contract_entrypoints = &sierra_program_and_entrypoints.1;
 
         let entry_point = match self.entry_point_type {
-            EntryPointType::External => contract_class
-                .entry_points_by_type
+            EntryPointType::External => contract_entrypoints
                 .external
                 .iter()
                 .find(|entry_point| entry_point.selector == self.entry_point_selector.to_biguint())
                 .unwrap(),
-            EntryPointType::Constructor => contract_class
-                .entry_points_by_type
+            EntryPointType::Constructor => contract_entrypoints
                 .constructor
                 .iter()
                 .find(|entry_point| entry_point.selector == self.entry_point_selector.to_biguint())
                 .unwrap(),
-            EntryPointType::L1Handler => contract_class
-                .entry_points_by_type
+            EntryPointType::L1Handler => contract_entrypoints
                 .l1_handler
                 .iter()
                 .find(|entry_point| entry_point.selector == self.entry_point_selector.to_biguint())
                 .unwrap(),
         };
 
-        let sierra_program = contract_class.extract_sierra_program().unwrap();
         let program_registry: ProgramRegistry<CoreType, CoreLibfunc> =
             ProgramRegistry::new(&sierra_program).unwrap();
 

--- a/src/services/api/contract_classes/compiled_class.rs
+++ b/src/services/api/contract_classes/compiled_class.rs
@@ -8,6 +8,7 @@ use crate::services::api::contract_classes::deprecated_contract_class::AbiType;
 use crate::{ContractEntryPoint, EntryPointType};
 
 use super::deprecated_contract_class::ContractClass;
+use cairo_lang_sierra::program::Program as SierraProgram;
 use cairo_lang_starknet::abi::Contract;
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::{
@@ -24,7 +25,7 @@ use starknet::core::types::ContractClass::{Legacy, Sierra};
 pub enum CompiledClass {
     Deprecated(Arc<ContractClass>),
     Casm(Arc<CasmContractClass>),
-    Sierra(Arc<SierraContractClass>),
+    Sierra(Arc<(SierraProgram, ContractEntryPoints)>),
 }
 
 impl TryInto<CasmContractClass> for CompiledClass {

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -20,8 +20,6 @@ use std::{
     sync::Arc,
 };
 
-pub type SierraProgramCache =
-    HashMap<ClassHash, cairo_lang_starknet::contract_class::ContractClass>;
 pub type ContractClassCache = HashMap<ClassHash, CompiledClass>;
 
 pub const UNINITIALIZED_CLASS_HASH: &ClassHash = &[0u8; 32];

--- a/src/syscalls/native_syscall_handler.rs
+++ b/src/syscalls/native_syscall_handler.rs
@@ -565,7 +565,9 @@ where
                 .ok_or(ContractClassError::NoneEntryPointType)?
                 .is_empty()),
             CompiledClass::Casm(class) => Ok(class.entry_points_by_type.constructor.is_empty()),
-            CompiledClass::Sierra(class) => Ok(class.entry_points_by_type.constructor.is_empty()),
+            CompiledClass::Sierra(sierra_program_and_entrypoints) => {
+                Ok(sierra_program_and_entrypoints.1.constructor.is_empty())
+            }
         }
     }
 }

--- a/tests/cairo_native.rs
+++ b/tests/cairo_native.rs
@@ -2,6 +2,7 @@
 
 use crate::CallType::Call;
 use cairo_lang_starknet::casm_contract_class::CasmContractEntryPoints;
+use cairo_lang_starknet::contract_class::ContractClass;
 use cairo_lang_starknet::contract_class::ContractEntryPoints;
 use cairo_vm::felt::Felt252;
 use num_bigint::BigUint;
@@ -26,6 +27,19 @@ use starknet_in_rust::{
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+
+fn insert_sierra_class_into_cache(
+    contract_class_cache: &mut HashMap<ClassHash, CompiledClass>,
+    class_hash: ClassHash,
+    sierra_class: ContractClass,
+) {
+    let sierra_program = sierra_class.extract_sierra_program().unwrap();
+    let entry_points = sierra_class.entry_points_by_type;
+    contract_class_cache.insert(
+        class_hash,
+        CompiledClass::Sierra(Arc::new((sierra_program, entry_points))),
+    );
+}
 
 #[test]
 fn integration_test_erc20() {
@@ -54,9 +68,10 @@ fn integration_test_erc20() {
 
     let caller_address = Address(123456789.into());
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         NATIVE_CLASS_HASH,
-        CompiledClass::Sierra(Arc::new(sierra_contract_class)),
+        sierra_contract_class,
     );
     contract_class_cache.insert(
         CASM_CLASS_HASH,
@@ -449,13 +464,16 @@ fn call_contract_test() {
     let callee_class_hash: ClassHash = [2; 32];
     let callee_nonce = Felt252::zero();
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         caller_class_hash,
-        CompiledClass::Sierra(Arc::new(caller_contract_class)),
+        caller_contract_class,
     );
-    contract_class_cache.insert(
+
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         callee_class_hash,
-        CompiledClass::Sierra(Arc::new(callee_contract_class)),
+        callee_contract_class,
     );
 
     let mut state_reader = InMemoryStateReader::default();
@@ -534,14 +552,16 @@ fn call_echo_contract_test() {
     let callee_class_hash: ClassHash = [2; 32];
     let callee_nonce = Felt252::zero();
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         caller_class_hash,
-        CompiledClass::Sierra(Arc::new(caller_contract_class)),
+        caller_contract_class,
     );
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         callee_class_hash,
-        CompiledClass::Sierra(Arc::new(callee_contract_class)),
+        callee_contract_class,
     );
 
     let mut state_reader = InMemoryStateReader::default();
@@ -622,14 +642,16 @@ fn call_events_contract_test() {
     let callee_class_hash: ClassHash = [2; 32];
     let callee_nonce = Felt252::zero();
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         caller_class_hash,
-        CompiledClass::Sierra(Arc::new(caller_contract_class)),
+        caller_contract_class,
     );
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         callee_class_hash,
-        CompiledClass::Sierra(Arc::new(callee_contract_class)),
+        callee_contract_class,
     );
 
     let mut state_reader = InMemoryStateReader::default();
@@ -840,14 +862,16 @@ fn deploy_syscall_test() {
     let deployee_class_hash: ClassHash = Felt252::one().to_be_bytes();
     let _deployee_nonce = Felt252::zero();
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         deployer_class_hash,
-        CompiledClass::Sierra(Arc::new(deployer_contract_class)),
+        deployer_contract_class,
     );
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         deployee_class_hash,
-        CompiledClass::Sierra(Arc::new(deployee_contract_class)),
+        deployee_contract_class,
     );
 
     let mut state_reader = InMemoryStateReader::default();
@@ -945,14 +969,16 @@ fn deploy_syscall_address_unavailable_test() {
     // Insert contract to be deployed so that its address is taken
     let deployee_address = expected_deployed_contract_address;
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         deployer_class_hash,
-        CompiledClass::Sierra(Arc::new(deployer_contract_class)),
+        deployer_contract_class,
     );
 
-    contract_class_cache.insert(
+    insert_sierra_class_into_cache(
+        &mut contract_class_cache,
         deployee_class_hash,
-        CompiledClass::Sierra(Arc::new(deployee_contract_class)),
+        deployee_contract_class,
     );
 
     let mut state_reader = InMemoryStateReader::default();


### PR DESCRIPTION
This avoids having to call `SierraContractClass.extract_sierra_program` more than once for each sierra program as this is quite expensive
