### PR TITLE
Fix CI coverage step: remove nightly

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -169,10 +169,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Install Rust nightly
-      uses: dtolnay/rust-toolchain@master
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@1.70.0
       with:
-        toolchain: nightly
+          components: llvm-tools-preview
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ coverage: compile-cairo compile-starknet compile-cairo-1-casm compile-cairo-2-ca
 	$(MAKE) coverage-report
 
 coverage-report: compile-cairo compile-starknet compile-cairo-1-casm compile-cairo-1-sierra compile-cairo-2-casm compile-cairo-2-sierra
-	cargo +nightly llvm-cov nextest --lcov --ignore-filename-regex 'main.rs' --output-path lcov.info --release
+	cargo llvm-cov nextest --lcov --ignore-filename-regex 'main.rs' --output-path lcov.info --release
 
 heaptrack:
 	./scripts/heaptrack.sh


### PR DESCRIPTION
The CI is currently broken due to a failure in the coverage job
This PR fixes it by running the coverage generation in stable rust and not nightly