### PR TITLE
Add `LLVM_SYS_170_PREFIX` export to Cairo Native support section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Starknet in Rust can be integrated with [Cairo Native](https://github.com/lambda
   ```
   brew install llvm@17
   export MLIR_SYS_170_PREFIX=/opt/homebrew/opt/llvm@17
+  export LLVM_SYS_170_PREFIX=/opt/homebrew/opt/llvm@17
   export TABLEGEN_170_PREFIX=/opt/homebrew/opt/llvm@17
   ```
   and you're set.


### PR DESCRIPTION
This env var is also needed when running with the `cairo-native` feature
