### PR TITLE
Update blockifier mainnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-crypto 0.5.2",
- "starknet_api",
+ "starknet_api 0.4.1",
  "strum",
  "strum_macros",
  "thiserror",
@@ -2143,7 +2143,7 @@ dependencies = [
  "honggfuzz",
  "num-traits 0.2.17",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.1.3",
  "starknet_in_rust",
  "tempfile",
 ]
@@ -3573,7 +3573,7 @@ dependencies = [
  "clap",
  "indicatif",
  "rpc_state_reader",
- "starknet_api",
+ "starknet_api 0.1.3",
  "starknet_in_rust",
  "tracing",
  "tracing-subscriber",
@@ -3668,7 +3668,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.4.0",
  "starknet",
- "starknet_api",
+ "starknet_api 0.1.3",
  "starknet_in_rust",
  "test-case",
  "thiserror",
@@ -4374,6 +4374,24 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d01f6ae6a699818b989a1249e0748085a41f157adf317e09ce3cf2e7046e190"
+dependencies = [
+ "cairo-lang-starknet",
+ "derive_more",
+ "hex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "starknet-crypto 0.5.2",
+ "thiserror",
+]
+
+[[package]]
+name = "starknet_api"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6e445fbd6bf3826dda26fd64aa5311353b4799c9bd1119d6ec1906be4c73bf"
@@ -4423,7 +4441,7 @@ dependencies = [
  "sha3",
  "starknet",
  "starknet-crypto 0.6.1",
- "starknet_api",
+ "starknet_api 0.1.3",
  "thiserror",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,13 +720,11 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.2.0-rc0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb4d375ae4ea55963350f296c9c22f245ceff91e7c9edcd61320792901b783f"
+version = "0.1.0-rc0"
+source = "git+https://github.com/starkware-libs/blockifier?rev=256e2a6bb600963c26c43bf64c53f5b91985a290#256e2a6bb600963c26c43bf64c53f5b91985a290"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
- "cached",
  "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-runner",
@@ -746,7 +744,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-crypto 0.5.2",
- "starknet_api 0.4.1",
+ "starknet_api",
  "strum",
  "strum_macros",
  "thiserror",
@@ -805,42 +803,6 @@ checksum = "74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72"
 dependencies = [
  "bytes",
 ]
-
-[[package]]
-name = "cached"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b195e4fbc4b6862bbd065b991a34750399c119797efff72492f28a5864de8700"
-dependencies = [
- "async-trait",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown 0.13.2",
- "instant",
- "once_cell",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b48814962d2fd604c50d2b9433c2a41a0ab567779ee2c02f7fba6eca1221f082"
-dependencies = [
- "cached_proc_macro_types",
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cairo-felt"
@@ -1343,7 +1305,7 @@ dependencies = [
  "cairo-lang-casm",
  "cairo-lang-starknet",
  "generic-array",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "hex",
  "keccak",
  "lazy_static",
@@ -1423,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1433,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1757,7 +1719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.9",
@@ -1952,12 +1914,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2061,9 +2023,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -2075,27 +2037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -2103,12 +2050,6 @@ name = "futures-core"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
-
-[[package]]
-name = "futures-io"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-sink"
@@ -2143,7 +2084,7 @@ dependencies = [
  "honggfuzz",
  "num-traits 0.2.17",
  "serde_json",
- "starknet_api 0.1.3",
+ "starknet_api",
  "starknet_in_rust",
  "tempfile",
 ]
@@ -2207,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -2266,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash 0.8.6",
  "allocator-api2",
@@ -2450,9 +2391,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2526,7 +2467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -2628,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2803,7 +2744,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3126,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.5"
+version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
+checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3213,9 +3154,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -3379,12 +3320,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "once_cell",
- "toml_edit",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -3413,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3573,7 +3513,7 @@ dependencies = [
  "clap",
  "indicatif",
  "rpc_state_reader",
- "starknet_api 0.1.3",
+ "starknet_api",
  "starknet_in_rust",
  "tracing",
  "tracing-subscriber",
@@ -3631,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
  "getrandom",
@@ -3668,7 +3608,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.4.0",
  "starknet",
- "starknet_api 0.1.3",
+ "starknet_api",
  "starknet_in_rust",
  "test-case",
  "thiserror",
@@ -4374,27 +4314,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d01f6ae6a699818b989a1249e0748085a41f157adf317e09ce3cf2e7046e190"
-dependencies = [
- "cairo-lang-starknet",
- "derive_more",
- "hex",
- "indexmap 1.9.3",
- "once_cell",
- "primitive-types",
- "serde",
- "serde_json",
- "starknet-crypto 0.5.2",
- "thiserror",
-]
-
-[[package]]
-name = "starknet_api"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6e445fbd6bf3826dda26fd64aa5311353b4799c9bd1119d6ec1906be4c73bf"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/starknet-api?rev=8f620bc#8f620bcec38b47ce0f2515f3ef158f4c6319608f"
 dependencies = [
  "cairo-lang-starknet",
  "derive_more",
@@ -4441,7 +4362,7 @@ dependencies = [
  "sha3",
  "starknet",
  "starknet-crypto 0.6.1",
- "starknet_api 0.1.3",
+ "starknet_api",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -4763,19 +4684,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
- "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -4811,7 +4720,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -4832,6 +4741,17 @@ dependencies = [
  "indexmap 2.1.0",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]
@@ -4936,9 +4856,9 @@ dependencies = [
 
 [[package]]
 name = "unescaper"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96a44ae11e25afb520af4534fd7b0bd8cd613e35a78def813b8cf41631fa3c8"
+checksum = "d8f0f68e58d297ba8b22b8b5a96a87b863ba6bb46aaf51e19a4b02c5a6dd5b7f"
 dependencies = [
  "thiserror",
 ]
@@ -5002,9 +4922,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7830e33f6e25723d41a63f77e434159dad02919f18f55a512b5f16f3b1d77138"
+checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
  "base64 0.21.5",
  "flate2",
@@ -5020,9 +4940,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5090,9 +5010,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5100,9 +5020,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -5115,9 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5127,9 +5047,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5137,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5150,15 +5070,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5166,9 +5086,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "which"
@@ -5241,6 +5161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,6 +5200,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5281,6 +5225,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5295,6 +5245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5305,6 +5261,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5319,6 +5281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5329,6 +5297,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5343,6 +5317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5353,6 +5333,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ members = [
 ]
 
 [workspace.dependencies]
-cairo-lang-casm = "2.3.1"
-cairo-lang-runner = "2.3.1"
-cairo-lang-sierra = "2.3.1"
-cairo-lang-starknet = "2.3.1"
-cairo-lang-utils = "2.3.1"
-cairo-vm = { version = "0.8.5", features = ["cairo-1-hints"] }
+cairo-lang-casm = "2.4.0-rc2"
+cairo-lang-runner = "2.4.0-rc2"
+cairo-lang-sierra = "2.4.0-rc2"
+cairo-lang-starknet = "2.4.0-rc2"
+cairo-lang-utils = "2.4.0-rc2"
+cairo-vm = { version = "0.8.2", features = ["cairo-1-hints"] }
 num-traits = "0.2.15"
 starknet = "0.5.0"
-starknet_api = "0.4.1"
+starknet_api = "0.1.0"
 thiserror = "1.0.32"
 
 [dependencies]
@@ -40,7 +40,8 @@ cairo-lang-runner = { workspace = true }
 cairo-lang-sierra = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "dc3ee4a746388c1f7fcc30f097da3220a5b1d3dc", optional = true }
+# cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "dc3ee4a746388c1f7fcc30f097da3220a5b1d3dc", optional = true }
+cairo-native = { path = "../cairo_native", optional = true }
 cairo-vm = { workspace = true }
 flate2 = "1.0.25"
 getset = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ members = [
 ]
 
 [workspace.dependencies]
-cairo-lang-casm = "2.4.0-rc2"
-cairo-lang-runner = "2.4.0-rc2"
-cairo-lang-sierra = "2.4.0-rc2"
-cairo-lang-starknet = "2.4.0-rc2"
-cairo-lang-utils = "2.4.0-rc2"
+cairo-lang-casm = "2.3.1"
+cairo-lang-runner = "2.3.1"
+cairo-lang-sierra = "2.3.1"
+cairo-lang-starknet = "2.3.1"
+cairo-lang-utils = "2.3.1"
 cairo-vm = { version = "0.8.2", features = ["cairo-1-hints"] }
 num-traits = "0.2.15"
 starknet = "0.5.0"
-starknet_api = "0.1.0"
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "8f620bc" }
 thiserror = "1.0.32"
 
 [dependencies]
@@ -40,8 +40,7 @@ cairo-lang-runner = { workspace = true }
 cairo-lang-sierra = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
-# cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "dc3ee4a746388c1f7fcc30f097da3220a5b1d3dc", optional = true }
-cairo-native = { path = "../cairo_native", optional = true }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "dc3ee4a746388c1f7fcc30f097da3220a5b1d3dc", optional = true }
 cairo-vm = { workspace = true }
 flate2 = "1.0.25"
 getset = "0.1.2"

--- a/rpc_state_reader/Cargo.toml
+++ b/rpc_state_reader/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = { workspace = true }
 flate2 = "1.0.25"
 serde_with = "3.0.0"
 dotenv = "0.15.0"
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "v0.4.0-rc7" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "256e2a6bb600963c26c43bf64c53f5b91985a290" }
 starknet_in_rust = { path = "../", version = "0.4.0" }
 
 [dev-dependencies]

--- a/rpc_state_reader/Cargo.toml
+++ b/rpc_state_reader/Cargo.toml
@@ -9,13 +9,14 @@ starknet_in_rust = []
 cairo-native = ["starknet_in_rust/cairo-native"]
 
 [dependencies]
+cairo-vm = { workspace = true }
 ureq = { version = "2.7.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = [
     "arbitrary_precision",
     "raw_value",
 ] }
-starknet_api = "0.4.1"
+starknet_api = { workspace = true }
 cairo-lang-starknet = { workspace = true }
 cairo-lang-utils = { workspace = true }
 starknet = { workspace = true }
@@ -23,8 +24,7 @@ thiserror = { workspace = true }
 flate2 = "1.0.25"
 serde_with = "3.0.0"
 dotenv = "0.15.0"
-cairo-vm = { workspace = true }
-blockifier = "=0.2.0-rc0"
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "v0.4.0-rc7" }
 starknet_in_rust = { path = "../", version = "0.4.0" }
 
 [dev-dependencies]

--- a/rpc_state_reader/src/lib.rs
+++ b/rpc_state_reader/src/lib.rs
@@ -16,7 +16,6 @@ pub use sir_state_reader::{
 mod tests {
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
     use starknet_api::{
-        class_hash,
         core::{ClassHash, ContractAddress, PatriciaKey},
         hash::{StarkFelt, StarkHash},
         patricia_key, stark_felt,
@@ -35,6 +34,12 @@ mod tests {
     macro_rules! contract_address {
         ($s:expr) => {
             ContractAddress(patricia_key!($s))
+        };
+    }
+
+    macro_rules! class_hash {
+        ($s:expr) => {
+            ClassHash(stark_felt!($s))
         };
     }
 

--- a/rpc_state_reader/src/utils.rs
+++ b/rpc_state_reader/src/utils.rs
@@ -1,11 +1,12 @@
 use std::{
     collections::HashMap,
-    io::{self, Read},
+    io::{self, Read}, borrow::BorrowMut,
 };
 
 use cairo_lang_starknet::contract_class::ContractEntryPoints;
 use cairo_lang_utils::bigint::BigUintAsHex;
 use serde::Deserialize;
+use serde_json::Value;
 use starknet::core::types::{LegacyContractEntryPoint, LegacyEntryPointsByType};
 use starknet_api::{
     core::EntryPointSelector,
@@ -70,7 +71,7 @@ pub fn deserialize_transaction_json(
     let tx_type: String = serde_json::from_value(transaction["type"].clone())?;
     let tx_version: String = serde_json::from_value(transaction["version"].clone())?;
 
-    match tx_type.as_str() {
+    match dbg!(tx_type.as_str()) {
         "INVOKE" => match tx_version.as_str() {
             "0x0" => Ok(Transaction::Invoke(InvokeTransaction::V0(
                 serde_json::from_value(transaction)?,

--- a/rpc_state_reader/src/utils.rs
+++ b/rpc_state_reader/src/utils.rs
@@ -70,8 +70,7 @@ pub fn deserialize_transaction_json(
 ) -> serde_json::Result<Transaction> {
     let tx_type: String = serde_json::from_value(transaction["type"].clone())?;
     let tx_version: String = serde_json::from_value(transaction["version"].clone())?;
-    dbg!(transaction.clone());
-    match dbg!(tx_type.as_str()) {
+    match tx_type.as_str() {
         "INVOKE" => match tx_version.as_str() {
             "0x0" => Ok(Transaction::Invoke(InvokeTransaction::V0(
                 serde_json::from_value(transaction)?,

--- a/rpc_state_reader/tests/blockifier_tests.rs
+++ b/rpc_state_reader/tests/blockifier_tests.rs
@@ -344,11 +344,6 @@ fn blockifier_test_recent_tx() {
     889897, // real block 889898
     RpcChain::TestNet
 )]
-#[test_case(
-    "0x00e33abef9126a0fa34175bd5a190873b2c6494b156014a4791e0476fa6de87f",
-    299999, // real block 300000
-    RpcChain::MainNet
-)]
 fn blockifier_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number));
     let TransactionExecutionInfo {

--- a/rpc_state_reader/tests/blockifier_tests.rs
+++ b/rpc_state_reader/tests/blockifier_tests.rs
@@ -344,6 +344,11 @@ fn blockifier_test_recent_tx() {
     889897, // real block 889898
     RpcChain::TestNet
 )]
+#[test_case(
+    "0x00e33abef9126a0fa34175bd5a190873b2c6494b156014a4791e0476fa6de87f",
+    299999, // real block 300000
+    RpcChain::MainNet
+)]
 fn blockifier_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number));
     let TransactionExecutionInfo {

--- a/src/services/api/contract_classes/deprecated_contract_class.rs
+++ b/src/services/api/contract_classes/deprecated_contract_class.rs
@@ -265,7 +265,9 @@ mod tests {
         felt::{felt_str, PRIME_STR},
         serde::deserialize_program::BuiltinName,
     };
-    use starknet_api::deprecated_contract_class::{FunctionAbiEntry, TypedParameter};
+    use starknet_api::deprecated_contract_class::{
+        FunctionAbiEntry, FunctionAbiEntryType, FunctionAbiEntryWithType, TypedParameter,
+    };
 
     #[test]
     fn deserialize_contract_class() {
@@ -331,28 +333,32 @@ mod tests {
         // This specific contract compiles with --no_debug_info
         let res = ContractClass::from_path("starknet_programs/fibonacci.json");
         let contract_class = res.expect("should be able to read file");
-        let expected_abi = Some(vec![ContractClassAbiEntry::Function(FunctionAbiEntry {
-            name: "fib".to_string(),
-            inputs: vec![
-                TypedParameter {
-                    name: "first_element".to_string(),
-                    r#type: "felt".to_string(),
+        let expected_abi = Some(vec![ContractClassAbiEntry::Function(
+            FunctionAbiEntryWithType {
+                entry: FunctionAbiEntry {
+                    name: "fib".to_string(),
+                    inputs: vec![
+                        TypedParameter {
+                            name: "first_element".to_string(),
+                            r#type: "felt".to_string(),
+                        },
+                        TypedParameter {
+                            name: "second_element".to_string(),
+                            r#type: "felt".to_string(),
+                        },
+                        TypedParameter {
+                            name: "n".to_string(),
+                            r#type: "felt".to_string(),
+                        },
+                    ],
+                    outputs: vec![TypedParameter {
+                        name: "res".to_string(),
+                        r#type: "felt".to_string(),
+                    }],
                 },
-                TypedParameter {
-                    name: "second_element".to_string(),
-                    r#type: "felt".to_string(),
-                },
-                TypedParameter {
-                    name: "n".to_string(),
-                    r#type: "felt".to_string(),
-                },
-            ],
-            outputs: vec![TypedParameter {
-                name: "res".to_string(),
-                r#type: "felt".to_string(),
-            }],
-            state_mutability: None,
-        })]);
+                r#type: FunctionAbiEntryType::Function,
+            },
+        )]);
         assert_eq!(contract_class.abi, expected_abi);
     }
 

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -596,9 +596,7 @@ fn convert_invoke_v0(
     value: starknet_api::transaction::InvokeTransactionV0,
     chain_id: StarknetChainId,
 ) -> Result<InvokeFunction, TransactionError> {
-    let contract_address = Address(Felt252::from_bytes_be(
-        value.contract_address.0.key().bytes(),
-    ));
+    let contract_address = Address(Felt252::from_bytes_be(value.sender_address.0.key().bytes()));
     let max_fee = value.max_fee.0;
     let entry_point_selector = Felt252::from_bytes_be(value.entry_point_selector.0.bytes());
     let nonce = None;
@@ -685,7 +683,9 @@ mod tests {
     use starknet_api::{
         core::{ContractAddress, Nonce, PatriciaKey},
         hash::{StarkFelt, StarkHash},
-        transaction::{Fee, InvokeTransaction, InvokeTransactionV1, TransactionSignature},
+        transaction::{
+            Fee, InvokeTransaction, InvokeTransactionV1, TransactionHash, TransactionSignature,
+        },
     };
     use std::sync::Arc;
 
@@ -693,16 +693,13 @@ mod tests {
     fn test_from_invoke_transaction() {
         // https://starkscan.co/tx/0x05b6cf416d56e7c7c519b44e6d06a41657ff6c6a3f2629044fac395e6d200ac4
         // result 0x05b6cf416d56e7c7c519b44e6d06a41657ff6c6a3f2629044fac395e6d200ac4
+        let tx_hash = StarkHash::try_from(
+            "0x05b6cf416d56e7c7c519b44e6d06a41657ff6c6a3f2629044fac395e6d200ac4",
+        )
+        .unwrap();
         let tx = InvokeTransaction::V1(InvokeTransactionV1 {
-            sender_address: ContractAddress(
-                PatriciaKey::try_from(
-                    StarkHash::try_from(
-                        "0x00c4658311841a69ce121543af332622bc243cf5593fc4aaf822481c7b7f183d",
-                    )
-                    .unwrap(),
-                )
-                .unwrap(),
-            ),
+            sender_address: ContractAddress(PatriciaKey::try_from(tx_hash).unwrap()),
+            transaction_hash: TransactionHash(tx_hash),
             max_fee: Fee(49000000000000),
             signature: TransactionSignature(vec![
                 StarkFelt::try_from(

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -694,7 +694,7 @@ mod tests {
         // https://starkscan.co/tx/0x05b6cf416d56e7c7c519b44e6d06a41657ff6c6a3f2629044fac395e6d200ac4
         // result 0x05b6cf416d56e7c7c519b44e6d06a41657ff6c6a3f2629044fac395e6d200ac4
         let tx_hash = StarkHash::try_from(
-            "0x05b6cf416d56e7c7c519b44e6d06a41657ff6c6a3f2629044fac395e6d200ac4",
+            "0x00c4658311841a69ce121543af332622bc243cf5593fc4aaf822481c7b7f183d",
         )
         .unwrap();
         let tx = InvokeTransaction::V1(InvokeTransactionV1 {


### PR DESCRIPTION
# TITLE

## Description

This PR aims to use the production version of blockifier, this crate depends on an old cairo-vm version. The next changes introduced in the current vm version will be lost: 


* fix: `Program` comparison depending on `hints_ranges` ordering [#1351](https://github.com/lambdaclass/cairo-rs/pull/1351)

* feat: implement the `--air_public_input` flag to the runner for outputting public inputs into a file [#1268](https://github.com/lambdaclass/cairo-rs/pull/1268)

* fix: CLI errors bad formatting and handling

* perf: replace insertion with bit-setting in validated addresses [#1208](https://github.com/lambdaclass/cairo-vm/pull/1208)

* fix: return error when a parsed hint's PC is invalid [#1340](https://github.com/lambdaclass/cairo-vm/pull/1340)

* chore(deps): bump _cairo-lang_ dependencies to v2.1.0-rc2 [#1345](https://github.com/lambdaclass/cairo-vm/pull/1345)

* chore(examples): remove _wee_alloc_ dependency from _wasm-demo_ example and _ensure-no_std_ dummy crate [#1337](https://github.com/lambdaclass/cairo-vm/pull/1337)

* docs: improved crate documentation [#1334](https://github.com/lambdaclass/cairo-vm/pull/1334)

* chore!: made `deserialize_utils` module private [#1334](https://github.com/lambdaclass/cairo-vm/pull/1334)
  BREAKING:
  * `deserialize_utils` is no longer exported
  * functions `maybe_add_padding`, `parse_value`, and `take_until_unbalanced` are no longer exported
  * `ReferenceParseError` is no more

* perf: changed `ok_or` usage for `ok_or_else` in expensive cases [#1332](https://github.com/lambdaclass/cairo-vm/pull/1332)

* feat: updated the old WASM example and moved it to [`examples/wasm-demo`](examples/wasm-demo/) [#1315](https://github.com/lambdaclass/cairo-vm/pull/1315)

* feat(fuzzing): add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig` [#1306](https://github.com/lambdaclass/cairo-vm/pull/1306) [#1330](https://github.com/lambdaclass/cairo-vm/pull/1330)

* perf: remove pointless iterator from rc limits tracking [#1316](https://github.com/lambdaclass/cairo-vm/pull/1316)

* feat(felt): add `from_bytes_le` and `from_bytes_ne` methods to `Felt252` [#1326](https://github.com/lambdaclass/cairo-vm/pull/1326)

* perf: change `Program::shared_program_data::hints` from `HashMap<usize, Vec<Box<dyn Any>>>` to `Vec<Box<dyn Any>>` and refer to them as ranges stored in a `Vec<_>` indexed by PC with run time reductions of up to 12% [#931](https://github.com/lambdaclass/cairo-vm/pull/931)
  BREAKING:
  * `get_hint_dictionary(&self, &[HintReference], &mut dyn HintProcessor) -> Result<HashMap<usize, Vec<Box<dyn Any>>, VirtualMachineError>` ->
    `get_hint_data(self, &[HintReference], &mut dyn HintProcessor) -> Result<Vec<Box<dyn Any>, VirtualMachineError>`
  * Hook methods receive `&[Box<dyn Any>]` rather than `&HashMap<usize, Vec<Box<dyn Any>>>`
  
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
