### PR TITLE
Include the entry point selector in `EntryPointNotFound` error

### DIFF
--- a/src/execution/execution_entry_point.rs
+++ b/src/execution/execution_entry_point.rs
@@ -269,7 +269,9 @@ impl ExecutionEntryPoint {
         entry_point
             .or(default_entry_point)
             .cloned()
-            .ok_or(TransactionError::EntryPointNotFound)
+            .ok_or(TransactionError::EntryPointNotFound(
+                self.entry_point_selector,
+            ))
     }
 
     // Returns the entry point with selector corresponding with self.entry_point_selector, or the
@@ -302,7 +304,9 @@ impl ExecutionEntryPoint {
         entry_point
             .or(default_entry_point)
             .cloned()
-            .ok_or(TransactionError::EntryPointNotFound)
+            .ok_or(TransactionError::EntryPointNotFound(
+                self.entry_point_selector,
+            ))
     }
 
     /// Constructs a CallInfo object for deprecated contract classes.

--- a/src/transaction/error.rs
+++ b/src/transaction/error.rs
@@ -80,8 +80,8 @@ pub enum TransactionError {
     NotDeployedContract(ClassHash),
     #[error("Non-unique entry points are not possible in a ContractClass object")]
     NonUniqueEntryPoint,
-    #[error("Requested entry point was not found")]
-    EntryPointNotFound,
+    #[error("Requested entry point with selector {0:#x} was not found")]
+    EntryPointNotFound(Felt252),
     #[error("Ptr result diverges after calculating final stacks")]
     OsContextPtrNotEqual,
     #[error("Empty OS context")]

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -950,7 +950,7 @@ mod tests {
         assert!(expected_error.is_err());
         assert_matches!(
             expected_error.unwrap_err(),
-            TransactionError::EntryPointNotFound
+            TransactionError::EntryPointNotFound(_)
         );
     }
 
@@ -1402,9 +1402,11 @@ mod tests {
 
     #[test]
     fn test_reverted_transaction_wrong_entry_point() {
+        let entry_point_selector = Felt252::from_bytes_be(&calculate_sn_keccak(b"factorial_"));
+
         let internal_invoke_function = InvokeFunction {
             contract_address: Address(0.into()),
-            entry_point_selector: Felt252::from_bytes_be(&calculate_sn_keccak(b"factorial_")),
+            entry_point_selector,
             entry_point_type: EntryPointType::External,
             calldata: vec![],
             tx_type: TransactionType::InvokeFunction,
@@ -1466,7 +1468,9 @@ mod tests {
         assert!(result.call_info.is_none());
         assert_eq!(
             result.revert_error,
-            Some("Requested entry point was not found".to_string())
+            Some(format!(
+                "Requested entry point with selector {entry_point_selector:#x} was not found"
+            ))
         );
         assert_eq_sorted!(
             state.cache.class_hash_writes,

--- a/tests/integration_tests/internals.rs
+++ b/tests/integration_tests/internals.rs
@@ -2208,7 +2208,7 @@ fn test_invoke_tx_wrong_entrypoint() {
     );
 
     // Assert error
-    assert_matches!(result, Err(TransactionError::EntryPointNotFound));
+    assert_matches!(result, Err(TransactionError::EntryPointNotFound(_)));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Include the selector felt value in the error, so that we can display the selector in the error message 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
