### PR TITLE
[0.13] Move handle_nonce call before check_fee_balance in DeployAccount, Declare & InvokeFunction txs

### DIFF
--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -388,11 +388,12 @@ impl Declare {
                 vec![0, 1],
             ));
         }
+
+        self.handle_nonce(state)?;
+
         if !self.skip_fee_transfer {
             self.check_fee_balance(state, block_context)?;
         }
-
-        self.handle_nonce(state)?;
 
         let mut tx_exec_info = self.apply(
             state,

--- a/src/transaction/declare_v2.rs
+++ b/src/transaction/declare_v2.rs
@@ -374,11 +374,11 @@ impl DeclareV2 {
             ));
         }
 
+        self.handle_nonce(state)?;
+
         if !self.skip_fee_transfer {
             self.check_fee_balance(state, block_context)?;
         }
-
-        self.handle_nonce(state)?;
 
         let mut resources_manager = ExecutionResourcesManager::default();
 

--- a/src/transaction/deploy_account.rs
+++ b/src/transaction/deploy_account.rs
@@ -202,11 +202,11 @@ impl DeployAccount {
             ));
         }
 
+        self.handle_nonce(state)?;
+
         if !self.skip_fee_transfer {
             self.check_fee_balance(state, block_context)?;
         }
-
-        self.handle_nonce(state)?;
 
         let mut transactional_state = state.create_transactional()?;
         let tx_exec_info = self.apply(

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -379,11 +379,11 @@ impl InvokeFunction {
             ));
         }
 
+        self.handle_nonce(state)?;
+
         if !self.skip_fee_transfer {
             self.check_fee_balance(state, block_context)?;
         }
-
-        self.handle_nonce(state)?;
 
         let mut transactional_state = state.create_transactional()?;
 


### PR DESCRIPTION
# Move handle_nonce

Move handle_nonce call before check_fee_balance in DeployAccount, Declare, DeclareV2 and InvokeFunction txs

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
