### PR TITLE
Cache data obtained from RPC requests for benchmarking in replay binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ default = ["with_mimalloc"]
 with_mimalloc = ["dep:mimalloc"]
 cairo_1_tests = []
 metrics = []
+# Disclaimer: This feature enables state modifications being applied on reverted txs
+# Only use for benchmarking using the replay binary
+replay_benchmark = []
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default = ["with_mimalloc"]
 with_mimalloc = ["dep:mimalloc"]
 cairo_1_tests = []
 metrics = []
-# Disclaimer: This feature enables state modifications being applied on reverted txs
+# Disclaimer: This feature enables state modifications being applied on reverted and failings txs, ands also disables address availability check when deploying contracts.
 # Only use for benchmarking using the replay binary
 replay_benchmark = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default = ["with_mimalloc"]
 with_mimalloc = ["dep:mimalloc"]
 cairo_1_tests = []
 metrics = []
-# Disclaimer: This feature enables state modifications being applied on reverted and failings txs, ands also disables address availability check when deploying contracts.
+# Disclaimer: This feature enables state modifications being applied on reverted and failings txs, and also disables address availability check when deploying contracts.
 # Only use for benchmarking using the replay binary
 replay_benchmark = []
 

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -10,7 +10,7 @@ benchmark = ["starknet_in_rust/replay_benchmark"]
 
 [dependencies]
 # starknet specific crates
-starknet_in_rust = { path = "../", version = "0.4.0" }
+starknet_in_rust = { path = "../", version = "0.4.0", features = ["replay_benchmark"] }
 rpc_state_reader = { path = "../rpc_state_reader", features = ["starknet_in_rust"] }
 starknet_api = { workspace = true }
 # CLI specific crates

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -10,7 +10,7 @@ benchmark = ["starknet_in_rust/replay_benchmark"]
 
 [dependencies]
 # starknet specific crates
-starknet_in_rust = { path = "../", version = "0.4.0", features = ["replay_benchmark"] }
+starknet_in_rust = { path = "../", version = "0.4.0" }
 rpc_state_reader = { path = "../rpc_state_reader", features = ["starknet_in_rust"] }
 starknet_api = { workspace = true }
 # CLI specific crates

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+benchmark = []
+
 [dependencies]
 # starknet specific crates
 starknet_in_rust = { path = "../", version = "0.4.0" }

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-benchmark = []
+benchmark = ["starknet_in_rust/replay_benchmark"]
 
 [dependencies]
 # starknet specific crates

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -61,7 +61,7 @@ enum ReplayExecute {
     },
     #[cfg(feature = "benchmark")]
     #[clap(
-        about = "Execute all the invoke transactions in a given range of blocks.
+        about = "Execute all the transactions in a given range of blocks.
 Runs the all transactions twice, once to fill up the caches and a second one to benchmark."
     )]
     BenchBlockRange {

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -46,13 +46,13 @@ enum ReplayExecute {
         block_number: u64,
         silent: Option<bool>,
     },
-    #[clap(about = "Execute all the invoke transactions in a given block.")]
+    #[clap(about = "Execute all the transactions in a given block.")]
     Block {
         chain: String,
         block_number: u64,
         silent: Option<bool>,
     },
-    #[clap(about = "Execute all the invoke transactions in a given range of blocks.")]
+    #[clap(about = "Execute all the transactions in a given range of blocks.")]
     BlockRange {
         block_start: u64,
         block_end: u64,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -25,6 +25,7 @@ use starknet_in_rust::{
     },
     utils::Address,
 };
+use std::ops::Div;
 #[cfg(feature = "benchmark")]
 use std::time::Instant;
 #[cfg(feature = "benchmark")]
@@ -239,7 +240,7 @@ fn main() {
                 block_end,
                 n_runs,
                 elapsed_time.as_secs_f64(),
-                elapsed_time.as_secs_f64().div_euclid(n_runs as f64)
+                elapsed_time.as_secs_f64().div(n_runs as f64)
             );
         }
     }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -1,25 +1,32 @@
