### PR TITLE
Refactor `InvokeFunction::handle_nonce` to increment the nonce even if `skip_nonce_check` is set

### DIFF
--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -253,7 +253,7 @@ pub fn execute_tx(
     TransactionTrace,
     RpcTransactionReceipt,
 ) {
-    execute_tx_configurable(tx_hash, network, block_number, false, false)
+    execute_tx_configurable(tx_hash, network, block_number, false, true)
 }
 
 pub fn execute_tx_without_validate(
@@ -388,6 +388,11 @@ fn test_get_gas_price() {
 #[test_case(
     "0x01583c47a929f81f6a8c74d31708a7f161603893435d51b6897017fdcdaafee4",
     889897, // real block 889898
+    RpcChain::TestNet
+)]
+#[test_case(
+    "0x05dc2a26a65b0fc9e8cb17d8b3e9142abdb2b2d2dd2f3eb275256f23bddfc9f2",
+    899787, // real block 899788
     RpcChain::TestNet
 )]
 fn starknet_in_rust_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -332,7 +332,7 @@ impl InvokeFunction {
                 vec![0, 1],
             ));
         }
-        self.handle_nonce(state, self.skip_nonce_check)?;
+        self.handle_nonce(state)?;
 
         let mut transactional_state = state.create_transactional();
         let mut tx_exec_info =
@@ -377,11 +377,7 @@ impl InvokeFunction {
         Ok(tx_exec_info)
     }
 
-    fn handle_nonce<S: State + StateReader>(
-        &self,
-        state: &mut S,
-        skip_nonce_check: bool,
-    ) -> Result<(), TransactionError> {
+    fn handle_nonce<S: State + StateReader>(&self, state: &mut S) -> Result<(), TransactionError> {
         if self.version.is_zero() {
             return Ok(());
         }
@@ -395,7 +391,7 @@ impl InvokeFunction {
                 Ok(())
             }
             Some(nonce) => {
-                if !skip_nonce_check && nonce != &current_nonce {
+                if !self.skip_nonce_check && nonce != &current_nonce {
                     return Err(TransactionError::InvalidTransactionNonce(
                         current_nonce.to_string(),
                         nonce.to_string(),

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -395,13 +395,11 @@ impl InvokeFunction {
                 Ok(())
             }
             Some(nonce) => {
-                if !skip_nonce_check {
-                    if nonce != &current_nonce {
-                        return Err(TransactionError::InvalidTransactionNonce(
-                            current_nonce.to_string(),
-                            nonce.to_string(),
-                        ));
-                    }
+                if !skip_nonce_check && nonce != &current_nonce {
+                    return Err(TransactionError::InvalidTransactionNonce(
+                        current_nonce.to_string(),
+                        nonce.to_string(),
+                    ));
                 }
                 state.increment_nonce(contract_address)?;
                 Ok(())


### PR DESCRIPTION
`handle_nonce` not only checks that the nonce is valid, but it also increments the nonce, which leads to a nonce_update being accounted for when calculating the fee. Currently, the nonce increase is being skipped if `skip_nonce_check` is set to true, leading to different fee values. This PR refactors the handle_nonce function to still perform the nonce increase and only skip the nonce check.
The PR also adds a test for the tx reported in #1133 
