### PR TITLE
Sandboxed Fallback

### DIFF
--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -189,6 +189,9 @@ impl ExecutionEntryPoint {
                             n_reverted_steps: 0,
                         })
                     },
+                    Err(TransactionError::SandboxError(e)) => {
+                        match e
+                    }
                     Err(e) => {
                         if !support_reverted {
                             state.apply_state_update(&StateDiff::from_cached_state(
@@ -741,15 +744,14 @@ impl ExecutionEntryPoint {
         };
 
         let value = if let Some(sandbox) = sandbox {
-            sandbox
-                .run_program(
-                    *class_hash,
-                    sierra_program.clone(),
-                    self.calldata.clone(),
-                    Some(self.initial_gas),
-                    entry_point.function_idx,
-                    &mut syscall_handler,
-                )?
+            sandbox.run_program(
+                *class_hash,
+                sierra_program.clone(),
+                self.calldata.clone(),
+                Some(self.initial_gas),
+                entry_point.function_idx,
+                &mut syscall_handler,
+            )?
         } else {
             let native_executor: NativeExecutor = {
                 let mut cache = program_cache.borrow_mut();

--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -157,9 +157,9 @@ impl ExecutionEntryPoint {
                 })
             }
             #[cfg(feature = "cairo-native")]
-            casm@CompiledClass::Casm {
+            CompiledClass::Casm {
                 sierra: Some(sierra_program_and_entrypoints),
-                ..
+                casm
             } => {
                 let mut transactional_state = state.create_transactional()?;
 
@@ -189,14 +189,13 @@ impl ExecutionEntryPoint {
                             n_reverted_steps: 0,
                         })
                     },
-                    Err(TransactionError::SandboxError(e)) => {
-                       // See contract class
+                    Err(TransactionError::SandboxError(_)) => {
                         match self._execute(
                             state,
                             resources_manager,
                             block_context,
                             tx_execution_context,
-                            contract_class,
+                            casm,
                             class_hash,
                             support_reverted,
                         ) {


### PR DESCRIPTION
# Sandbox_Fallback

## Description

The change implements a fallback mechanism, if the sandboxed cairo_native fails, the cairoVM should run instead.

## Checklist
- [N/A] Linked to Github Issue
- [  ] Unit tests added
- [  ] Integration tests added.
- [N/A] This change requires new documentation.
- [N/A] Documentation has been added/updated.
