### PR TITLE
fix: declare tx validate entrypoint should be non-revertible

### DIFF
--- a/src/transaction/declare.rs
+++ b/src/transaction/declare.rs
@@ -521,7 +521,7 @@ impl Declare {
                 block_context,
                 resources_manager,
                 &mut tx_execution_context,
-                true,
+                false,
                 block_context.validate_max_n_steps,
                 #[cfg(feature = "cairo-native")]
                 program_cache,


### PR DESCRIPTION
## Description

All the other txs have this value to be `false` except for `Declare` tx

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
