### PR TITLE
Fix Goerli testnet tests

### DIFF
--- a/rpc_state_reader/tests/blockifier_tests.rs
+++ b/rpc_state_reader/tests/blockifier_tests.rs
@@ -329,9 +329,9 @@ fn blockifier_test_recent_tx() {
     RpcChain::MainNet
 )]
 #[test_case(
-    "0x1cbc74e101a1533082a021ce53235cfd744899b0ff948d1949a64646e0f15c2",
-    885298, // real block 885299
-    RpcChain::TestNet
+    "0x04db9b88e07340d18d53b8b876f28f449f77526224afb372daaf1023c8b08036",
+    398051, // real block 398052
+    RpcChain::MainNet
 )]
 #[test_case(
     "0x5a5de1f42f6005f3511ea6099daed9bcbcf9de334ee714e8563977e25f71601",
@@ -352,21 +352,15 @@ fn blockifier_test_recent_tx() {
 // All of them were deployed on testnet using starkli
 // OpenZeppelin (v0.7.0)
 #[test_case(
-    "0x0012696c03a0f0301af190288d9824583be813b71882308e4c5d686bf5967ec5",
-    889866, // real block 889867
-    RpcChain::TestNet
-)]
-// Braavos (v3.21.10)
-#[test_case(
-    "0x04dc838fd4ed265ab2ea5fbab08e67b398e3caaedf75c548113c6b2f995fc9db",
-    889858, // real block 889859
-    RpcChain::TestNet
+    "0x04df8a364233d995c33c7f4666a776bf458631bec2633e932b433a783db410f8",
+    422881, // real block 422882
+    RpcChain::MainNet
 )]
 // Argent X (v5.7.0)
 #[test_case(
-    "0x01583c47a929f81f6a8c74d31708a7f161603893435d51b6897017fdcdaafee4",
-    889897, // real block 889898
-    RpcChain::TestNet
+    "0x039683c034f8e67cfb4af6e3109cefb3c170ee15ceacf07ee2d926915c4620e5",
+    475945, // real block 475946
+    RpcChain::MainNet
 )]
 fn blockifier_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number));

--- a/rpc_state_reader/tests/blockifier_tests.rs
+++ b/rpc_state_reader/tests/blockifier_tests.rs
@@ -348,8 +348,8 @@ fn blockifier_test_recent_tx() {
     351225, // real block 351226
     RpcChain::MainNet
 )]
-// DeployAccount for different account providers (as of October 2023):
-// All of them were deployed on testnet using starkli
+// DeployAccount for different account providers:
+
 // OpenZeppelin (v0.7.0)
 #[test_case(
     "0x04df8a364233d995c33c7f4666a776bf458631bec2633e932b433a783db410f8",

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -120,13 +120,13 @@ fn test_get_gas_price() {
     351225, // real block 351226
     RpcChain::MainNet
 )]
-// DeployAccount for different account providers (as of October 2023):
-// All of them were deployed on testnet using starkli
+// DeployAccount for different account providers:
+
 // OpenZeppelin (v0.7.0)
 #[test_case(
-    "0x0012696c03a0f0301af190288d9824583be813b71882308e4c5d686bf5967ec5",
-    889866, // real block 889867
-    RpcChain::TestNet
+    "0x04df8a364233d995c33c7f4666a776bf458631bec2633e932b433a783db410f8",
+    422881, // real block 422882
+    RpcChain::MainNet
 )]
 // Braavos (v3.21.10)
 #[test_case(
@@ -136,14 +136,9 @@ fn test_get_gas_price() {
 )]
 // Argent X (v5.7.0)
 #[test_case(
-    "0x01583c47a929f81f6a8c74d31708a7f161603893435d51b6897017fdcdaafee4",
-    889897, // real block 889898
-    RpcChain::TestNet
-)]
-#[test_case(
-    "0x037e199c9560666d810862bc0cf62a67aae33af6b65823068143640cdeecd8ab",
-    895707, // real block 895708
-    RpcChain::TestNet
+    "0x039683c034f8e67cfb4af6e3109cefb3c170ee15ceacf07ee2d926915c4620e5",
+    475945, // real block 889898
+    RpcChain::MainNet
 )]
 fn starknet_in_rust_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number)).unwrap();

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -204,12 +204,6 @@ fn starknet_in_rust_test_case_tx(hash: &str, block_number: u64, chain: RpcChain)
     197000,
     3
 )]
