### PR TITLE
refactor: use gas price from `BlockInfo`

### DIFF
--- a/rpc_state_reader/src/sir_state_reader.rs
+++ b/rpc_state_reader/src/sir_state_reader.rs
@@ -180,11 +180,7 @@ pub fn execute_tx_configurable_with_state(
         RpcChain::TestNet => StarknetChainId::TestNet,
         RpcChain::TestNet2 => StarknetChainId::TestNet2,
     };
-    let starknet_os_config = StarknetOsConfig::new(
-        chain_id.to_felt(),
-        fee_token_address,
-        block_info.gas_price.clone(),
-    );
+    let starknet_os_config = StarknetOsConfig::new(chain_id.to_felt(), fee_token_address);
 
     // Get transaction before giving ownership of the reader
     let tx = match tx {

--- a/src/bin/invoke_with_cachedstate.rs
+++ b/src/bin/invoke_with_cachedstate.rs
@@ -129,11 +129,7 @@ fn create_initial_state() -> CachedState<InMemoryStateReader, PermanentContractC
 
 pub fn new_starknet_block_context_for_testing() -> BlockContext {
     BlockContext::new(
-        StarknetOsConfig::new(
-            StarknetChainId::TestNet.to_felt(),
-            Default::default(),
-            Default::default(),
-        ),
+        StarknetOsConfig::new(StarknetChainId::TestNet.to_felt(), Default::default()),
         0,
         0,
         Default::default(),

--- a/src/definitions/block_context.rs
+++ b/src/definitions/block_context.rs
@@ -72,9 +72,6 @@ pub struct StarknetOsConfig {
     /// Address of the token used when paying fees
     #[get = "pub"]
     pub(crate) fee_token_address: FeeTokenAddresses,
-    /// Price of gas
-    #[get = "pub"]
-    pub(crate) gas_price: GasPrices,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -135,15 +132,10 @@ impl StarknetOsConfig {
     /// * `chain_id` - [`Felt252`] of the configured chain.
     /// * `fee_token_address` - Address of the token used when paying fees.
     /// * `gas_price` - Price of gas.
-    pub const fn new(
-        chain_id: Felt252,
-        fee_token_address: FeeTokenAddresses,
-        gas_price: GasPrices,
-    ) -> Self {
+    pub const fn new(chain_id: Felt252, fee_token_address: FeeTokenAddresses) -> Self {
         StarknetOsConfig {
             chain_id,
             fee_token_address,
-            gas_price,
         }
     }
 }
@@ -218,7 +210,7 @@ impl BlockContext {
     }
 
     pub fn get_gas_price_by_fee_type(&self, fee_type: &FeeType) -> u128 {
-        self.starknet_os_config.gas_price.get_by_fee_type(fee_type)
+        self.block_info().gas_price.get_by_fee_type(fee_type)
     }
 
     pub fn get_fee_token_address_by_fee_type(&self, fee_type: &FeeType) -> &Address {

--- a/src/definitions/constants.rs
+++ b/src/definitions/constants.rs
@@ -51,7 +51,6 @@ lazy_static! {
                 "0x4c07059285c2607d528a4c5220ef1f64d8f01273c23cfd9dec68759f61b544"
             ).unwrap()),
         },
-        gas_price: crate::definitions::block_context::GasPrices::default(),
     };
 
 pub static ref DECLARE_VERSION: Felt252 = 2.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ mod test {
         );
 
         let mut block_context = BlockContext::default();
-        block_context.starknet_os_config.gas_price = GasPrices::new(1, 0);
+        block_context.block_info_mut().gas_price = GasPrices::new(1, 0);
 
         let estimated_fee = estimate_message_fee(
             &l1_handler,
@@ -1072,7 +1072,7 @@ mod test {
             .unwrap();
 
         let mut block_context = BlockContext::default();
-        block_context.starknet_os_config.gas_price = GasPrices::new(1, 0);
+        block_context.block_info_mut().gas_price = GasPrices::new(1, 0);
 
         simulate_transaction(
             &[&l1_handler_tx],
@@ -1272,7 +1272,7 @@ mod test {
         declare.hash_value = Felt252::from_dec_str("2718").unwrap();
 
         let mut block_context = BlockContext::default();
-        block_context.starknet_os_config_mut().gas_price = GasPrices::new(12, 0);
+        block_context.block_info.gas_price = GasPrices::new(12, 0);
 
         let declare_tx = Transaction::DeclareDeprecated(declare);
 

--- a/src/transaction/declare_deprecated.rs
+++ b/src/transaction/declare_deprecated.rs
@@ -961,7 +961,7 @@ mod tests {
         // ---------------------
         let mut state_copy = state.clone_for_testing();
         let mut bock_context = BlockContext::default();
-        bock_context.starknet_os_config.gas_price = GasPrices::new(12, 0);
+        bock_context.block_info_mut().gas_price = GasPrices::new(12, 0);
         assert!(
             declare
                 .execute(

--- a/src/transaction/fee.rs
+++ b/src/transaction/fee.rs
@@ -378,7 +378,7 @@ mod tests {
         );
         let mut tx_execution_context = TransactionExecutionContext::default();
         let mut block_context = BlockContext::default();
-        block_context.starknet_os_config.gas_price = GasPrices::new(1, 0);
+        block_context.block_info.gas_price = GasPrices::new(1, 0);
         let resources = HashMap::from([
             ("l1_gas_usage".to_string(), 200_usize),
             ("pedersen_builtin".to_string(), 10000_usize),
@@ -420,7 +420,7 @@ mod tests {
             ..Default::default()
         };
         let mut block_context = BlockContext::default();
-        block_context.starknet_os_config.gas_price = GasPrices::new(1, 0);
+        block_context.block_info.gas_price = GasPrices::new(1, 0);
         let resources = HashMap::from([
             ("l1_gas_usage".to_string(), 200_usize),
             ("pedersen_builtin".to_string(), 10000_usize),

--- a/src/transaction/invoke_function.rs
+++ b/src/transaction/invoke_function.rs
@@ -1219,7 +1219,7 @@ mod tests {
             .unwrap();
 
         let mut block_context = BlockContext::default();
-        block_context.starknet_os_config.gas_price = GasPrices::new(1, 0);
+        block_context.block_info.gas_price = GasPrices::new(1, 0);
 
         let tx_info = internal_invoke_function
             .execute(

--- a/src/transaction/l1_handler.rs
+++ b/src/transaction/l1_handler.rs
@@ -319,7 +319,7 @@ mod test {
             .unwrap();
 
         let mut block_context = BlockContext::default();
-        block_context.starknet_os_config.gas_price = GasPrices::new(1, 0);
+        block_context.block_info.gas_price = GasPrices::new(1, 0);
 
         let tx_exec = l1_handler
             .execute(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -681,14 +681,17 @@ pub mod test_utils {
             StarknetOsConfig::new(
                 StarknetChainId::TestNet.to_felt(),
                 TEST_FEE_TOKEN_ADDRESSES.clone(),
-                GasPrices::new(1, 1),
             ),
             0,
             0,
             DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS.clone(),
             1_000_000,
             0,
-            BlockInfo::empty(TEST_SEQUENCER_ADDRESS.clone()),
+            BlockInfo {
+                gas_price: GasPrices::new(1, 1),
+                sequencer_address: TEST_SEQUENCER_ADDRESS.clone(),
+                ..Default::default()
+            },
             HashMap::default(),
             true,
         )

--- a/tests/integration_tests/internals.rs
+++ b/tests/integration_tests/internals.rs
@@ -119,7 +119,6 @@ pub fn new_starknet_block_context_for_testing() -> BlockContext {
         StarknetOsConfig::new(
             StarknetChainId::TestNet.to_felt(),
             TEST_FEE_TOKEN_ADDRESSES.clone(),
-            GAS_PRICES.clone(),
         ),
         0,
         0,


### PR DESCRIPTION
## Description

Resolves #1255 

Remove gas prices from os config and use the one in block info instead. I've decided to keep the one in `BlockInfo` because `blockifier` also put it in a struct called [block info](https://github.com/starkware-libs/blockifier/blob/a6aa9a965e824442487f2c376b65e2e1c9a66944/crates/blockifier/src/blockifier/block.rs#L26)

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