-use std::{collections::HashMap, sync::Arc};
-
 use clap::{Parser, Subcommand};
 use rpc_state_reader::{
-    execute_tx_configurable, execute_tx_configurable_with_state, get_transaction_hashes,
-    rpc_state::{RpcBlockInfo, RpcChain, RpcState, RpcTransactionReceipt},
+    execute_tx_configurable, get_transaction_hashes,
+    rpc_state::{RpcChain, RpcTransactionReceipt},
+};
+#[cfg(feature = "benchmark")]
+use rpc_state_reader::{
+    execute_tx_configurable_with_state,
+    rpc_state::{RpcBlockInfo, RpcState},
     RpcStateReader,
 };
-use starknet_api::hash::StarkFelt;
+use starknet_api::block::BlockNumber;
+#[cfg(feature = "benchmark")]
 use starknet_api::{
-    block::BlockNumber,
+    hash::StarkFelt,
     stark_felt,
     transaction::{Transaction, TransactionHash},
 };
+use starknet_in_rust::execution::TransactionExecutionInfo;
+#[cfg(feature = "benchmark")]
 use starknet_in_rust::{
-    execution::TransactionExecutionInfo,
     felt::Felt252,
     state::{
         cached_state::CachedState, contract_class_cache::PermanentContractClassCache, BlockInfo,
     },
     utils::Address,
 };
+#[cfg(feature = "benchmark")]
+use std::{collections::HashMap, sync::Arc};
 
 #[derive(Debug, Parser)]
 #[command(about = "Replay is a tool for executing Starknet transactions.", long_about = None)]
@@ -50,6 +57,7 @@ enum ReplayExecute {
         chain: String,
         silent: Option<bool>,
     },
+    #[cfg(feature = "benchmark")]
     #[clap(
         about = "Execute all the invoke transactions in a given range of blocks.
 Runs the all transactions twice, once to fill up the caches and a second one to benchmark."
@@ -106,6 +114,7 @@ fn main() {
                 }
             }
         }
+        #[cfg(feature = "benchmark")]
         ReplayExecute::BenchBlockRange {
             block_start,
             block_end,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -238,8 +238,8 @@ fn main() {
                 block_start,
                 block_end,
                 n_runs,
-                elapsed_time.as_secs(),
-                elapsed_time.as_secs().div_euclid(n_runs as u64)
+                elapsed_time.as_secs_f64(),
+                elapsed_time.as_secs_f64().div_euclid(n_runs as f64)
             );
         }
     }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -48,7 +48,7 @@ enum ReplayExecute {
     },
     #[clap(
         about = "Execute all the invoke transactions in a given range of blocks.
