### PR TITLE
Bump starknet-crypto version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
  "serde_json_pythonic",
  "sha3",
  "starknet",
- "starknet-crypto 0.5.2",
+ "starknet-crypto 0.6.1",
  "starknet_api",
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde_json = { version = "1.0", features = [
 serde_json_pythonic = "0.1.2"
 starknet = { workspace = true }
 starknet_api = { workspace = true }
-starknet-crypto = "0.5.1"
+starknet-crypto = "0.6.1"
 thiserror = { workspace = true }
 tracing = "0.1.37"
 


### PR DESCRIPTION
# Bump starknet-crypto version

Update Starknet-crypto version to 0.6.1

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
