### PR TITLE
Extend `cairo-native` feature to `rpc-state-reader` crate

### DIFF
--- a/rpc_state_reader/Cargo.toml
+++ b/rpc_state_reader/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+cairo-native = ["starknet_in_rust/cairo-native"]
+
 [dependencies]
 ureq = { version = "2.7.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -236,8 +236,14 @@ pub fn execute_tx_configurable(
     );
 
     (
-        tx.execute(&mut state, &block_context, u128::MAX, None)
-            .unwrap(),
+        tx.execute(
+            &mut state,
+            &block_context,
+            u128::MAX,
+            #[cfg(feature = "cairo-native")]
+            None,
+        )
+        .unwrap(),
         trace,
         receipt,
     )


### PR DESCRIPTION
Currently in main, running `cargo test` from within the `rpc-state-reader` source fails, as the code was changed to support the changes made to `starknet_in_rust` under the `cairo-native` feature flag without including said feature. This PR adds the `cairo-native` feature flag to the `rpc-state-reader` and gates the changes under this flag, so that the tests pass when running `make test`, and also when running `cargo test` from within the `rpc-state-reader` crate.