-    Runs the all transactions twice, once to fill up the caches and a second one to benchmark."
+Runs the all transactions twice, once to fill up the caches and a second one to benchmark."
     )]
     BenchBlockRange {
         block_start: u64,
@@ -156,7 +156,7 @@ fn main() {
                 let block_txs = transactions.get(&block_number).unwrap();
                 // Run txs
                 for (tx_hash, tx) in block_txs {
-                    execute_tx_configurable_with_state(
+                    let _ = execute_tx_configurable_with_state(
                         tx_hash,
                         tx.clone(),
                         network,
@@ -164,8 +164,7 @@ fn main() {
                         false,
                         true,
                         state,
-                    )
-                    .unwrap();
+                    );
                 }
             }
         }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -173,7 +173,6 @@ fn main() {
                         &tx_hash,
                         tx.clone(),
                         network,
-                        block_number,
                         BlockInfo {
                             block_number: block_number.0,
                             block_timestamp: block_timestamp.0,
@@ -220,7 +219,6 @@ fn main() {
                             tx_hash,
                             tx.clone(),
                             network,
-                            block_number,
                             BlockInfo {
                                 block_number: block_number.0,
                                 block_timestamp,
@@ -235,7 +233,14 @@ fn main() {
                 }
             }
             let elapsed_time = now.elapsed();
-            println!("Ran blocks {} - {} {} times in {} seconds", block_start, block_end, n_runs, elapsed_time.as_secs());
+            println!(
+                "Ran blocks {} - {} {} times in {} seconds. Approximately {} seconds per run",
+                block_start,
+                block_end,
+                n_runs,
+                elapsed_time.as_secs(),
+                elapsed_time.as_secs().div_euclid(n_runs as u64)
+            );
         }
     }
 }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -1,10 +1,21 @@
+use std::{collections::HashMap, sync::Arc};
+
 use clap::{Parser, Subcommand};
 use rpc_state_reader::{
-    execute_tx_configurable, get_transaction_hashes,
-    rpc_state::{RpcChain, RpcTransactionReceipt},
+    execute_tx_configurable, execute_tx_configurable_with_state, get_transaction_hashes,
+    rpc_state::{RpcChain, RpcState, RpcTransactionReceipt},
+    RpcStateReader,
 };
-use starknet_api::block::BlockNumber;
-use starknet_in_rust::execution::TransactionExecutionInfo;
+use starknet_api::hash::StarkFelt;
+use starknet_api::{
+    block::BlockNumber,
+    stark_felt,
+    transaction::{Transaction, TransactionHash},
+};
+use starknet_in_rust::{
+    execution::TransactionExecutionInfo,
+    state::{cached_state::CachedState, contract_class_cache::PermanentContractClassCache},
+};
 
 #[derive(Debug, Parser)]
 #[command(about = "Replay is a tool for executing Starknet transactions.", long_about = None)]
@@ -34,6 +45,15 @@ enum ReplayExecute {
         block_end: u64,
         chain: String,
         silent: Option<bool>,
+    },
+    #[clap(
+        about = "Execute all the invoke transactions in a given range of blocks.
+    Runs the all transactions twice, once to fill up the caches and a second one to benchmark."
+    )]
+    BenchBlockRange {
+        block_start: u64,
+        block_end: u64,
+        chain: String,
     },
 }
 
@@ -79,6 +99,73 @@ fn main() {
 
                 for tx_hash in transaction_hashes {
                     show_execution_data(tx_hash, &chain, block_number.0, silent);
+                }
+            }
+        }
+        ReplayExecute::BenchBlockRange {
+            block_start,
+            block_end,
+            chain,
+        } => {
+            println!("Filling up Cache");
+            let network = parse_network(&chain);
+            // Create a single class_cache for all states
+            let class_cache = Arc::new(PermanentContractClassCache::default());
+            // HashMaps to cache txs & states
+            let mut transactions =
+                HashMap::<BlockNumber, Vec<(TransactionHash, Transaction)>>::new();
+            let mut cached_states = HashMap::<
+                BlockNumber,
+                CachedState<RpcStateReader, PermanentContractClassCache>,
+            >::new();
+            for block_number in block_start..=block_end {
+                // For each block:
+                let block_number = BlockNumber(block_number);
+                // Create a cached state
+                let rpc_reader = RpcStateReader::new(
+                    RpcState::new_infura(network, block_number.into()).unwrap(),
+                );
+                let mut state = CachedState::new(Arc::new(rpc_reader), class_cache.clone());
+                // Fetch txs for the block
+                let transaction_hashes = get_transaction_hashes(block_number, network)
+                    .expect("Unable to fetch the transaction hashes.");
+                let mut txs_in_block = Vec::<(TransactionHash, Transaction)>::new();
+                for tx_hash in transaction_hashes {
+                    // Fetch tx and add it to txs_in_block cache
+                    let tx_hash = TransactionHash(stark_felt!(tx_hash.strip_prefix("0x").unwrap()));
+                    let tx = state.state_reader.0.get_transaction(&tx_hash).unwrap();
+                    txs_in_block.push((tx_hash, tx));
+                }
+                // Add the txs from the current block to the transactions cache
+                transactions.insert(block_number, txs_in_block);
+                // Clean writes from cached_state
+                state.cache_mut().storage_writes_mut().clear();
+                state.cache_mut().class_hash_writes_mut().clear();
+                state.cache_mut().nonce_writes_mut().clear();
+                // Add the cached state for the current block to the cached_states cache
+                cached_states.insert(block_number, state);
+            }
+            // Benchmark run should make no api requests as all data is cached
+
+            println!("Executing block range: {} - {}", block_start, block_end);
+            for block_number in block_start..=block_end {
+                let block_number = BlockNumber(block_number);
+                // Fetch state
+                let state = cached_states.get_mut(&block_number).unwrap();
+                // Fetch txs
+                let block_txs = transactions.get(&block_number).unwrap();
+                // Run txs
+                for (tx_hash, tx) in block_txs {
+                    execute_tx_configurable_with_state(
+                        tx_hash,
+                        tx.clone(),
+                        network,
+                        block_number,
+                        false,
+                        true,
+                        state,
+                    )
+                    .unwrap();
                 }
             }
         }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -61,8 +61,8 @@ enum ReplayExecute {
     },
     #[cfg(feature = "benchmark")]
     #[clap(
