### PR TITLE
Fix Makefile dependencies for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,8 @@ deps: check-python-version build-cairo-2-compiler build-cairo-1-compiler
 	cargo install cargo-nextest --version 0.9.49
 
 deps-macos: check-python-version build-cairo-2-compiler-macos build-cairo-1-compiler-macos
+	brew install python@3.9
+	brew install pyenv
 	cargo install flamegraph --version 0.6.2
 	cargo install cargo-llvm-cov --version 0.5.14
 	-pyenv install -s pypy3.9-7.3.9


### PR DESCRIPTION
# Fix Makefile dependencies for MacOS

## Description

Added two commands to the Makefile instructions when installing the MacOS dependencies.

<img width="425" alt="image" src="https://github.com/lambdaclass/starknet_in_rust/assets/146965181/92d9dfa7-dfe3-4f8d-a8e4-27b371461f52">
