### PR TITLE
Revert Invoke txs if the balance cannot cover the actual_fee after executing the tx

### DIFF
--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -252,6 +252,18 @@ fn test_sorted_events(
     RpcChain::MainNet
     => ignore["broken on both due to a cairo-vm error"]
 )]
+// Insufficient fee token balance
+#[test_case(
+    "0x006978ae71587d4ab1048d7836c2d656222a16976c82c0dc24d3b44316d63cfe",
+    440823, // real block     440824
+    RpcChain::MainNet
+)]
+// Insufficient fee token balance
+#[test_case(
+    "0x03e458ef06c17dd2601013746ae5622d8434348b246a335b20b6543f37aff0f8",
+    440849, // real block     440850
+    RpcChain::MainNet
+)]
 fn starknet_in_rust_test_case_reverted_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number)).unwrap();
 

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -406,8 +406,8 @@ impl InvokeFunction {
         } else {
             // Check if as a result of tx execution the sender's fee token balance is not enough to pay the actual_fee.
             // If so, revert the transaction.
-            let (balance_low, balance_high) =
-                state.get_fee_token_balance(block_context, self.contract_address())?;
+            let (balance_low, balance_high) = transactional_state
+                .get_fee_token_balance(block_context, self.contract_address())?;
             // The fee is at most 128 bits, while balance is 256 bits (split into two 128 bit words).
             if balance_high.is_zero()
                 && balance_low < Felt252::from(actual_fee)

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -404,8 +404,18 @@ impl InvokeFunction {
                 .as_str(),
             );
         } else {
-            state
-                .apply_state_update(&StateDiff::from_cached_state(transactional_state.cache())?)?;
+            // Check if as a result of tx execution the sender's fee token balance is not enough to pay the actual_fee.
+            // If so, revert the transaction.
+            let (balance_low, balance_high) =
+                state.get_fee_token_balance(block_context, self.contract_address())?;
+            // The fee is at most 128 bits, while balance is 256 bits (split into two 128 bit words).
+            if balance_high.is_zero() && balance_low < Felt252::from(self.max_fee) {
+                tx_exec_info = tx_exec_info.to_revert_error("Insufficient fee token balance");
+            } else {
+                state.apply_state_update(&StateDiff::from_cached_state(
+                    transactional_state.cache(),
+                )?)?;
+            }
         }
 
         let mut tx_execution_context =

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -409,7 +409,10 @@ impl InvokeFunction {
             let (balance_low, balance_high) =
                 state.get_fee_token_balance(block_context, self.contract_address())?;
             // The fee is at most 128 bits, while balance is 256 bits (split into two 128 bit words).
-            if balance_high.is_zero() && balance_low < Felt252::from(self.max_fee) {
+            if balance_high.is_zero()
+                && balance_low < Felt252::from(self.max_fee)
+                && !self.skip_fee_transfer
+            {
                 tx_exec_info = tx_exec_info.to_revert_error("Insufficient fee token balance");
             } else {
                 state.apply_state_update(&StateDiff::from_cached_state(

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -410,7 +410,7 @@ impl InvokeFunction {
                 state.get_fee_token_balance(block_context, self.contract_address())?;
             // The fee is at most 128 bits, while balance is 256 bits (split into two 128 bit words).
             if balance_high.is_zero()
-                && balance_low < Felt252::from(self.max_fee)
+                && balance_low < Felt252::from(actual_fee)
                 && !self.skip_fee_transfer
             {
                 tx_exec_info = tx_exec_info.to_revert_error("Insufficient fee token balance");


### PR DESCRIPTION
This contemplates the case in which the sender's balance is high enough to pay the max_fee before running the tx, but after running it it is not enough to cover the actual_fee. In that case, the tx should be reverted