-        about = "Execute all the transactions in a given range of blocks.
-Runs the all transactions twice, once to fill up the caches and a second one to benchmark."
+        about = "Measures the time it takes to run all transactions in a given range of blocks.
+Caches all rpc data before the benchmark runs to provide accurate results"
     )]
     BenchBlockRange {
         block_start: u64,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -234,7 +234,7 @@ fn main() {
             }
             let elapsed_time = now.elapsed();
             println!(
-                "Ran blocks {} - {} {} times in {} seconds. Approximately {} seconds per run",
+                "Ran blocks {} - {} {} times in {} seconds. Approximately {} second(s) per run",
                 block_start,
                 block_end,
                 n_runs,

--- a/rpc_state_reader/src/lib.rs
+++ b/rpc_state_reader/src/lib.rs
@@ -14,6 +14,7 @@ pub use sir_state_reader::{
 
 #[cfg(test)]
 mod tests {
+    use cairo_vm::felt::Felt252;
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
     use starknet_api::{
         class_hash,
@@ -23,9 +24,7 @@ mod tests {
         state::StorageKey,
         transaction::{Transaction as SNTransaction, TransactionHash},
     };
-    use starknet_in_rust::{
-        definitions::block_context::StarknetChainId, transaction::InvokeFunction,
-    };
+    use starknet_in_rust::transaction::InvokeFunction;
 
     use crate::rpc_state::*;
 
@@ -111,9 +110,10 @@ mod tests {
 
         let tx = rpc_state.get_transaction(&tx_hash).unwrap();
         match tx {
-            SNTransaction::Invoke(tx) => {
-                InvokeFunction::from_invoke_transaction(tx, StarknetChainId::MainNet)
-            }
+            SNTransaction::Invoke(tx) => InvokeFunction::from_invoke_transaction(
+                tx,
+                Felt252::from_bytes_be(tx_hash.0.bytes()),
+            ),
             _ => unreachable!(),
         }
         .unwrap();

--- a/rpc_state_reader/src/lib.rs
+++ b/rpc_state_reader/src/lib.rs
@@ -8,8 +8,8 @@ pub mod utils;
 mod sir_state_reader;
 #[cfg(feature = "starknet_in_rust")]
 pub use sir_state_reader::{
-    execute_tx, execute_tx_configurable, execute_tx_without_validate, get_transaction_hashes,
-    RpcStateReader,
+    execute_tx, execute_tx_configurable, execute_tx_configurable_with_state,
+    execute_tx_without_validate, get_transaction_hashes, RpcStateReader,
 };
 
 #[cfg(test)]

--- a/rpc_state_reader/src/sir_state_reader.rs
+++ b/rpc_state_reader/src/sir_state_reader.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct RpcStateReader(RpcState);
+pub struct RpcStateReader(pub RpcState);
 
 impl RpcStateReader {
     pub fn new(state: RpcState) -> Self {
@@ -260,11 +260,7 @@ pub fn execute_tx_configurable_with_state(
         SNTransaction::Deploy(_) => unimplemented!(),
     };
 
-    let trace = state
-        .state_reader
-        .0
-        .get_transaction_trace(tx_hash)
-        .unwrap();
+    let trace = state.state_reader.0.get_transaction_trace(tx_hash).unwrap();
     let receipt = state
         .state_reader
         .0

--- a/rpc_state_reader/src/sir_state_reader.rs
+++ b/rpc_state_reader/src/sir_state_reader.rs
@@ -137,7 +137,6 @@ pub fn execute_tx_configurable(
         &tx_hash,
         tx,
         network,
-        block_number,
         block_info,
         skip_validate,
         skip_nonce_check,
@@ -160,7 +159,6 @@ pub fn execute_tx_configurable_with_state(
     tx_hash: &TransactionHash,
     tx: SNTransaction,
     network: RpcChain,
-    block_number: BlockNumber,
     block_info: BlockInfo,
     skip_validate: bool,
     skip_nonce_check: bool,
@@ -198,7 +196,11 @@ pub fn execute_tx_configurable_with_state(
             } else {
                 // Fetch the contract_class from the next block (as we don't have it in the previous one)
                 let next_block_state_reader = RpcStateReader(
-                    RpcState::new_infura(network, (block_number.next()).into()).unwrap(),
+                    RpcState::new_infura(
+                        network,
+                        BlockNumber(block_info.block_number).next().into(),
+                    )
+                    .unwrap(),
                 );
 
                 let contract_class = next_block_state_reader

--- a/rpc_state_reader/src/sir_state_reader.rs
+++ b/rpc_state_reader/src/sir_state_reader.rs
@@ -184,7 +184,7 @@ pub fn execute_tx_configurable_with_state(
             .unwrap()
             .create_for_simulation(skip_validate, false, false, false, skip_nonce_check),
         SNTransaction::DeployAccount(tx) => {
-            DeployAccount::from_sn_api_transaction(tx, chain_id.to_felt())
+            DeployAccount::from_sn_api_transaction(tx, Felt252::from_bytes_be(tx_hash.0.bytes()))
                 .unwrap()
                 .create_for_simulation(skip_validate, false, false, false, skip_nonce_check)
         }

--- a/rpc_state_reader/src/sir_state_reader.rs
+++ b/rpc_state_reader/src/sir_state_reader.rs
@@ -180,9 +180,11 @@ pub fn execute_tx_configurable_with_state(
 
     // Get transaction before giving ownership of the reader
     let tx = match tx {
-        SNTransaction::Invoke(tx) => InvokeFunction::from_invoke_transaction(tx, chain_id)
-            .unwrap()
-            .create_for_simulation(skip_validate, false, false, false, skip_nonce_check),
+        SNTransaction::Invoke(tx) => {
+            InvokeFunction::from_invoke_transaction(tx, Felt252::from_bytes_be(tx_hash.0.bytes()))
+                .unwrap()
+                .create_for_simulation(skip_validate, false, false, false, skip_nonce_check)
+        }
         SNTransaction::DeployAccount(tx) => {
             DeployAccount::from_sn_api_transaction(tx, Felt252::from_bytes_be(tx_hash.0.bytes()))
                 .unwrap()

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -12,7 +12,6 @@ use starknet_api::{
     transaction::{Transaction as SNTransaction, TransactionHash},
 };
 use starknet_in_rust::{
-    definitions::block_context::StarknetChainId,
     execution::{CallInfo, TransactionExecutionInfo},
     transaction::InvokeFunction,
 };
@@ -27,9 +26,11 @@ fn test_get_transaction_try_from() {
     let sn_tx = rpc_state.get_transaction(&tx_hash).unwrap();
     match &sn_tx {
         SNTransaction::Invoke(sn_tx) => {
-            let tx =
-                InvokeFunction::from_invoke_transaction(sn_tx.clone(), StarknetChainId::MainNet)
-                    .unwrap();
+            let tx = InvokeFunction::from_invoke_transaction(
+                sn_tx.clone(),
+                Felt252::from_bytes_be(tx_hash.0.bytes()),
+            )
+            .unwrap();
             assert_eq!(tx.hash_value().to_be_bytes().as_slice(), str_hash.bytes())
         }
         _ => unimplemented!(),

--- a/src/state/cached_state.rs
+++ b/src/state/cached_state.rs
@@ -255,7 +255,7 @@ impl<T: StateReader, C: ContractClassCache> State for CachedState<T, C> {
                 deploy_contract_address.clone(),
             ));
         }
-
+        #[cfg(not(feature = "replay_benchmark"))]
         match self.get_class_hash_at(&deploy_contract_address) {
             Ok(x) if x == [0; 32] => {}
             Ok(_) => {

--- a/src/state/state_api.rs
+++ b/src/state/state_api.rs
@@ -25,30 +25,6 @@ pub trait StateReader {
         &self,
         class_hash: &ClassHash,
     ) -> Result<CompiledClassHash, StateError>;
-    /// Returns the storage value representing the balance (in fee token) at the given address as a (low, high) pair
-    fn get_fee_token_balance(
-        &mut self,
-        block_context: &BlockContext,
-        contract_address: &Address,
-    ) -> Result<(Felt252, Felt252), StateError> {
-        let (low_key, high_key) = get_erc20_balance_var_addresses(contract_address)?;
-        let low = self.get_storage_at(&(
-            block_context
-                .starknet_os_config()
-                .fee_token_address()
-                .clone(),
-            low_key,
-        ))?;
-        let high = self.get_storage_at(&(
-            block_context
-                .starknet_os_config()
-                .fee_token_address()
-                .clone(),
-            high_key,
-        ))?;
-
-        Ok((low, high))
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -121,4 +97,29 @@ pub trait State {
         &mut self,
         class_hash: &ClassHash,
     ) -> Result<Vec<BigUintAsHex>, StateError>;
+
+    /// Returns the storage value representing the balance (in fee token) at the given address as a (low, high) pair
+    fn get_fee_token_balance(
+        &mut self,
+        block_context: &BlockContext,
+        contract_address: &Address,
+    ) -> Result<(Felt252, Felt252), StateError> {
+        let (low_key, high_key) = get_erc20_balance_var_addresses(contract_address)?;
+        let low = self.get_storage_at(&(
+            block_context
+                .starknet_os_config()
+                .fee_token_address()
+                .clone(),
+            low_key,
+        ))?;
+        let high = self.get_storage_at(&(
+            block_context
+                .starknet_os_config()
+                .fee_token_address()
+                .clone(),
+            high_key,
+        ))?;
+
+        Ok((low, high))
+    }
 }

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -583,7 +583,7 @@ impl DeployAccount {
 
     pub fn from_sn_api_transaction(
         value: starknet_api::transaction::DeployAccountTransaction,
-        chain_id: Felt252,
+        tx_hash: Felt252,
     ) -> Result<Self, SyscallHandlerError> {
         let max_fee = value.max_fee.0;
         let version = Felt252::from_bytes_be(value.version.0.bytes());
@@ -605,7 +605,7 @@ impl DeployAccount {
             .map(|f| Felt252::from_bytes_be(f.bytes()))
             .collect();
 
-        DeployAccount::new(
+        DeployAccount::new_with_tx_hash(
             class_hash,
             max_fee,
             version,
@@ -613,7 +613,7 @@ impl DeployAccount {
             constructor_calldata,
             signature,
             contract_address_salt,
-            chain_id,
+            tx_hash,
         )
     }
 }

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -204,12 +204,31 @@ impl DeployAccount {
         self.handle_nonce(state)?;
 
         let mut transactional_state = state.create_transactional()?;
-        let mut tx_exec_info = self.apply(
+        let tx_exec_info = self.apply(
             &mut transactional_state,
             block_context,
             #[cfg(feature = "cairo-native")]
             program_cache.clone(),
-        )?;
+        );
+        #[cfg(feature = "replay_benchmark")]
+        // Add initial values to cache despite tx outcome
+        {
+            state.cache_mut().storage_initial_values_mut().extend(
+                transactional_state
+                    .cache()
+                    .storage_initial_values
+                    .clone()
+                    .into_iter(),
+            );
+            state.cache_mut().class_hash_initial_values_mut().extend(
+                transactional_state
+                    .cache()
+                    .class_hash_initial_values
+                    .clone()
+                    .into_iter(),
+            );
+        }
+        let mut tx_exec_info = tx_exec_info?;
 
         let actual_fee = calculate_tx_fee(
             &tx_exec_info.actual_resources,

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -404,9 +404,12 @@ impl InvokeFunction {
                 .as_str(),
             );
         } else {
+            #[cfg(not(feature = "replay_benchmark"))]
             state
                 .apply_state_update(&StateDiff::from_cached_state(transactional_state.cache())?)?;
         }
+        #[cfg(feature = "replay_benchmark")]
+        state.apply_state_update(&StateDiff::from_cached_state(transactional_state.cache())?)?;
 
         let mut tx_execution_context =
             self.get_execution_context(block_context.invoke_tx_max_n_steps)?;

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -410,6 +410,8 @@ impl InvokeFunction {
         }
         #[cfg(feature = "replay_benchmark")]
         state.apply_state_update(&StateDiff::from_cached_state(transactional_state.cache())?)?;
+        #[cfg(feature = "replay_benchmark")]
+        state.cache_mut().class_hash_initial_values_mut().extend(transactional_state.cache().class_hash_initial_values.clone().into_iter());
 
         let mut tx_execution_context =
             self.get_execution_context(block_context.invoke_tx_max_n_steps)?;

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -404,12 +404,11 @@ impl InvokeFunction {
                 .as_str(),
             );
         } else {
-            #[cfg(not(feature = "replay_benchmark"))]
             state
                 .apply_state_update(&StateDiff::from_cached_state(transactional_state.cache())?)?;
         }
         #[cfg(feature = "replay_benchmark")]
-        state.apply_state_update(&StateDiff::from_cached_state(transactional_state.cache())?)?;
+        state.cache_mut().storage_initial_values_mut().extend(transactional_state.cache().storage_initial_values.clone().into_iter());
         #[cfg(feature = "replay_benchmark")]
         state.cache_mut().class_hash_initial_values_mut().extend(transactional_state.cache().class_hash_initial_values.clone().into_iter());
 

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -408,9 +408,22 @@ impl InvokeFunction {
                 .apply_state_update(&StateDiff::from_cached_state(transactional_state.cache())?)?;
         }
         #[cfg(feature = "replay_benchmark")]
-        state.cache_mut().storage_initial_values_mut().extend(transactional_state.cache().storage_initial_values.clone().into_iter());
-        #[cfg(feature = "replay_benchmark")]
-        state.cache_mut().class_hash_initial_values_mut().extend(transactional_state.cache().class_hash_initial_values.clone().into_iter());
+        {
+            state.cache_mut().storage_initial_values_mut().extend(
+                transactional_state
+                    .cache()
+                    .storage_initial_values
+                    .clone()
+                    .into_iter(),
+            );
+            state.cache_mut().class_hash_initial_values_mut().extend(
+                transactional_state
+                    .cache()
+                    .class_hash_initial_values
+                    .clone()
+                    .into_iter(),
+            );
+        }
 
         let mut tx_execution_context =
             self.get_execution_context(block_context.invoke_tx_max_n_steps)?;


### PR DESCRIPTION
Adds `benchmark` feature and `bench-block-range` command to the `replay` binary
This new command will cache all tx & block data, run all txs to cache data obtained from rpc calls, and then perform a given ammount of benchmark runs without the need of network data.
In order to achieve this, the `replay_benchmark` feature was added to `starknet_in_rust` with changes necessary to cache all data needed for the benchmark execution, this changes include:
* Updating the cached_state with the initial writes of the transactional state regardless of tx outcome for txs that use transactional state.
* Skipping the address availability check when deploying contracts

Other changes not under a feature:
* Use the tx_hash obtained from the rpc instead of calculating it when running rpc transactions using `execute_tx_configurable`
* Move `get_fee_token_balance` method from `StateReader` to `State` trait