-#[test_case(
-    "0x037e199c9560666d810862bc0cf62a67aae33af6b65823068143640cdeecd8ab",
-    RpcChain::TestNet,
-    895707,
-    1
-)]
 fn test_sorted_events(
     tx_hash: &str,
     chain: RpcChain,
@@ -367,14 +361,9 @@ fn starknet_in_rust_test_case_tx_skip_nonce_check(hash: &str, block_number: u64,
 }
 
 #[test_case(
-    "0x037e199c9560666d810862bc0cf62a67aae33af6b65823068143640cdeecd8ab",
-    895707, // real block 895708
-    RpcChain::TestNet
-)]
-#[test_case(
-    "0x048ffc49f04504710e984923980fb63c4f17fb3022467251329adc75aae93c4b",
-    900795, // real block 900796
-    RpcChain::TestNet
+    "0x05ee0cd7be18a4f8a2d6845a9960c0573318393122fe392c5d156eb460beff21",
+    422346, // real block 422347
+    RpcChain::MainNet
 )]
 fn starknet_in_rust_check_fee_and_retdata(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) = execute_tx(hash, chain, BlockNumber(block_number)).unwrap();

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -128,16 +128,10 @@ fn test_get_gas_price() {
     422881, // real block 422882
     RpcChain::MainNet
 )]
-// Braavos (v3.21.10)
-#[test_case(
-    "0x04dc838fd4ed265ab2ea5fbab08e67b398e3caaedf75c548113c6b2f995fc9db",
-    889858, // real block 889859
-    RpcChain::TestNet
-)]
 // Argent X (v5.7.0)
 #[test_case(
     "0x039683c034f8e67cfb4af6e3109cefb3c170ee15ceacf07ee2d926915c4620e5",
-    475945, // real block 889898
+    475945, // real block 475946
     RpcChain::MainNet
 )]
 fn starknet_in_rust_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -101,9 +101,9 @@ fn test_get_gas_price() {
     RpcChain::MainNet
 )]
 #[test_case(
-    "0x1cbc74e101a1533082a021ce53235cfd744899b0ff948d1949a64646e0f15c2",
-    885298, // real block 885299
-    RpcChain::TestNet
+    "0x04db9b88e07340d18d53b8b876f28f449f77526224afb372daaf1023c8b08036",
+    398051, // real block 398052
+    RpcChain::MainNet
 )]
 #[test_case(
     "0x5a5de1f42f6005f3511ea6099daed9bcbcf9de334ee714e8563977e25f71601",
@@ -321,9 +321,9 @@ fn starknet_in_rust_test_case_declare_tx(hash: &str, block_number: u64, chain: R
 }
 
 #[test_case(
-    "0x05dc2a26a65b0fc9e8cb17d8b3e9142abdb2b2d2dd2f3eb275256f23bddfc9f2",
-    899787, // real block 899788
-    RpcChain::TestNet
+    "0x0200b493df8310215b188343f227dd1894c9edda597465cb336d25610172c701",
+    470061, // real block 470062
+    RpcChain::MainNet
 )]
 fn starknet_in_rust_test_case_tx_skip_nonce_check(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info, trace, receipt) =


### PR DESCRIPTION
# Fix Goerli testnet tests

Since Goerli testnet is not available any more, we change the tx test to mainnet ones

Removed the tx tests:
* 0x04dc838fd4ed265ab2ea5fbab08e67b398e3caaedf75c548113c6b2f995fc9db, deploy tx that is no longer supported
* 0x037e199c9560666d810862bc0cf62a67aae33af6b65823068143640cdeecd8ab, 0x04ef5afaba2c2b1af9718e03c83176a6f9f0bd19988f4c24b6de55d41d3b9ee1, invoke tx of a contract that is not deployed in mainnet

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
