### PR TITLE
Make `RpcState` compatible with version 0.6.0 of Starknet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Run the following command:
 ```bash
 $ make test
 ```
-Take into account that some tests use the [RPC State Reader](#rpc-state-reader) so you need a full-node instance or an RPC provider that supports Starknet API version 0.5.0.
+Take into account that some tests use the [RPC State Reader](#rpc-state-reader) so you need a full-node instance or an RPC provider that supports Starknet API version 0.6.0.
 
 ### RPC State Reader
 

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -291,7 +291,10 @@ fn show_execution_data(tx_hash: String, chain: &str, block_number: u64, silent: 
         if let Some(revert_error) = revert_error {
             println!("[SIR] Revert error: {}", revert_error);
         }
-        println!("[RPC] Actual fee: {} {}", actual_fee.amount, actual_fee.unit);
+        println!(
+            "[RPC] Actual fee: {} {}",
+            actual_fee.amount, actual_fee.unit
+        );
         println!("[SIR] Actual fee: {} wei", sir_actual_fee);
     }
 }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -291,7 +291,7 @@ fn show_execution_data(tx_hash: String, chain: &str, block_number: u64, silent: 
         if let Some(revert_error) = revert_error {
             println!("[SIR] Revert error: {}", revert_error);
         }
-        println!("[RPC] Actual fee: {} wei", actual_fee);
+        println!("[RPC] Actual fee: {} {}", actual_fee.amount, actual_fee.unit);
         println!("[SIR] Actual fee: {} wei", sir_actual_fee);
     }
 }

--- a/rpc_state_reader/src/rpc_state.rs
+++ b/rpc_state_reader/src/rpc_state.rs
@@ -225,8 +225,9 @@ where
     .map_err(|e| serde::de::Error::custom(e.to_string()))?;
 
     // Parse n_memory_holes
