### PR TITLE
Improve error handling

### DIFF
--- a/rpc_state_reader/src/rpc_state.rs
+++ b/rpc_state_reader/src/rpc_state.rs
@@ -394,8 +394,8 @@ impl RpcState {
         let result = self
             .rpc_call::<serde_json::Value>("starknet_traceTransaction", &json!([hash.to_string()]))?
             .get("result")
-            .ok_or(RpcStateError::RpcCall(
-                "Response has no field result".into(),
+            .ok_or(RpcStateError::MissingRpcResponseField(
+                "result".into(),
             ))?
             .clone();
         serde_json::from_value(result).map_err(|e| RpcStateError::Request(e.to_string()))
@@ -409,8 +409,8 @@ impl RpcState {
                 &json!([hash.to_string()]),
             )?
             .get("result")
-            .ok_or(RpcStateError::RpcCall(
-                "Response has no field result".into(),
+            .ok_or(RpcStateError::MissingRpcResponseField(
+                "result".into(),
             ))?
             .clone();
         utils::deserialize_transaction_json(result).map_err(RpcStateError::SerdeJson)
@@ -424,16 +424,16 @@ impl RpcState {
                 &json!({"block_id" : { "block_number": block_number }}),
             )?
             .get("result")
-            .ok_or(RpcStateError::RpcCall(
-                "Response has no field result".into(),
+            .ok_or(RpcStateError::MissingRpcResponseField(
+                "result".into(),
             ))?
             .clone();
         let gas_price_hex = res
             .get("l1_gas_price")
             .and_then(|gp| gp.get("price_in_wei"))
             .and_then(|gp| gp.as_str())
-            .ok_or(RpcStateError::Request(
-                "Response has no field gas_price".to_string(),
+            .ok_or(RpcStateError::MissingRpcResponseField(
+                "gas_price".to_string(),
             ))?;
         let gas_price =
             u128::from_str_radix(gas_price_hex.trim_start_matches("0x"), 16).map_err(|_| {

--- a/rpc_state_reader/src/rpc_state.rs
+++ b/rpc_state_reader/src/rpc_state.rs
@@ -372,7 +372,9 @@ impl RpcState {
             .set("Content-Type", "application/json")
             .set("accept", "application/json")
             .send_json(params)
-            .map_err(|err| RpcStateError::Request(err.to_string()))
+            .map_err(|err| if err.to_string().contains("request failed or timed out through") { 
+                RpcStateError::RpcConnectionNotAvailable 
+            } else { RpcStateError::Request(err.to_string())})
     }
 
     fn deserialize_call<T: for<'a> Deserialize<'a>>(

--- a/rpc_state_reader/src/rpc_state.rs
+++ b/rpc_state_reader/src/rpc_state.rs
@@ -8,6 +8,7 @@ use cairo_vm::vm::runners::{
 };
 use core::fmt;
 use dotenv::dotenv;
+use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_json::json;
 use starknet::core::types::ContractClass as SNContractClass;
@@ -210,7 +211,7 @@ where
     let n_steps_str: String = serde_json::from_value(
         value
             .get("steps")
-            .ok_or(serde::de::Error::custom("Missing field steps"))?
+            .ok_or(serde::de::Error::custom(RpcStateError::MissingRpcResponseField("steps".to_string())))?
             .clone(),
     )
     .map_err(|e| serde::de::Error::custom(e.to_string()))?;
@@ -221,7 +222,7 @@ where
     let n_memory_holes_str: String = serde_json::from_value(
         value
             .get("memory_holes")
-            .ok_or(serde::de::Error::custom("Missing field memory_holes"))?
+            .ok_or(serde::de::Error::custom(RpcStateError::MissingRpcResponseField("memory_holes".to_string())))?
             .clone(),
     )
     .map_err(|e| serde::de::Error::custom(e.to_string()))?;
@@ -276,7 +277,7 @@ impl<'de> Deserialize<'de> for RpcCallInfo {
         // Parse retdata
         let retdata_value = value
             .get("result")
-            .ok_or(serde::de::Error::custom("Missing field result"))?
+            .ok_or(serde::de::Error::custom(RpcStateError::MissingRpcResponseField("result".to_string())))?
             .clone();
         let retdata = serde_json::from_value(retdata_value)
             .map_err(|e| serde::de::Error::custom(e.to_string()))?;
@@ -284,7 +285,7 @@ impl<'de> Deserialize<'de> for RpcCallInfo {
         // Parse calldata
         let calldata_value = value
             .get("calldata")
-            .ok_or(serde::de::Error::custom("Missing field calldata"))?
+            .ok_or(serde::de::Error::custom(RpcStateError::MissingRpcResponseField("calldata".to_string())))?
             .clone();
         let calldata = serde_json::from_value(calldata_value)
             .map_err(|e| serde::de::Error::custom(e.to_string()))?;
@@ -292,14 +293,14 @@ impl<'de> Deserialize<'de> for RpcCallInfo {
         // Parse internal calls
         let internal_calls_value = value
             .get("calls")
-            .ok_or(serde::de::Error::custom("Missing field calls"))?
+            .ok_or(serde::de::Error::custom(RpcStateError::MissingRpcResponseField("calls".to_string())))?
             .clone();
         let mut internal_calls = vec![];
 
         for call in internal_calls_value
             .as_array()
             .ok_or(serde::de::Error::custom(
-                "Wrong type for field internal_calls",
+                RpcStateError::RpcResponseWrongType("internal_calls".to_string())
             ))?
         {
             internal_calls
@@ -437,7 +438,7 @@ impl RpcState {
             ))?;
         let gas_price =
             u128::from_str_radix(gas_price_hex.trim_start_matches("0x"), 16).map_err(|_| {
-                RpcStateError::Request("Response field gas_price has wrong type".to_string())
+                RpcStateError::RpcResponseWrongType("gas_price".to_string())
             })?;
         Ok(gas_price)
     }

--- a/rpc_state_reader/src/rpc_state.rs
+++ b/rpc_state_reader/src/rpc_state.rs
@@ -8,7 +8,6 @@ use cairo_vm::vm::runners::{
 };
 use core::fmt;
 use dotenv::dotenv;
-use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_json::json;
 use starknet::core::types::ContractClass as SNContractClass;

--- a/rpc_state_reader/src/rpc_state_errors.rs
+++ b/rpc_state_reader/src/rpc_state_errors.rs
@@ -21,5 +21,7 @@ pub enum RpcStateError {
     #[error("The service is down")]
     RpcConnectionNotAvailable,
     #[error("The response does not have a field named '{0}'")]
-    MissingRpcResponseField(String)
+    MissingRpcResponseField(String),
+    #[error("Wrong type for response field '{0}'")]
+    RpcResponseWrongType(String)
 }

--- a/rpc_state_reader/src/rpc_state_errors.rs
+++ b/rpc_state_reader/src/rpc_state_errors.rs
@@ -21,5 +21,5 @@ pub enum RpcStateError {
     #[error("The service is down")]
     RpcConnectionNotAvailable,
     #[error("The response does not have a field named '{0}'")]
-    RpcResponseMissingField(String)
+    MissingRpcResponseField(String)
 }

--- a/rpc_state_reader/src/rpc_state_errors.rs
+++ b/rpc_state_reader/src/rpc_state_errors.rs
@@ -18,4 +18,8 @@ pub enum RpcStateError {
     RpcObjectHasNoField(String, String),
     #[error("Failed to convert StarkFelt to PatriciaKey")]
     StarkFeltToParticiaKeyConversion,
+    #[error("The service is down")]
+    RpcConnectionNotAvailable,
+    #[error("The response does not have a field named '{0}'")]
+    RpcResponseMissingField(String)
 }


### PR DESCRIPTION
# Improving Error Handling

## Description

Error handling for RPC has been improved: A new error type has been added for when a field is missing in the response, for when the return type of a field is incorrect and for when the service is not available.

## Checklist
- [x] Add an specific error case for handling when we can't connect to the RPC [fixed adding RpcConnectionNotAvailable].
- [x] Add an specific error case for handling when the response is not as expected [fixed adding MissingRpcResponseField and RpcResponseWrongType].
