### PR TITLE
Replace todo with error handling in `DeprecatedBLSyscallHandler::constructor_entry_points_empty`

### DIFF
--- a/src/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -192,9 +192,7 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
                 .ok_or(ContractClassError::NoneEntryPointType)?
                 .is_empty()),
             CompiledClass::Casm(class) => Ok(class.entry_points_by_type.constructor.is_empty()),
-            CompiledClass::Sierra(_) => {
-                return Err(ContractClassError::NotADeprecatedContractClass.into())
-            }
+            CompiledClass::Sierra(_) => Err(ContractClassError::NotADeprecatedContractClass.into()),
         }
     }
 

--- a/src/syscalls/deprecated_business_logic_syscall_handler.rs
+++ b/src/syscalls/deprecated_business_logic_syscall_handler.rs
@@ -192,7 +192,9 @@ impl<'a, S: StateReader> DeprecatedBLSyscallHandler<'a, S> {
                 .ok_or(ContractClassError::NoneEntryPointType)?
                 .is_empty()),
             CompiledClass::Casm(class) => Ok(class.entry_points_by_type.constructor.is_empty()),
-            CompiledClass::Sierra(_) => todo!(),
+            CompiledClass::Sierra(_) => {
+                return Err(ContractClassError::NotADeprecatedContractClass.into())
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1056
