### PR TITLE
Implement  `ClassHash::from_hex_string`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,6 +79,12 @@ impl PartialEq<[u8; 32]> for ClassHash {
     }
 }
 
+impl ClassHash {
+    pub fn from_hex_string(hex_string: String) -> Option<Self> {
+        Some(Self(hex::decode(hex_string).ok()?.try_into().ok()?))
+    }
+}
+
 pub type CompiledClassHash = ClassHash;
 
 #[cfg(feature = "cairo-native")]


### PR DESCRIPTION
Closes #1222 :

- [x] Implement Debug and Display for ClassHash so we can see it as an hexadecimal value. (Already in main before this PR)

- [x] Also we should be able to create a new ClassHash from a hex string 