-    let n_memory_holes: usize = if let Some(memory_holes) = value.get("memory_holes"){
-        serde_json::from_value(memory_holes.clone()).map_err(|e| serde::de::Error::custom(e.to_string()))?
+    let n_memory_holes: usize = if let Some(memory_holes) = value.get("memory_holes") {
+        serde_json::from_value(memory_holes.clone())
+            .map_err(|e| serde::de::Error::custom(e.to_string()))?
     } else {
         0
     };

--- a/rpc_state_reader/tests/blockifier_tests.rs
+++ b/rpc_state_reader/tests/blockifier_tests.rs
@@ -266,7 +266,7 @@ fn blockifier_test_recent_tx() {
         ..
     } = execute_call_info.unwrap();
 
-    assert_eq!(actual_fee.0, receipt.actual_fee);
+    assert_eq!(actual_fee.0, receipt.actual_fee.amount);
     assert_eq!(
         vm_resources.n_memory_holes,
         receipt.execution_resources.n_memory_holes
@@ -385,12 +385,12 @@ fn blockifier_test_case_tx(hash: &str, block_number: u64, chain: RpcChain) {
     } = execute_call_info.unwrap();
 
     let actual_fee = actual_fee.0;
-    if receipt.actual_fee != actual_fee {
-        let diff = 100 * receipt.actual_fee.abs_diff(actual_fee) / receipt.actual_fee;
+    if receipt.actual_fee.amount != actual_fee {
+        let diff = 100 * receipt.actual_fee.amount.abs_diff(actual_fee) / receipt.actual_fee.amount;
 
         if diff >= 5 {
             assert_eq!(
-                actual_fee, receipt.actual_fee,
+                actual_fee, receipt.actual_fee.amount,
                 "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
             );
         }
@@ -436,11 +436,12 @@ fn blockifier_test_case_reverted_tx(hash: &str, block_number: u64, chain: RpcCha
         trace.execute_invocation.unwrap().revert_reason.is_some()
     );
 
-    let diff = 100 * receipt.actual_fee.abs_diff(tx_info.actual_fee.0) / receipt.actual_fee;
+    let diff =
+        100 * receipt.actual_fee.amount.abs_diff(tx_info.actual_fee.0) / receipt.actual_fee.amount;
 
     if diff >= 5 {
         assert_eq!(
-            tx_info.actual_fee.0, receipt.actual_fee,
+            tx_info.actual_fee.0, receipt.actual_fee.amount,
             "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
         );
     }
@@ -469,12 +470,12 @@ fn blockifier_test_case_declare_tx(hash: &str, block_number: u64, chain: RpcChai
     assert!(execute_call_info.is_none());
 
     let actual_fee = actual_fee.0;
-    if receipt.actual_fee != actual_fee {
-        let diff = 100 * receipt.actual_fee.abs_diff(actual_fee) / receipt.actual_fee;
+    if receipt.actual_fee.amount != actual_fee {
+        let diff = 100 * receipt.actual_fee.amount.abs_diff(actual_fee) / receipt.actual_fee.amount;
 
         if diff >= 5 {
             assert_eq!(
-                actual_fee, receipt.actual_fee,
+                actual_fee, receipt.actual_fee.amount,
                 "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
             );
         }

--- a/rpc_state_reader/tests/sir_tests.rs
+++ b/rpc_state_reader/tests/sir_tests.rs
@@ -169,12 +169,12 @@ fn starknet_in_rust_test_case_tx(hash: &str, block_number: u64, chain: RpcChain)
     );
 
     // check actual fee calculation
-    if receipt.actual_fee != actual_fee {
-        let diff = 100 * receipt.actual_fee.abs_diff(actual_fee) / receipt.actual_fee;
+    if receipt.actual_fee.amount != actual_fee {
+        let diff = 100 * receipt.actual_fee.amount.abs_diff(actual_fee) / receipt.actual_fee.amount;
 
         if diff >= 5 {
             assert_eq!(
-                actual_fee, receipt.actual_fee,
+                actual_fee, receipt.actual_fee.amount,
                 "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
             );
         }
@@ -250,11 +250,12 @@ fn starknet_in_rust_test_case_reverted_tx(hash: &str, block_number: u64, chain: 
         trace.execute_invocation.unwrap().revert_reason.is_some()
     );
 
-    let diff = 100 * receipt.actual_fee.abs_diff(tx_info.actual_fee) / receipt.actual_fee;
+    let diff =
+        100 * receipt.actual_fee.amount.abs_diff(tx_info.actual_fee) / receipt.actual_fee.amount;
 
     if diff >= 5 {
         assert_eq!(
-            tx_info.actual_fee, receipt.actual_fee,
+            tx_info.actual_fee, receipt.actual_fee.amount,
             "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
         );
     }
@@ -270,7 +271,7 @@ fn test_validate_fee(hash: &str, block_number: u64, chain: RpcChain) {
     let (tx_info_without_fee, _trace, _receipt) =
         execute_tx_without_validate(hash, chain, BlockNumber(block_number)).unwrap();
 
-    assert_eq!(tx_info.actual_fee, receipt.actual_fee);
+    assert_eq!(tx_info.actual_fee, receipt.actual_fee.amount);
     assert!(tx_info_without_fee.actual_fee < tx_info.actual_fee);
 }
 
@@ -297,12 +298,12 @@ fn starknet_in_rust_test_case_declare_tx(hash: &str, block_number: u64, chain: R
     assert!(call_info.is_none());
 
     let actual_fee = actual_fee;
-    if receipt.actual_fee != actual_fee {
-        let diff = 100 * receipt.actual_fee.abs_diff(actual_fee) / receipt.actual_fee;
+    if receipt.actual_fee.amount != actual_fee {
+        let diff = 100 * receipt.actual_fee.amount.abs_diff(actual_fee) / receipt.actual_fee.amount;
 
         if diff >= 5 {
             assert_eq!(
-                actual_fee, receipt.actual_fee,
+                actual_fee, receipt.actual_fee.amount,
                 "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
             );
         }
@@ -349,12 +350,12 @@ fn starknet_in_rust_test_case_tx_skip_nonce_check(hash: &str, block_number: u64,
     );
 
     // check actual fee calculation
-    if receipt.actual_fee != actual_fee {
-        let diff = 100 * receipt.actual_fee.abs_diff(actual_fee) / receipt.actual_fee;
+    if receipt.actual_fee.amount != actual_fee {
+        let diff = 100 * receipt.actual_fee.amount.abs_diff(actual_fee) / receipt.actual_fee.amount;
 
         if diff >= 5 {
             assert_eq!(
-                actual_fee, receipt.actual_fee,
+                actual_fee, receipt.actual_fee.amount,
                 "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
             );
         }
@@ -377,12 +378,12 @@ fn starknet_in_rust_check_fee_and_retdata(hash: &str, block_number: u64, chain: 
     let CallInfo { retdata, .. } = call_info.unwrap();
 
     // check actual fee calculation
-    if receipt.actual_fee != actual_fee {
-        let diff = 100 * receipt.actual_fee.abs_diff(actual_fee) / receipt.actual_fee;
+    if receipt.actual_fee.amount != actual_fee {
+        let diff = 100 * receipt.actual_fee.amount.abs_diff(actual_fee) / receipt.actual_fee.amount;
 
         if diff >= 5 {
             assert_eq!(
-                actual_fee, receipt.actual_fee,
+                actual_fee, receipt.actual_fee.amount,
                 "actual_fee mismatch differs from the baseline by more than 5% ({diff}%)",
             );
         }


### PR DESCRIPTION
CI is currently failing as the juno instance used for testing was updated and uses an updated version of the rpc spec
